### PR TITLE
feat(settings): add standalone config discovery and path defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "mcp[cli]==1.26.0",
   "openai==2.29.0",
   "pandas==2.2.3",
+  "platformdirs==4.5.0",
   "pydantic==2.12.5",
   "pydantic-settings==2.13.1",
   "typer==0.24.1",

--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -1,0 +1,126 @@
+"""Helpers for installed config discovery and standalone data defaults."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from platformdirs import user_config_path, user_data_path
+
+APP_NAME = "policynim"
+APP_AUTHOR = "PolicyNIM"
+
+
+@dataclass(frozen=True)
+class StandalonePaths:
+    """User-owned config and data paths for installed standalone use."""
+
+    config_file: Path
+    data_root: Path
+    lancedb_uri: Path
+    runtime_rules_artifact_path: Path
+    runtime_evidence_db_path: Path
+    eval_workspace_dir: Path
+
+
+@dataclass(frozen=True)
+class ConfigDiscovery:
+    """Resolved env-file discovery order for env-backed settings loads."""
+
+    env_files: tuple[Path, ...]
+    active_config_file: Path | None
+    user_config_file: Path
+    has_discovered_config: bool
+
+
+def standalone_paths() -> StandalonePaths:
+    """Return the installed-runtime config and data layout."""
+    config_root = user_config_path(APP_NAME, APP_AUTHOR)
+    data_root = user_data_path(APP_NAME, APP_AUTHOR)
+    return StandalonePaths(
+        config_file=config_root / "config.env",
+        data_root=data_root,
+        lancedb_uri=data_root / "lancedb",
+        runtime_rules_artifact_path=data_root / "runtime" / "runtime_rules.json",
+        runtime_evidence_db_path=data_root / "runtime" / "runtime_evidence.sqlite3",
+        eval_workspace_dir=data_root / "evals" / "workspace",
+    )
+
+
+def discover_config_files(
+    *,
+    cwd: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> ConfigDiscovery:
+    """Return env files in low-to-high priority order for settings loading."""
+    current_dir = Path.cwd() if cwd is None else cwd
+    process_env = os.environ if environ is None else environ
+    standalone = standalone_paths()
+
+    env_files: list[Path] = []
+    active_config_file: Path | None = None
+
+    if not is_source_checkout(cwd=current_dir) and not is_hosted_process_environment(process_env):
+        if standalone.config_file.is_file():
+            env_files.append(standalone.config_file)
+            active_config_file = standalone.config_file
+
+    cwd_env_file = current_dir / ".env"
+    if cwd_env_file.is_file():
+        env_files.append(cwd_env_file)
+        active_config_file = cwd_env_file
+
+    explicit_config_file = _explicit_config_file(process_env)
+    if explicit_config_file is not None and explicit_config_file.is_file():
+        if explicit_config_file not in env_files:
+            env_files.append(explicit_config_file)
+        active_config_file = explicit_config_file
+
+    return ConfigDiscovery(
+        env_files=tuple(env_files),
+        active_config_file=active_config_file,
+        user_config_file=standalone.config_file,
+        has_discovered_config=active_config_file is not None,
+    )
+
+
+def is_source_checkout(*, cwd: Path | None = None) -> bool:
+    """Return whether PolicyNIM is running from a source checkout."""
+    return find_source_checkout_root(cwd=cwd) is not None
+
+
+def find_source_checkout_root(*, cwd: Path | None = None) -> Path | None:
+    """Locate a contributor checkout from the current directory or package path."""
+    current_dir = Path.cwd() if cwd is None else cwd
+    candidate_roots = (current_dir, Path(__file__).resolve().parent)
+    seen: set[Path] = set()
+
+    for root in candidate_roots:
+        for candidate in (root, *root.parents):
+            resolved = candidate.resolve(strict=False)
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if _looks_like_source_checkout(resolved):
+                return resolved
+
+    return None
+
+
+def is_hosted_process_environment(environ: Mapping[str, str] | None = None) -> bool:
+    """Return whether the process already looks like a platform-hosted runtime."""
+    process_env = os.environ if environ is None else environ
+    return bool(str(process_env.get("PORT", "")).strip())
+
+
+def _explicit_config_file(environ: Mapping[str, str]) -> Path | None:
+    raw_value = str(environ.get("POLICYNIM_CONFIG_FILE", "")).strip()
+    if not raw_value:
+        return None
+    return Path(raw_value).expanduser()
+
+
+def _looks_like_source_checkout(path: Path) -> bool:
+    return (path / "pyproject.toml").is_file() and (path / "src" / "policynim").is_dir()

--- a/src/policynim/runtime_paths.py
+++ b/src/policynim/runtime_paths.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import atexit
+from contextlib import ExitStack
+from importlib import resources
 from pathlib import Path
 
 from policynim.errors import InvalidPolicyDocumentError
+
+_PACKAGED_RESOURCE_STACK = ExitStack()
+atexit.register(_PACKAGED_RESOURCE_STACK.close)
 
 
 def resolve_runtime_path(path: Path) -> Path:
@@ -32,34 +38,52 @@ def resolve_corpus_root(configured_root: Path | str | None = None) -> Path:
     if normalized_root is not None:
         return resolve_runtime_path(normalized_root)
 
-    package_root = Path(__file__).resolve().parent
-    bundled_corpus = package_root / "policies"
-    if bundled_corpus.is_dir():
+    bundled_corpus = _resolve_packaged_resource("policies")
+    if bundled_corpus is not None and bundled_corpus.is_dir():
         return bundled_corpus
 
-    for parent in package_root.parents:
-        checkout_corpus = parent / "policies"
-        if checkout_corpus.is_dir():
-            return checkout_corpus
+    checkout_corpus = _resolve_checkout_resource("policies")
+    if checkout_corpus is not None:
+        return checkout_corpus
 
     raise InvalidPolicyDocumentError(
-        "Could not locate the policy corpus. Set `POLICYNIM_CORPUS_DIR` to the directory "
-        "containing your policy Markdown files."
+        "Could not locate the policy corpus in installed package resources or a source checkout. "
+        "Set `POLICYNIM_CORPUS_DIR` to the directory containing your policy Markdown files."
     )
 
 
 def resolve_eval_suite_path() -> Path:
     """Resolve the bundled default eval suite."""
-    package_root = Path(__file__).resolve().parent
-    bundled_suite = package_root / "evals" / "default_cases.json"
-    if bundled_suite.is_file():
+    bundled_suite = _resolve_packaged_resource("evals", "default_cases.json")
+    if bundled_suite is not None and bundled_suite.is_file():
         return bundled_suite
 
-    for parent in package_root.parents:
-        checkout_suite = parent / "evals" / "default_cases.json"
-        if checkout_suite.is_file():
-            return checkout_suite
+    checkout_suite = _resolve_checkout_resource("evals", "default_cases.json")
+    if checkout_suite is not None:
+        return checkout_suite
 
     raise InvalidPolicyDocumentError(
-        "Could not locate the default eval suite. Add `evals/default_cases.json` to the project."
+        "Could not locate the default eval suite in installed package resources or a source "
+        "checkout. Reinstall PolicyNIM or run from a source checkout that contains "
+        "`evals/default_cases.json`."
     )
+
+
+def _resolve_packaged_resource(*parts: str) -> Path | None:
+    """Resolve a packaged resource to a filesystem path when the package ships it."""
+    resource = resources.files("policynim")
+    for part in parts:
+        resource = resource.joinpath(part)
+    if not resource.exists():
+        return None
+    return _PACKAGED_RESOURCE_STACK.enter_context(resources.as_file(resource))
+
+
+def _resolve_checkout_resource(*parts: str) -> Path | None:
+    """Resolve a checkout-relative fallback by walking parents of the package path."""
+    package_root = Path(__file__).resolve().parent
+    for parent in package_root.parents:
+        candidate = parent.joinpath(*parts)
+        if candidate.exists():
+            return candidate
+    return None

--- a/src/policynim/runtime_paths.py
+++ b/src/policynim/runtime_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+from collections.abc import Callable
 from contextlib import ExitStack
 from importlib import resources
 from pathlib import Path
@@ -42,7 +43,7 @@ def resolve_corpus_root(configured_root: Path | str | None = None) -> Path:
     if bundled_corpus is not None and bundled_corpus.is_dir():
         return bundled_corpus
 
-    checkout_corpus = _resolve_checkout_resource("policies")
+    checkout_corpus = _resolve_checkout_resource("policies", predicate=Path.is_dir)
     if checkout_corpus is not None:
         return checkout_corpus
 
@@ -58,7 +59,11 @@ def resolve_eval_suite_path() -> Path:
     if bundled_suite is not None and bundled_suite.is_file():
         return bundled_suite
 
-    checkout_suite = _resolve_checkout_resource("evals", "default_cases.json")
+    checkout_suite = _resolve_checkout_resource(
+        "evals",
+        "default_cases.json",
+        predicate=Path.is_file,
+    )
     if checkout_suite is not None:
         return checkout_suite
 
@@ -79,11 +84,14 @@ def _resolve_packaged_resource(*parts: str) -> Path | None:
     return _PACKAGED_RESOURCE_STACK.enter_context(resources.as_file(resource))
 
 
-def _resolve_checkout_resource(*parts: str) -> Path | None:
+def _resolve_checkout_resource(
+    *parts: str,
+    predicate: Callable[[Path], bool],
+) -> Path | None:
     """Resolve a checkout-relative fallback by walking parents of the package path."""
     package_root = Path(__file__).resolve().parent
     for parent in package_root.parents:
         candidate = parent.joinpath(*parts)
-        if candidate.exists():
+        if predicate(candidate):
             return candidate
     return None

--- a/src/policynim/settings.py
+++ b/src/policynim/settings.py
@@ -15,15 +15,51 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    DotEnvSettingsSource,
+    NoDecode,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
+import policynim.config_discovery as config_discovery
 from policynim.errors import ConfigurationError
 from policynim.types import DEFAULT_TOP_K, TopK
+
+
+class StandaloneDefaultPathsSource(PydanticBaseSettingsSource):
+    """Provide user-owned path defaults for installed standalone runtimes."""
+
+    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
+        return None, field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        if _should_use_repo_relative_defaults():
+            return {}
+
+        standalone = config_discovery.standalone_paths()
+        return {
+            "lancedb_uri": standalone.lancedb_uri,
+            "runtime_rules_artifact_path": standalone.runtime_rules_artifact_path,
+            "runtime_evidence_db_path": standalone.runtime_evidence_db_path,
+            "eval_workspace_dir": standalone.eval_workspace_dir,
+        }
+
+
+class ProcessEnvOnlyConfigDotEnvSettingsSource(DotEnvSettingsSource):
+    """Drop config-file overrides from dotenv sources so only process env can set them."""
+
+    def __call__(self) -> dict[str, Any]:
+        data = super().__call__()
+        data.pop("config_file", None)
+        return data
 
 
 class Settings(BaseSettings):
     """Validated environment-backed settings."""
 
+    config_file: Path | None = Field(default=None, exclude=True, repr=False)
     nvidia_api_key: str | None = Field(default=None, validation_alias="NVIDIA_API_KEY")
     policynim_env: str = Field(default="development", validation_alias="POLICYNIM_ENV")
     corpus_dir: Path | None = None
@@ -71,6 +107,50 @@ class Settings(BaseSettings):
         extra="ignore",
         populate_by_name=True,
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        resolved_dotenv = dotenv_settings
+        if isinstance(dotenv_settings, DotEnvSettingsSource):
+            if _uses_default_env_file(dotenv_settings.env_file):
+                resolved_dotenv = _build_discovered_dotenv_source(settings_cls, dotenv_settings)
+            else:
+                resolved_dotenv = _clone_filtered_dotenv_source(
+                    settings_cls,
+                    dotenv_settings,
+                    env_file=dotenv_settings.env_file,
+                )
+
+        return (
+            init_settings,
+            env_settings,
+            resolved_dotenv,
+            file_secret_settings,
+            StandaloneDefaultPathsSource(settings_cls),
+        )
+
+    @field_validator("config_file", mode="before")
+    @classmethod
+    def validate_config_file(cls, value: Any) -> Any:
+        """Reject empty or missing explicit config-file overrides."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("POLICYNIM_CONFIG_FILE must not be empty.")
+            value = Path(stripped).expanduser()
+        if isinstance(value, Path):
+            if not value.is_file():
+                raise ValueError("POLICYNIM_CONFIG_FILE must point to an existing env file.")
+        return value
 
     @field_validator("corpus_dir", mode="before")
     @classmethod
