### PR TITLE
Add installer init CLI setup recovery

### DIFF
--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 from collections.abc import Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -113,8 +114,12 @@ def standalone_setup_missing(
     if raw_explicit_config is not None and explicit_config_file is None:
         return False
     if explicit_config_file is not None:
-        return not explicit_config_file.is_file()
-    return not discover_config_files(cwd=current_dir, environ=process_env).has_discovered_config
+        return not _env_file_has_nonempty_value(explicit_config_file, "NVIDIA_API_KEY")
+    discovery = discover_config_files(cwd=current_dir, environ=process_env)
+    return not any(
+        _env_file_has_nonempty_value(config_file, "NVIDIA_API_KEY")
+        for config_file in discovery.env_files
+    )
 
 
 def build_init_config_contents(
@@ -173,14 +178,19 @@ def write_init_config_file(
     )
     temp_path = Path(temp_name)
     try:
-        with os.fdopen(handle, "w", encoding="utf-8") as output:
+        try:
+            output = os.fdopen(handle, "w", encoding="utf-8")
+        except OSError:
+            with suppress(OSError):
+                os.close(handle)
+            raise
+
+        with output:
             output.write(contents)
         os.replace(temp_path, resolved_destination)
     except OSError:
-        try:
+        with suppress(OSError):
             temp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         raise
     return resolved_destination
 
@@ -219,6 +229,32 @@ def _explicit_config_file(environ: Mapping[str, str]) -> Path | None:
     if not raw_value:
         return None
     return Path(raw_value).expanduser()
+
+
+def _env_file_has_nonempty_value(path: Path, key: str) -> bool:
+    """Return whether an env file defines a non-empty value for a specific key."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped.removeprefix("export ").strip()
+        candidate_key, separator, raw_value = stripped.partition("=")
+        if separator and candidate_key.strip() == key and _env_value_is_nonempty(raw_value):
+            return True
+    return False
+
+
+def _env_value_is_nonempty(raw_value: str) -> bool:
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1].strip()
+    return bool(value)
 
 
 def normalize_init_corpus_dir(value: Path | str | None) -> Path | None:

--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,15 @@ def standalone_paths() -> StandalonePaths:
     )
 
 
+def resolve_init_config_file(*, environ: Mapping[str, str] | None = None) -> Path:
+    """Return the config file that `policynim init` should write."""
+    process_env = os.environ if environ is None else environ
+    explicit_config = _explicit_config_file(process_env)
+    if explicit_config is not None:
+        return explicit_config
+    return standalone_paths().config_file
+
+
 def discover_config_files(
     *,
     cwd: Path | None = None,
@@ -86,6 +96,95 @@ def discover_config_files(
     )
 
 
+def standalone_setup_missing(
+    *,
+    cwd: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether installed local CLI setup has not been initialized yet."""
+    current_dir = Path.cwd() if cwd is None else cwd
+    process_env = os.environ if environ is None else environ
+    if is_source_checkout(cwd=current_dir) or is_hosted_process_environment(process_env):
+        return False
+    if str(process_env.get("NVIDIA_API_KEY", "")).strip():
+        return False
+    explicit_config_file = _explicit_config_file(process_env)
+    raw_explicit_config = process_env.get("POLICYNIM_CONFIG_FILE")
+    if raw_explicit_config is not None and explicit_config_file is None:
+        return False
+    if explicit_config_file is not None:
+        return not explicit_config_file.is_file()
+    return not discover_config_files(cwd=current_dir, environ=process_env).has_discovered_config
+
+
+def build_init_config_contents(
+    *,
+    api_key: str,
+    corpus_dir: Path | str | None,
+) -> str:
+    """Return the env-file contents for standalone local CLI setup."""
+    normalized_api_key = str(api_key).strip()
+    if not normalized_api_key:
+        raise ValueError("NVIDIA_API_KEY is required.")
+
+    standalone = standalone_paths()
+    lines = [_env_assignment("NVIDIA_API_KEY", normalized_api_key)]
+
+    normalized_corpus_dir = normalize_init_corpus_dir(corpus_dir)
+    if normalized_corpus_dir is not None:
+        lines.append(_env_assignment("POLICYNIM_CORPUS_DIR", normalized_corpus_dir.as_posix()))
+
+    lines.extend(
+        [
+            _env_assignment("POLICYNIM_LANCEDB_URI", standalone.lancedb_uri.as_posix()),
+            _env_assignment(
+                "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
+                standalone.runtime_rules_artifact_path.as_posix(),
+            ),
+            _env_assignment(
+                "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
+                standalone.runtime_evidence_db_path.as_posix(),
+            ),
+            _env_assignment(
+                "POLICYNIM_EVAL_WORKSPACE_DIR",
+                standalone.eval_workspace_dir.as_posix(),
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_init_config_file(
+    *,
+    destination: Path,
+    api_key: str,
+    corpus_dir: Path | str | None,
+) -> Path:
+    """Write the standalone init config atomically and return the destination."""
+    resolved_destination = destination.expanduser()
+    contents = build_init_config_contents(api_key=api_key, corpus_dir=corpus_dir)
+    resolved_destination.parent.mkdir(parents=True, exist_ok=True)
+
+    handle, temp_name = tempfile.mkstemp(
+        dir=resolved_destination.parent,
+        prefix=f".{resolved_destination.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as output:
+            output.write(contents)
+        os.replace(temp_path, resolved_destination)
+    except OSError:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return resolved_destination
+
+
 def is_source_checkout(*, cwd: Path | None = None) -> bool:
     """Return whether PolicyNIM is running from a source checkout."""
     return find_source_checkout_root(cwd=cwd) is not None
@@ -120,6 +219,36 @@ def _explicit_config_file(environ: Mapping[str, str]) -> Path | None:
     if not raw_value:
         return None
     return Path(raw_value).expanduser()
+
+
+def normalize_init_corpus_dir(value: Path | str | None) -> Path | None:
+    """Normalize optional init prompt paths to stable absolute paths."""
+    if value is None:
+        return None
+    raw_value = value.as_posix() if isinstance(value, Path) else str(value)
+    stripped = raw_value.strip()
+    if not stripped:
+        return None
+
+    candidate = Path(stripped).expanduser()
+    if not candidate.is_absolute():
+        candidate = (Path.cwd() / candidate).resolve(strict=False)
+    else:
+        candidate = candidate.resolve(strict=False)
+    if not candidate.is_dir():
+        raise ValueError(
+            f"Custom corpus directory {candidate} does not exist or is not a directory."
+        )
+    return candidate
+
+
+def _env_assignment(key: str, value: str) -> str:
+    return f"{key}={_quote_env_value(value)}"
+
+
+def _quote_env_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")
+    return f"'{escaped}'"
 
 
 def _looks_like_source_checkout(path: Path) -> bool:

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
 from pathlib import Path
 from typing import Annotated, Literal, NoReturn
 
 import typer
 from pydantic import TypeAdapter, ValidationError
 
-from policynim.errors import PolicyNIMError
+import policynim.config_discovery as config_discovery
+from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
 from policynim.services import (
     create_beta_auth_service,
@@ -23,7 +26,7 @@ from policynim.services import (
     create_runtime_execution_service,
     create_search_service,
 )
-from policynim.settings import get_settings
+from policynim.settings import Settings, get_settings
 from policynim.types import (
     MAX_TOP_K,
     EvalExecutionMode,
@@ -35,6 +38,9 @@ from policynim.types import (
 )
 
 _RUNTIME_REQUEST_ADAPTER = TypeAdapter(RuntimeActionRequest)
+_STANDALONE_MISSING_INDEX_MESSAGE = (
+    "Local PolicyNIM data is not built yet. Run `policynim ingest` to build the local policy index."
+)
 
 app = typer.Typer(
     add_completion=False,
@@ -61,14 +67,76 @@ app.add_typer(runtime_app, name="runtime")
 app.add_typer(evidence_app, name="evidence")
 
 
+@app.callback()
+def root(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Print the installed PolicyNIM version and exit.",
+            callback=lambda value: _version_option_callback(value),
+            is_eager=True,
+        ),
+    ] = False,
+) -> None:
+    """Run the PolicyNIM CLI."""
+    del version
+
+
+@app.command(
+    help=(
+        "Run interactive standalone setup, prompt for NVIDIA_API_KEY and an optional "
+        "custom corpus directory, and write the local PolicyNIM config file."
+    ),
+)
+def init() -> None:
+    """Prompt for standalone local CLI settings and write them to an env file."""
+    destination = config_discovery.resolve_init_config_file()
+    api_key = typer.prompt(
+        "NVIDIA_API_KEY",
+        default="",
+        show_default=False,
+        hide_input=True,
+    ).strip()
+    if not api_key:
+        _exit_with_error("NVIDIA_API_KEY is required.")
+
+    corpus_input = typer.prompt(
+        "Optional custom corpus directory",
+        default="",
+        show_default=False,
+    )
+    try:
+        resolved_corpus_dir = config_discovery.normalize_init_corpus_dir(corpus_input)
+        config_path = config_discovery.write_init_config_file(
+            destination=destination,
+            api_key=api_key,
+            corpus_dir=resolved_corpus_dir,
+        )
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+    except OSError as exc:
+        _exit_with_error(f"Could not write config file {destination.expanduser()}: {exc}.")
+
+    corpus_message = (
+        resolved_corpus_dir.as_posix()
+        if resolved_corpus_dir is not None
+        else "bundled PolicyNIM corpus"
+    )
+    typer.echo(f"Wrote PolicyNIM config to {config_path}.")
+    typer.echo(f"Corpus: {corpus_message}")
+    typer.echo("Next step: run `policynim ingest`.")
+
+
 @app.command()
 def ingest() -> None:
     """Build the local policy index from the shipped corpus."""
     try:
-        service = create_ingest_service(get_settings())
+        settings = _load_setup_dependent_settings()
+        service = create_ingest_service(settings)
         result = service.run()
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
 
@@ -95,10 +163,11 @@ def dump_index(
 ) -> None:
     """Print all indexed chunks in a terminal-friendly format."""
     try:
-        service = create_index_dump_service(get_settings())
+        settings = _load_setup_dependent_settings()
+        service = create_index_dump_service(settings)
         chunks = service.list_chunks()
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
 
     typer.echo(f"Indexed chunks: {len(chunks)}")
     if count_only:
@@ -132,14 +201,14 @@ def preflight(
     ] = None,
 ) -> None:
     """Return policy guidance for a coding task."""
-    settings = get_settings()
-    resolved_top_k = top_k if top_k is not None else settings.default_top_k
     service = None
     try:
+        settings = _load_setup_dependent_settings()
+        resolved_top_k = top_k if top_k is not None else settings.default_top_k
         service = create_preflight_service(settings)
         result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
@@ -169,14 +238,14 @@ def search(
     ] = None,
 ) -> None:
     """Search the policy corpus."""
-    settings = get_settings()
-    resolved_top_k = top_k if top_k is not None else settings.default_top_k
     service = None
     try:
+        settings = _load_setup_dependent_settings()
+        resolved_top_k = top_k if top_k is not None else settings.default_top_k
         service = create_search_service(settings)
         result = service.search(SearchRequest(query=query, domain=domain, top_k=resolved_top_k))
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
@@ -199,10 +268,10 @@ def runtime_decide(
     service = None
     try:
         request = _load_runtime_request_payload(input)
-        service = create_runtime_decision_service(get_settings())
+        service = create_runtime_decision_service(_load_setup_dependent_settings())
         result = service.decide(request)
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     finally:
         _close_service(service)
 
@@ -223,10 +292,13 @@ def runtime_execute(
     service = None
     try:
         request = _load_runtime_request_payload(input)
-        service = create_runtime_execution_service(get_settings(), confirmer=_build_cli_confirmer())
+        service = create_runtime_execution_service(
+            _load_setup_dependent_settings(),
+            confirmer=_build_cli_confirmer(),
+        )
         result = service.execute(request)
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     finally:
         _close_service(service)
 
@@ -249,10 +321,10 @@ def evidence_report(
     """Summarize one runtime evidence session from SQLite-backed storage."""
     service = None
     try:
-        service = create_runtime_evidence_report_service(get_settings())
+        service = create_runtime_evidence_report_service(_load_setup_dependent_settings())
         result = service.report_session(session_id)
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     finally:
         _close_service(service)
 
@@ -283,10 +355,11 @@ def eval(
     """Run the PolicyNIM eval suite and persist local reports."""
     service = None
     try:
-        service = create_eval_service(get_settings())
+        settings = _load_setup_dependent_settings()
+        service = create_eval_service(settings)
         result = service.run(mode=mode, compare_rerank=not no_compare_rerank)
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
@@ -295,10 +368,10 @@ def eval(
     typer.echo(result.model_dump_json(indent=2))
     if not headless:
         try:
-            service = create_eval_service(get_settings())
+            service = create_eval_service(settings)
             service.start_ui()
         except PolicyNIMError as exc:
-            _exit_with_error(str(exc))
+            _exit_with_error(_cli_error_message(exc))
         finally:
             _close_service(service)
     if any(run.metrics.passed_count != run.metrics.case_count for run in result.runs):
@@ -317,9 +390,10 @@ def mcp(
 ) -> None:
     """Run the MCP server."""
     try:
+        _load_setup_dependent_settings()
         run_server(transport=transport)
     except PolicyNIMError as exc:
-        _exit_with_error(str(exc))
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
 
@@ -409,6 +483,13 @@ def main() -> None:
     app()
 
 
+def _version_option_callback(value: bool) -> None:
+    if not value:
+        return
+    typer.echo(_resolve_installed_version())
+    raise typer.Exit()
+
+
 def _exit_with_error(message: str) -> NoReturn:
     typer.secho(message, fg=typer.colors.RED, err=True)
     raise typer.Exit(code=1)
@@ -482,6 +563,51 @@ def _describe_runtime_input_source(input_value: str) -> str:
     if input_value == "-":
         return "stdin"
     return str(Path(input_value))
+
+
+def _resolve_installed_version() -> str:
+    try:
+        return installed_version("policynim")
+    except PackageNotFoundError as exc:
+        raise PolicyNIMError("Installed package metadata for PolicyNIM is unavailable.") from exc
+
+
+def _load_setup_dependent_settings() -> Settings:
+    if config_discovery.standalone_setup_missing():
+        _exit_with_error(_missing_setup_message())
+    try:
+        return get_settings()
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+
+
+def _missing_setup_message() -> str:
+    config_path = config_discovery.resolve_init_config_file()
+    return f"PolicyNIM is not set up yet. Run `policynim init` to create {config_path}."
+
+
+def _cli_error_message(error: PolicyNIMError) -> str:
+    if config_discovery.standalone_setup_missing() and _looks_like_missing_local_setup_error(error):
+        return _missing_setup_message()
+    if isinstance(error, MissingIndexError) and _is_standalone_local_runtime():
+        return _STANDALONE_MISSING_INDEX_MESSAGE
+    return str(error)
+
+
+def _looks_like_missing_local_setup_error(error: PolicyNIMError) -> bool:
+    if not isinstance(error, ConfigurationError):
+        return False
+
+    message = str(error)
+    lowered = message.lower()
+    return "nvidia_api_key" in lowered or "missing nvidia key" in lowered
+
+
+def _is_standalone_local_runtime() -> bool:
+    return (
+        not config_discovery.is_source_checkout()
+        and not config_discovery.is_hosted_process_environment()
+    )
 
 
 def _close_service(service: object | None) -> None:

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -486,7 +486,10 @@ def main() -> None:
 def _version_option_callback(value: bool) -> None:
     if not value:
         return
-    typer.echo(_resolve_installed_version())
+    try:
+        typer.echo(_resolve_installed_version())
+    except PolicyNIMError as exc:
+        _exit_with_error(str(exc))
     raise typer.Exit()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -679,6 +679,25 @@ def test_version_flag_prints_installed_version(monkeypatch: pytest.MonkeyPatch) 
     assert result.stderr == ""
 
 
+def test_version_flag_surfaces_metadata_errors_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_version_lookup() -> str:
+        raise PolicyNIMError("Installed package metadata for PolicyNIM is unavailable.")
+
+    monkeypatch.setattr(
+        "policynim.interfaces.cli._resolve_installed_version",
+        fail_version_lookup,
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 1
+    assert "Installed package metadata for PolicyNIM is unavailable." in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_init_help_documents_interactive_setup_flow() -> None:
     result = runner.invoke(app, ["init", "--help"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
@@ -655,12 +656,13 @@ def test_help_includes_dump_index_command() -> None:
 
 def test_help_includes_runtime_and_evidence_commands() -> None:
     result = runner.invoke(app, ["--help"])
+    help_output = strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "--version" in result.stdout
-    assert "init" in result.stdout
-    assert "runtime" in result.stdout
-    assert "evidence" in result.stdout
+    assert "--version" in help_output
+    assert "init" in help_output
+    assert "runtime" in help_output
+    assert "evidence" in help_output
 
 
 def test_version_flag_prints_installed_version(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,13 +8,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from typer.testing import CliRunner
 
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.cli import app
 from policynim.services.runtime_evidence_report import RuntimeEvidenceReportService
 from policynim.services.runtime_execution import RuntimeExecutionService
-from policynim.settings import Settings
+from policynim.settings import Settings, get_settings
 from policynim.storage import RuntimeEvidenceStore
 from policynim.types import (
     BetaAccount,
@@ -40,6 +41,68 @@ from policynim.types import (
 )
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def clear_cached_settings() -> None:
+    """Prevent settings cache from leaking between CLI tests."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def write_env_file(path: Path, **values: str) -> None:
+    """Write a small env-style config file for CLI setup tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key}={value}" for key, value in values.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def clear_installer_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear env that would interfere with standalone installer-style tests."""
+    for key in (
+        "NVIDIA_API_KEY",
+        "POLICYNIM_CONFIG_FILE",
+        "POLICYNIM_CORPUS_DIR",
+        "POLICYNIM_LANCEDB_URI",
+        "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
+        "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
+        "POLICYNIM_EVAL_WORKSPACE_DIR",
+        "PORT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def configure_standalone_cli_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, Path, Path]:
+    """Simulate an installed standalone runtime outside a contributor checkout."""
+    clear_installer_env(monkeypatch)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    config_root = tmp_path / "user-config"
+    data_root = tmp_path / "user-data"
+    package_root = tmp_path / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_config_path",
+        lambda *args, **kwargs: config_root,
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_data_path",
+        lambda *args, **kwargs: data_root,
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+
+    return workspace, config_root, data_root
 
 
 class MockIngestService:
@@ -594,8 +657,98 @@ def test_help_includes_runtime_and_evidence_commands() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
+    assert "--version" in result.stdout
+    assert "init" in result.stdout
     assert "runtime" in result.stdout
     assert "evidence" in result.stdout
+
+
+def test_version_flag_prints_installed_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli._resolve_installed_version",
+        lambda: "1.2.3",
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "1.2.3\n"
+    assert result.stderr == ""
+
+
+def test_init_help_documents_interactive_setup_flow() -> None:
+    result = runner.invoke(app, ["init", "--help"])
+
+    assert result.exit_code == 0
+    assert "interactive" in result.stdout.lower()
+    assert "NVIDIA_API_KEY" in result.stdout
+    assert "--non-interactive" not in result.stdout
+
+
+def test_init_command_writes_config_and_prints_next_step(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, config_root, data_root = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    custom_corpus = tmp_path / "custom-corpus"
+    custom_corpus.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["init"],
+        input=f"nvapi-test-key\n{custom_corpus}\n",
+    )
+
+    config_path = config_root / "config.env"
+    assert result.exit_code == 0
+    assert str(config_path) in result.stdout
+    assert str(custom_corpus) in result.stdout
+    assert "policynim ingest" in result.stdout
+    assert config_path.read_text(encoding="utf-8") == (
+        "NVIDIA_API_KEY='nvapi-test-key'\n"
+        f"POLICYNIM_CORPUS_DIR='{custom_corpus}'\n"
+        f"POLICYNIM_LANCEDB_URI='{data_root / 'lancedb'}'\n"
+        f"POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH='{data_root / 'runtime' / 'runtime_rules.json'}'\n"
+        "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH="
+        f"'{data_root / 'runtime' / 'runtime_evidence.sqlite3'}'\n"
+        f"POLICYNIM_EVAL_WORKSPACE_DIR='{data_root / 'evals' / 'workspace'}'\n"
+    )
+
+
+def test_init_command_rejects_blank_required_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["init"], input="\n")
+
+    assert result.exit_code == 1
+    assert "NVIDIA_API_KEY is required." in result.stderr
+    assert not (config_root / "config.env").exists()
+
+
+def test_init_command_surfaces_unwritable_config_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    target_config = tmp_path / "blocked" / "config.env"
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(target_config))
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr("policynim.config_discovery.os.replace", fail_replace)
+
+    result = runner.invoke(app, ["init"], input="nvapi-test-key\n\n")
+
+    assert result.exit_code == 1
+    assert str(target_config) in result.stderr
+    assert "permission denied" in result.stderr
+    assert not target_config.exists()
+    assert list(target_config.parent.glob("*.tmp")) == []
 
 
 def test_runtime_help_mentions_decide_and_execute_commands() -> None:
@@ -640,6 +793,101 @@ def test_search_command_surfaces_configuration_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "missing NVIDIA key" in result.stderr
+
+
+def test_search_command_points_to_init_when_standalone_setup_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_search_service",
+        lambda settings: (_ for _ in ()).throw(
+            ConfigurationError("NVIDIA_API_KEY is required for embeddings.")
+        ),
+    )
+
+    result = runner.invoke(app, ["search", "--query", "backend logs"])
+
+    assert result.exit_code == 1
+    assert "PolicyNIM is not set up yet." in result.stderr
+    assert "policynim init" in result.stderr
+    assert str(config_root / "config.env") in result.stderr
+    assert "policynim ingest" not in result.stderr
+
+
+def test_search_command_points_to_ingest_when_config_exists_but_index_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", NVIDIA_API_KEY="nvapi-test-key")
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_search_service",
+        lambda settings: (_ for _ in ()).throw(MissingIndexError("Local index is missing.")),
+    )
+
+    result = runner.invoke(app, ["search", "--query", "backend logs"])
+
+    assert result.exit_code == 1
+    assert "policynim ingest" in result.stderr
+    assert "policynim init" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("argv", "stdin_text"),
+    [
+        (["ingest"], None),
+        (["search", "--query", "backend logs"], None),
+        (["preflight", "--task", "refresh token cleanup"], None),
+        (["dump-index"], None),
+        (["eval", "--headless"], None),
+        (
+            ["runtime", "decide", "--input", "-"],
+            json.dumps(
+                {
+                    "kind": "shell_command",
+                    "task": "Run tests.",
+                    "cwd": "/tmp",
+                    "command": ["make", "test"],
+                }
+            ),
+        ),
+        (
+            ["runtime", "execute", "--input", "-"],
+            json.dumps(
+                {
+                    "kind": "shell_command",
+                    "task": "Run tests.",
+                    "cwd": "/tmp",
+                    "command": ["make", "test"],
+                }
+            ),
+        ),
+        (["evidence", "report", "--session-id", "session-123"], None),
+        (["mcp"], None),
+    ],
+)
+def test_setup_dependent_commands_point_to_init_when_redirected_config_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    argv: list[str],
+    stdin_text: str | None,
+) -> None:
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    redirected_config = tmp_path / "redirected" / "config.env"
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(redirected_config))
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.run_server",
+        lambda transport: (_ for _ in ()).throw(AssertionError("run_server should not be called")),
+    )
+
+    result = runner.invoke(app, argv, input=stdin_text)
+
+    assert result.exit_code == 1
+    assert "PolicyNIM is not set up yet." in result.stderr
+    assert "policynim init" in result.stderr
+    assert str(redirected_config) in result.stderr
 
 
 def test_preflight_command_surfaces_missing_index_errors(monkeypatch) -> None:

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -257,6 +257,59 @@ def test_standalone_setup_missing_when_redirected_config_file_does_not_exist(
     )
 
 
+def test_standalone_setup_missing_ignores_unrelated_cwd_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
+
+    assert (
+        config_discovery.standalone_setup_missing(
+            cwd=workspace,
+            environ=dict(config_discovery.os.environ),
+        )
+        is True
+    )
+
+
+def test_standalone_setup_present_when_cwd_dotenv_has_nvidia_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    write_env_file(workspace / ".env", NVIDIA_API_KEY="'nvapi-test-key'")
+
+    assert (
+        config_discovery.standalone_setup_missing(
+            cwd=workspace,
+            environ=dict(config_discovery.os.environ),
+        )
+        is False
+    )
+
+
+def test_standalone_setup_missing_when_existing_explicit_config_lacks_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    explicit_config = tmp_path / "explicit.env"
+    write_env_file(explicit_config, POLICYNIM_DEFAULT_TOP_K="4")
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(explicit_config))
+
+    assert (
+        config_discovery.standalone_setup_missing(
+            cwd=workspace,
+            environ=dict(config_discovery.os.environ),
+        )
+        is True
+    )
+
+
 def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -291,6 +344,34 @@ def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces
     assert settings.runtime_rules_artifact_path == data_root / "runtime" / "runtime_rules.json"
     assert settings.runtime_evidence_db_path == data_root / "runtime" / "runtime_evidence.sqlite3"
     assert settings.eval_workspace_dir == data_root / "evals" / "workspace"
+
+
+def test_write_init_config_file_closes_temp_handle_when_fdopen_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    closed_handles: list[int] = []
+    real_close = config_discovery.os.close
+
+    def fail_fdopen(handle: int, *args: object, **kwargs: object) -> object:
+        raise OSError("fdopen failed")
+
+    def track_close(handle: int) -> None:
+        closed_handles.append(handle)
+        real_close(handle)
+
+    monkeypatch.setattr("policynim.config_discovery.os.fdopen", fail_fdopen)
+    monkeypatch.setattr("policynim.config_discovery.os.close", track_close)
+
+    with pytest.raises(OSError, match="fdopen failed"):
+        config_discovery.write_init_config_file(
+            destination=tmp_path / "config.env",
+            api_key="nvapi-test-key",
+            corpus_dir=None,
+        )
+
+    assert len(closed_handles) == 1
+    assert list(tmp_path.glob("*.tmp")) == []
 
 
 def test_settings_uses_default_runtime_rules_artifact_path() -> None:

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
+import policynim.config_discovery as config_discovery
 from policynim.settings import Settings
 from policynim.types import (
     DEFAULT_TOP_K,
@@ -236,6 +237,60 @@ def test_settings_ignores_config_file_from_discovered_user_config(
     assert settings.default_top_k == 8
     assert settings.config_file is None
     assert settings.lancedb_uri == data_root / "lancedb"
+
+
+def test_standalone_setup_missing_when_redirected_config_file_does_not_exist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    clear_day1_env(monkeypatch)
+    workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
+    redirected_config = tmp_path / "redirected" / "config.env"
+    monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(redirected_config))
+
+    assert (
+        config_discovery.standalone_setup_missing(
+            cwd=workspace,
+            environ=dict(config_discovery.os.environ),
+        )
+        is True
+    )
+
+
+def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    clear_day1_env(monkeypatch)
+    config_root = tmp_path / "Application Support" / "PolicyNIM"
+    data_root = tmp_path / "Library" / "Application Support" / "PolicyNIM"
+    custom_corpus = tmp_path / "Custom Policies"
+    custom_corpus.mkdir(parents=True)
+    config_path = config_root / "config.env"
+
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_config_path",
+        lambda *args, **kwargs: config_root,
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_data_path",
+        lambda *args, **kwargs: data_root,
+    )
+
+    config_discovery.write_init_config_file(
+        destination=config_path,
+        api_key="quoted-key",
+        corpus_dir=custom_corpus,
+    )
+
+    settings = Settings(_env_file=config_path)
+
+    assert settings.nvidia_api_key == "quoted-key"
+    assert settings.corpus_dir == custom_corpus.resolve(strict=False)
+    assert settings.lancedb_uri == data_root / "lancedb"
+    assert settings.runtime_rules_artifact_path == data_root / "runtime" / "runtime_rules.json"
+    assert settings.runtime_evidence_db_path == data_root / "runtime" / "runtime_evidence.sqlite3"
+    assert settings.eval_workspace_dir == data_root / "evals" / "workspace"
 
 
 def test_settings_uses_default_runtime_rules_artifact_path() -> None:


### PR DESCRIPTION
## Summary
- add `policynim --version` and interactive `policynim init`
- write standalone env config with redirected `POLICYNIM_CONFIG_FILE` support and atomic writes
- route setup-dependent CLI commands to `policynim init` for missing standalone config and `policynim ingest` for missing local index

## Tests
- `uv run python -m pytest -q tests/test_cli.py tests/test_settings_and_types.py`
- `uv run ruff check src/policynim/config_discovery.py src/policynim/interfaces/cli.py tests/test_cli.py tests/test_settings_and_types.py`

Note: full `uv run ruff check` is currently blocked by unrelated untracked `test_issue.py` in the local worktree; it is not included in this PR.