@@ -226,6 +306,58 @@ def _dedupe_tokens(values: list[str] | tuple[str, ...]) -> list[str]:
         deduped.append(token)
         seen.add(token)
     return deduped
+
+
+def _uses_default_env_file(env_file: object) -> bool:
+    """Return whether dotenv loading still points at the model's default `.env`."""
+    if isinstance(env_file, (str, Path)):
+        return Path(env_file) == Path(".env")
+    if isinstance(env_file, (list, tuple)) and len(env_file) == 1:
+        candidate = env_file[0]
+        return isinstance(candidate, (str, Path)) and Path(candidate) == Path(".env")
+    return False
+
+
+def _build_discovered_dotenv_source(
+    settings_cls: type[BaseSettings],
+    template: DotEnvSettingsSource,
+) -> DotEnvSettingsSource:
+    """Replace the static `.env` source with Day 1 discovery precedence."""
+    discovery = config_discovery.discover_config_files()
+    return _clone_filtered_dotenv_source(
+        settings_cls,
+        template,
+        env_file=discovery.env_files or None,
+    )
+
+
+def _clone_filtered_dotenv_source(
+    settings_cls: type[BaseSettings],
+    template: DotEnvSettingsSource,
+    *,
+    env_file: object,
+) -> DotEnvSettingsSource:
+    """Clone the existing dotenv source while keeping config-file override process-env only."""
+    return ProcessEnvOnlyConfigDotEnvSettingsSource(
+        settings_cls,
+        env_file=env_file,
+        env_file_encoding=template.env_file_encoding,
+        case_sensitive=template.case_sensitive,
+        env_prefix=template.env_prefix,
+        env_prefix_target=template.env_prefix_target,
+        env_nested_delimiter=template.env_nested_delimiter,
+        env_nested_max_split=template.env_nested_max_split,
+        env_ignore_empty=template.env_ignore_empty,
+        env_parse_none_str=template.env_parse_none_str,
+        env_parse_enums=template.env_parse_enums,
+    )
+
+
+def _should_use_repo_relative_defaults() -> bool:
+    """Preserve checkout and hosted path defaults instead of forcing platformdirs."""
+    if config_discovery.is_source_checkout():
+        return True
+    return config_discovery.is_hosted_process_environment()
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -75,6 +75,21 @@ def test_resolve_corpus_root_falls_back_to_checkout_when_package_resource_is_mis
     assert resolve_corpus_root() == checkout_corpus
 
 
+def test_resolve_corpus_root_skips_checkout_candidates_that_are_not_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout_root = tmp_path / "checkout"
+    valid_corpus = checkout_root / "policies"
+    valid_corpus.mkdir(parents=True)
+    package_root = checkout_root / ".venv" / "lib" / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+    wrong_type_corpus = checkout_root / ".venv" / "lib" / "policies"
+    wrong_type_corpus.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+
+    assert resolve_corpus_root() == valid_corpus
+
+
 def test_resolve_corpus_root_raises_with_override_guidance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -118,6 +133,22 @@ def test_resolve_eval_suite_path_falls_back_to_checkout_when_package_resource_is
     monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
 
     assert resolve_eval_suite_path() == checkout_suite
+
+
+def test_resolve_eval_suite_path_skips_checkout_candidates_that_are_not_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout_root = tmp_path / "checkout"
+    valid_suite = checkout_root / "evals" / "default_cases.json"
+    valid_suite.parent.mkdir(parents=True)
+    valid_suite.write_text("[]", encoding="utf-8")
+    package_root = checkout_root / ".venv" / "lib" / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+    wrong_type_suite = checkout_root / ".venv" / "lib" / "evals" / "default_cases.json"
+    wrong_type_suite.mkdir(parents=True)
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+
+    assert resolve_eval_suite_path() == valid_suite
 
 
 def test_resolve_eval_suite_path_raises_with_override_guidance(

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -40,7 +40,10 @@ def test_resolve_corpus_root_finds_bundled_package_policies(
     package_root = tmp_path / "site-packages" / "policynim"
     bundled_corpus = package_root / "policies"
     bundled_corpus.mkdir(parents=True)
-    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+    monkeypatch.setattr(
+        "policynim.runtime_paths._resolve_packaged_resource",
+        lambda *parts: bundled_corpus,
+    )
 
     assert resolve_corpus_root() == bundled_corpus
 
@@ -51,9 +54,25 @@ def test_resolve_corpus_root_ignores_empty_string_override(
     package_root = tmp_path / "site-packages" / "policynim"
     bundled_corpus = package_root / "policies"
     bundled_corpus.mkdir(parents=True)
-    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+    monkeypatch.setattr(
+        "policynim.runtime_paths._resolve_packaged_resource",
+        lambda *parts: bundled_corpus,
+    )
 
     assert resolve_corpus_root("") == bundled_corpus
+
+
+def test_resolve_corpus_root_falls_back_to_checkout_when_package_resource_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout_root = tmp_path / "checkout"
+    checkout_corpus = checkout_root / "policies"
+    checkout_corpus.mkdir(parents=True)
+    package_root = checkout_root / ".venv" / "lib" / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+
+    assert resolve_corpus_root() == checkout_corpus
 
 
 def test_resolve_corpus_root_raises_with_override_guidance(
@@ -79,9 +98,26 @@ def test_resolve_eval_suite_path_finds_bundled_package_suite(
     bundled_suite = package_root / "evals" / "default_cases.json"
     bundled_suite.parent.mkdir(parents=True)
     bundled_suite.write_text("[]", encoding="utf-8")
-    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+    monkeypatch.setattr(
+        "policynim.runtime_paths._resolve_packaged_resource",
+        lambda *parts: bundled_suite,
+    )
 
     assert resolve_eval_suite_path() == bundled_suite
+
+
+def test_resolve_eval_suite_path_falls_back_to_checkout_when_package_resource_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout_root = tmp_path / "checkout"
+    checkout_suite = checkout_root / "evals" / "default_cases.json"
+    checkout_suite.parent.mkdir(parents=True)
+    checkout_suite.write_text("[]", encoding="utf-8")
+    package_root = checkout_root / ".venv" / "lib" / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+
+    assert resolve_eval_suite_path() == checkout_suite
 
 
 def test_resolve_eval_suite_path_raises_with_override_guidance(
@@ -98,6 +134,26 @@ def test_resolve_eval_suite_path_raises_with_override_guidance(
 
     with pytest.raises(InvalidPolicyDocumentError, match="default eval suite"):
         resolve_eval_suite_path()
+
+
+def test_resolve_eval_suite_path_raises_with_actionable_recovery_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    isolated_package = tmp_path / "isolated" / "policynim"
+    isolated_package.mkdir(parents=True)
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr(
+        "policynim.runtime_paths.__file__", str(isolated_package / "runtime_paths.py")
+    )
+
+    with pytest.raises(InvalidPolicyDocumentError) as exc:
+        resolve_eval_suite_path()
+
+    message = str(exc.value)
+    assert "source checkout" in message
+    assert "reinstall" in message.lower()
 
 
 def test_resolve_eval_suite_path_error_no_longer_references_cases_flag(

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -10,6 +10,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from policynim.settings import Settings
 from policynim.types import (
+    DEFAULT_TOP_K,
     DocumentSection,
     HTTPRequestActionRequest,
     ParsedRuntimeRule,
@@ -28,6 +29,88 @@ def load_settings_without_env_file(**overrides: Any) -> Settings:
     """Construct Settings without reading the repo .env file."""
     settings_type = cast(Any, Settings)
     return settings_type(_env_file=None, **overrides)
+
+
+def write_env_file(path: Path, **values: str) -> None:
+    """Write a small env-style config file for precedence tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key}={value}" for key, value in values.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def clear_day1_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear env variables that would interfere with Day 1 precedence tests."""
+    for key in (
+        "POLICYNIM_CONFIG_FILE",
+        "POLICYNIM_DEFAULT_TOP_K",
+        "POLICYNIM_LANCEDB_URI",
+        "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
+        "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
+        "POLICYNIM_EVAL_WORKSPACE_DIR",
+        "POLICYNIM_ENV",
+        "PORT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def configure_standalone_discovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, Path, Path]:
+    """Simulate an installed runtime outside a source checkout."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    config_root = tmp_path / "user-config"
+    data_root = tmp_path / "user-data"
+    package_root = tmp_path / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.user_config_path",
+        lambda *args, **kwargs: config_root,
+    )
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.user_data_path",
+        lambda *args, **kwargs: data_root,
+    )
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+
+    return workspace, config_root, data_root
+
+
+def configure_checkout_discovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, Path, Path]:
+    """Simulate running from a contributor checkout."""
+    checkout_root = tmp_path / "checkout"
+    package_root = checkout_root / "src" / "policynim"
+    package_root.mkdir(parents=True)
+    (checkout_root / "pyproject.toml").write_text(
+        "[project]\nname = 'policynim'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(checkout_root)
+
+    config_root = tmp_path / "user-config"
+    data_root = tmp_path / "user-data"
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.user_config_path",
+        lambda *args, **kwargs: config_root,
+    )
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.user_data_path",
+        lambda *args, **kwargs: data_root,
+    )
+    monkeypatch.setattr(
+        "policynim.settings.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+
+    return checkout_root, config_root, data_root
 
 
 def test_settings_reads_prefixed_env_and_nvidia_alias(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -63,6 +146,96 @@ def test_settings_parses_csv_bearer_tokens(monkeypatch: pytest.MonkeyPatch) -> N
     settings = load_settings_without_env_file()
 
     assert settings.mcp_bearer_tokens == ["token-a", "token-b"]
+
+
+def test_settings_uses_user_config_and_standalone_defaults_when_no_local_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    _, config_root, data_root = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="8")
+
+    settings = Settings()
+
+    assert settings.default_top_k == 8
+    assert settings.lancedb_uri == data_root / "lancedb"
+    assert settings.eval_workspace_dir == data_root / "evals" / "workspace"
+
+
+def test_settings_prefers_explicit_config_file_over_cwd_dotenv_and_user_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
+    write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
+    explicit_config = tmp_path / "explicit.env"
+    write_env_file(explicit_config, POLICYNIM_DEFAULT_TOP_K="5")
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(explicit_config))
+
+    settings = Settings()
+
+    assert settings.default_top_k == 5
+
+
+def test_settings_prefers_cwd_dotenv_over_user_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
+    write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
+
+    settings = Settings()
+
+    assert settings.default_top_k == 4
+
+
+def test_settings_prefers_process_env_over_all_discovered_config_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
+    write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
+    explicit_config = tmp_path / "explicit.env"
+    write_env_file(explicit_config, POLICYNIM_DEFAULT_TOP_K="5")
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(explicit_config))
+    monkeypatch.setenv("POLICYNIM_DEFAULT_TOP_K", "6")
+
+    settings = Settings()
+
+    assert settings.default_top_k == 6
+
+
+def test_settings_fails_closed_when_explicit_config_file_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    configure_standalone_discovery(monkeypatch, tmp_path)
+    missing_config = tmp_path / "missing.env"
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(missing_config))
+
+    with pytest.raises(ValidationError, match="POLICYNIM_CONFIG_FILE"):
+        Settings()
+
+
+def test_settings_ignores_config_file_from_discovered_user_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    _, config_root, data_root = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(
+        config_root / "config.env",
+        POLICYNIM_DEFAULT_TOP_K="8",
+        POLICYNIM_CONFIG_FILE=str(tmp_path / "missing.env"),
+    )
+
+    settings = Settings()
+
+    assert settings.default_top_k == 8
+    assert settings.config_file is None
+    assert settings.lancedb_uri == data_root / "lancedb"
 
 
 def test_settings_uses_default_runtime_rules_artifact_path() -> None:
@@ -163,6 +336,58 @@ def test_settings_keeps_loopback_host_outside_production_even_with_port(
     settings = load_settings_without_env_file()
 
     assert settings.mcp_host == "127.0.0.1"
+
+
+def test_settings_ignores_user_config_when_platform_port_is_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    _, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(
+        config_root / "config.env",
+        POLICYNIM_ENV="production",
+        POLICYNIM_DEFAULT_TOP_K="8",
+    )
+    monkeypatch.setenv("PORT", "8123")
+
+    settings = Settings()
+
+    assert settings.policynim_env == "development"
+    assert settings.default_top_k == DEFAULT_TOP_K
+    assert settings.mcp_host == "127.0.0.1"
+    assert settings.lancedb_uri == Path("data/lancedb")
+    assert settings.eval_workspace_dir == Path("data/evals/workspace")
+
+
+def test_settings_keeps_checkout_defaults_when_running_from_source_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    checkout_root, config_root, _ = configure_checkout_discovery(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
+    write_env_file(checkout_root / ".env", POLICYNIM_DEFAULT_TOP_K="11")
+
+    settings = Settings()
+
+    assert settings.default_top_k == 11
+    assert settings.lancedb_uri == Path("data/lancedb")
+    assert settings.eval_workspace_dir == Path("data/evals/workspace")
+
+
+def test_settings_keeps_hosted_defaults_out_of_standalone_platformdirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_day1_env(monkeypatch)
+    configure_standalone_discovery(monkeypatch, tmp_path)
+    monkeypatch.setenv("POLICYNIM_ENV", "production")
+    monkeypatch.setenv("PORT", "8123")
+
+    settings = Settings()
+
+    assert settings.mcp_host == "0.0.0.0"
+    assert settings.mcp_port == 8123
+    assert settings.lancedb_uri == Path("data/lancedb")
+    assert settings.eval_workspace_dir == Path("data/evals/workspace")
 
 
 def test_settings_requires_bearer_tokens_when_auth_is_enabled() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -927,11 +927,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
 ]
 
 [[package]]
@@ -970,6 +970,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "openai" },
     { name = "pandas" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "typer" },
@@ -995,6 +996,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
     { name = "openai", specifier = "==2.29.0" },
     { name = "pandas", specifier = "==2.2.3" },
+    { name = "platformdirs", specifier = "==4.5.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.13.1" },
     { name = "typer", specifier = "==0.24.1" },


### PR DESCRIPTION
## Summary
- add Day 1 standalone config discovery with process env -> `POLICYNIM_CONFIG_FILE` -> CWD `.env` -> user config -> code defaults precedence
- move installed standalone local-state defaults to user-owned `platformdirs` locations while preserving checkout and hosted behavior
- resolve bundled runtime resources via packaged resources with checkout fallback and add regression coverage for hosted and standalone edge cases

## Verification
- `uv run pytest -q tests/test_settings_and_types.py tests/test_runtime_paths.py`
- `uv run ruff check`
- `uv run pytest -q`

## Notes
- `POLICYNIM_CONFIG_FILE` is process-env only and is ignored from discovered dotenv files
- standalone user config is suppressed when a platform `PORT` is present so hosted runtimes do not inherit local installed config