### PR TITLE
feat(route): add build 1 policy router

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - Deterministic Markdown ingest with heading-aware chunking and source line spans.
 - NVIDIA-hosted embeddings and reranking for retrieval.
 - Local LanceDB storage for the retrievable policy index.
+- Task-aware policy routing with citation-preserving selected-policy packets.
 - Grounded preflight synthesis with citation validation and fail-closed fallback.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `preflight`,
+- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `preflight`,
   `eval`, `mcp`, `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
@@ -94,6 +95,7 @@ After the index is built, the fastest local sanity checks are:
 
 ```bash
 uv run policynim search --query "refresh token cleanup background job" --top-k 5
+uv run policynim route --task "Implement a refresh-token cleanup background job" --top-k 5
 uv run policynim preflight --task "Implement a refresh-token cleanup background job" --top-k 5
 ```
 
@@ -110,7 +112,7 @@ Start here when you want the longer version of a specific path:
 - [docs/index.md](docs/index.md): documentation hub by audience and task
 - [docs/contributor-guide.md](docs/contributor-guide.md): local setup, env vars,
   model references, and quality gates
-- [docs/workflows.md](docs/workflows.md): CLI surfaces, ingest/search/preflight,
+- [docs/workflows.md](docs/workflows.md): CLI surfaces, ingest/search/route/preflight,
   eval, MCP, runtime/evidence, and troubleshooting
 - [docs/hosted-beta-operations.md](docs/hosted-beta-operations.md): hosted beta
   quickstart, recovery, container build flow, and Railway deploy notes

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -26,6 +26,7 @@ flowchart LR
         direction TB
         IngestSvc["IngestService"]
         SearchSvc["SearchService"]
+        RouterSvc["PolicyRouterService"]
         PreflightSvc["PreflightService"]
         RuntimeDecisionSvc["RuntimeDecisionService"]
         RuntimeExecSvc["RuntimeExecutionService"]
@@ -68,6 +69,7 @@ flowchart LR
 
     CLI --> IngestSvc
     CLI --> SearchSvc
+    CLI --> RouterSvc
     CLI --> PreflightSvc
     CLI --> EvalSvc
     CLI --> DumpSvc
@@ -82,13 +84,16 @@ flowchart LR
 
     IngestSvc --> NvidiaAdapter
     SearchSvc --> NvidiaAdapter
+    RouterSvc --> NvidiaAdapter
     PreflightSvc --> NvidiaAdapter
     RuntimeDecisionSvc --> LanceStore
     RuntimeExecSvc --> RuntimeDecisionSvc
     RuntimeExecSvc --> RuntimeEvidenceStore
     IngestSvc --> LanceStore
     SearchSvc --> LanceStore
+    RouterSvc --> LanceStore
     PreflightSvc --> LanceStore
+    PreflightSvc --> RouterSvc
     DumpSvc --> LanceStore
     HealthSvc --> LanceStore
 
@@ -105,6 +110,7 @@ flowchart LR
 
     IngestSvc -. typed requests and results .-> Types
     SearchSvc -. typed requests and results .-> Types
+    RouterSvc -. typed requests and results .-> Types
     PreflightSvc -. typed requests and results .-> Types
     RuntimeDecisionSvc -. typed requests and results .-> Types
     RuntimeExecSvc -. typed requests and results .-> Types
@@ -112,6 +118,7 @@ flowchart LR
     HealthSvc -. typed requests and results .-> Types
     IngestSvc -. validated settings .-> Settings
     SearchSvc -. validated settings .-> Settings
+    RouterSvc -. validated settings .-> Settings
     PreflightSvc -. validated settings .-> Settings
     RuntimeDecisionSvc -. validated settings .-> Settings
     RuntimeExecSvc -. validated settings .-> Settings
@@ -119,12 +126,13 @@ flowchart LR
     HealthSvc -. validated settings .-> Settings
     IngestSvc -. contracts .-> Contracts
     SearchSvc -. contracts .-> Contracts
+    RouterSvc -. contracts .-> Contracts
     PreflightSvc -. contracts .-> Contracts
     RuntimeDecisionSvc -. contracts .-> Contracts
     RuntimeExecSvc -. contracts .-> Contracts
 
     class CLI,MCP iface
-    class IngestSvc,SearchSvc,PreflightSvc,RuntimeDecisionSvc,RuntimeExecSvc,EvalSvc,DumpSvc,HealthSvc service
+    class IngestSvc,SearchSvc,RouterSvc,PreflightSvc,RuntimeDecisionSvc,RuntimeExecSvc,EvalSvc,DumpSvc,HealthSvc service
     class IngestPkg,NvidiaAdapter,LanceStore,RuntimeEvidenceStore adapter
     class Settings,Types,Contracts shared
     class Policies,EvalSuite,RuntimeRules,RuntimeEvidenceDB local
@@ -162,15 +170,22 @@ flowchart TB
 
     subgraph Preflight["Grounded Preflight"]
         direction LR
-        Task["Coding task"] --> EmbedTask["Embed task"]
-        EmbedTask --> DensePreflight["Dense retrieve from index"]
-        DensePreflight --> PreflightRerank["Rerank candidates"]
-        PreflightRerank --> Retain["Retain diverse context"]
-        Retain --> Generate["Generate grounded draft"]
+        Task["Coding task"] --> PreflightRoute["Route selected evidence"]
+        PreflightRoute --> Generate["Generate grounded draft"]
         Generate --> Validate["Validate cited chunk IDs"]
         Validate --> Enough{"Grounded enough?"}
         Enough -- yes --> PreflightJSON["PreflightResult JSON"]
         Enough -- no --> Insufficient["insufficient_context=true"]
+    end
+
+    subgraph Route["Policy Route Request"]
+        direction LR
+        RouteTask["Coding task"] --> ProfileTask["Infer task profile"]
+        ProfileTask --> EmbedRouteTask["Embed task"]
+        EmbedRouteTask --> DenseRoute["Dense retrieve from index"]
+        DenseRoute --> RouteRerank["Rerank with profile signals"]
+        RouteRerank --> SelectPolicies["Select policy packet"]
+        SelectPolicies --> RouteJSON["PolicySelectionPacket JSON"]
     end
 
     subgraph Runtime["Runtime Decisions"]
@@ -197,20 +212,21 @@ flowchart TB
     end
 
     Index -. vector lookup .-> DenseSearch
-    Index -. vector lookup .-> DensePreflight
+    Index -. vector lookup .-> DenseRoute
+    PreflightRoute -. task-aware selection .-> SelectPolicies
     RuntimeRules -. compiled rules .-> LoadRules
     Index -. indexed evidence .-> MatchRules
     RuntimeEvidenceDB -. persisted evidence .-> Persist
 
     EmbedDocs --> Embeddings["NVIDIA embeddings"]
     EmbedQuery --> Embeddings
-    EmbedTask --> Embeddings
+    EmbedRouteTask --> Embeddings
     SearchRerank --> RerankAPI["NVIDIA reranking"]
-    PreflightRerank --> RerankAPI
+    RouteRerank --> RerankAPI
     Generate --> GroundAPI["NVIDIA grounded generation"]
 
-    class Policies,Query,Task,EvalSuite input
-    class Parse,Chunk,EmbedDocs,EmbedQuery,DenseSearch,DomainFilter,SearchRerank,EmbedTask,DensePreflight,PreflightRerank,Retain,Generate,Validate,EvalRun,Compare,Reports step
+    class Policies,Query,Task,RouteTask,EvalSuite input
+    class Parse,Chunk,EmbedDocs,EmbedQuery,DenseSearch,DomainFilter,SearchRerank,ProfileTask,EmbedRouteTask,DenseRoute,RouteRerank,SelectPolicies,PreflightRoute,Generate,Validate,EvalRun,Compare,Reports step
     class Index store
     class Action input
     class LoadRules,MatchRules,Decision,Execute,Persist step
@@ -219,7 +235,7 @@ flowchart TB
     class HealthRoute input
     class HealthRuntime step
     class HealthJSON result
-    class SearchJSON,PreflightJSON,Insufficient,UI result
+    class SearchJSON,RouteJSON,PreflightJSON,Insufficient,UI result
 ```
 
 ## Reading Notes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ The architecture stays intentionally small:
 
 - typed contracts shared by CLI and MCP
 - explicit provider and storage adapters
-- application services for ingest, retrieval, preflight, and evaluation
+- application services for ingest, retrieval, task-aware routing, preflight, and
+  evaluation
 - application services for runtime decisions, runtime execution, and durable
   evidence capture
 - fail-closed grounding rules instead of best-effort freeform answers
@@ -73,14 +74,33 @@ Current retrieval design choices:
 - the same embedding model is used for document and query vectors
 - reranking is part of the normal search path, not a separate experimental mode
 
+### Task-Aware Routing Flow
+
+`PolicyRouterService` is the selection-only layer between raw retrieval and
+grounded synthesis.
+
+Routing flow:
+
+1. validate the route request and optional task-type override
+2. infer a deterministic `TaskProfile` from task text when no override is present
+3. embed the original task through NVIDIA-hosted embeddings
+4. retrieve broad dense candidates from the local LanceDB table
+5. rerank candidates against the task plus task-profile signals
+6. retain bounded policy evidence with source chunk IDs and line spans
+7. return a JSON-first `PolicySelectionPacket`
+
+Build 1 routing intentionally does not compile policies into planning
+constraints. Weak or empty routing evidence becomes `insufficient_context=true`;
+missing configuration or a missing local index remains an explicit error.
+
 ### Grounded Preflight Flow
 
 `PreflightService` is the main orchestration layer for grounded policy guidance.
 
 Preflight flow:
 
-1. retrieve and rerank relevant evidence
-2. send retained evidence to the grounded generator
+1. route the task into a retained `PolicySelectionPacket`
+2. send retained policy evidence to the grounded generator
 3. receive a structured draft that cites retrieved chunk IDs
 4. validate every cited chunk ID against the retained result set
 5. materialize public citations and policy guidance
@@ -167,8 +187,10 @@ Important evaluation rules:
 - Owns application orchestration.
 - `IngestService` handles parse, chunk, embed, and rebuild.
 - `SearchService` handles query embedding, retrieval, and reranking.
-- `PreflightService` handles retrieval, grounded synthesis, and citation
-  validation.
+- `PolicyRouterService` handles deterministic task profiling, broad retrieval,
+  reranking, selected-policy grouping, and citation-preserving route packets.
+- `PreflightService` handles routed evidence selection, grounded synthesis, and
+  citation validation.
 - `RuntimeDecisionService` compiles and matches runtime rules against the local
   index by loading the compiled runtime rules artifact, matching actions
   against it, and linking the matched rules back to indexed evidence.
@@ -214,6 +236,7 @@ Important evaluation rules:
 - `policynim ingest`
 - `policynim dump-index`
 - `policynim search --query ...`
+- `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim preflight --task ...`
 - `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
@@ -247,6 +270,8 @@ Important evaluation rules:
 Shared interface guarantees:
 
 - CLI `search` and MCP `policy_search` use the same `SearchResult` shape.
+- CLI `route` returns a `PolicySelectionPacket`; there is no MCP route tool in
+  Build 1.
 - CLI `preflight` and MCP `policy_preflight` use the same `PreflightResult`
   shape.
 - CLI `runtime decide` and `runtime execute` use the same `RuntimeActionRequest`
@@ -268,7 +293,7 @@ Shared interface guarantees:
 NVIDIA-hosted APIs are used for:
 
 - document embeddings during ingest
-- query embeddings during search and preflight
+- query embeddings during search, route, and preflight
 - reranking retrieved candidates
 - grounded generation for preflight
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ operations into separate pages so the root README can stay short.
   quickstart, and links outward
 - [contributor-guide.md](contributor-guide.md): local setup, env templates,
   important settings, model references, and quality gates
-- [workflows.md](workflows.md): CLI, MCP, runtime/evidence, eval, and
+- [workflows.md](workflows.md): CLI, route/preflight, MCP, runtime/evidence, eval, and
   troubleshooting handbook
 - [hosted-beta-operations.md](hosted-beta-operations.md): hosted beta quickstart,
   recovery, container build flow, and Railway deployment notes

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -10,6 +10,7 @@ reference that used to live in the root README.
 - `policynim ingest`
 - `policynim dump-index`
 - `policynim search --query "..."`
+- `policynim route --task "..."`
 - `policynim preflight --task "..."`
 - `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
@@ -83,7 +84,34 @@ uv run policynim search \
   --top-k 5
 ```
 
-### 4. Run Grounded Preflight
+### 4. Route Task-Aware Policy Selection
+
+```bash
+uv run policynim route \
+  --task "Implement a refresh-token cleanup background job" \
+  --top-k 5
+```
+
+`route` is the inspection path between raw search and grounded preflight. It
+returns a JSON `PolicySelectionPacket` with:
+
+- the inferred or explicitly provided task type
+- selected policies
+- selection reasons
+- supporting chunk IDs, source paths, line spans, and evidence text
+- `insufficient_context`
+
+Use `--task-type` when the task text is intentionally terse or mixed:
+
+```bash
+uv run policynim route \
+  --task "token cleanup" \
+  --task-type refactor \
+  --domain security \
+  --top-k 5
+```
+
+### 5. Run Grounded Preflight
 
 ```bash
 uv run policynim preflight \
@@ -104,7 +132,7 @@ uv run policynim preflight \
 If citation validation fails or the grounded answer is too weak, PolicyNIM
 returns `insufficient_context=true` instead of bluffing.
 
-### 5. Run Evaluations
+### 6. Run Evaluations
 
 ```bash
 uv run policynim eval
@@ -298,8 +326,9 @@ PolicyNIM keeps the retrieval stack explicit:
 2. embed query and document text with NVIDIA-hosted embeddings
 3. retrieve dense candidates from LanceDB
 4. rerank candidates with NVIDIA
-5. generate grounded guidance from retained evidence only
-6. validate every citation against retrieved chunks before returning results
+5. route retained evidence into selected-policy packets
+6. generate grounded guidance from routed evidence only
+7. validate every citation against retrieved chunks before returning results
 
 The system is designed to fail closed:
 
@@ -320,6 +349,15 @@ uv run policynim search \
   --top-k 5 | jq
 ```
 
+Then inspect routed policy selection:
+
+```bash
+uv run policynim route \
+  --task "Implement a refresh-token cleanup background job" \
+  --domain security \
+  --top-k 5 | jq
+```
+
 Then compare that with:
 
 ```bash
@@ -329,9 +367,11 @@ uv run policynim preflight \
   --top-k 5 | jq
 ```
 
-If `search` returns strong hits while `preflight` returns
-`insufficient_context=true`, the failure is in grounded answer validation, not
-indexing.
+If `search` returns strong hits and `route` returns selected policies while
+`preflight` returns `insufficient_context=true`, the failure is in grounded
+answer validation, not indexing. If `route` also returns
+`insufficient_context=true`, inspect the task type, domain filter, and indexed
+policy coverage first.
 
 ### Negative Search Scores
 

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -20,6 +20,7 @@ from policynim.services import (
     create_eval_service,
     create_index_dump_service,
     create_ingest_service,
+    create_policy_router_service,
     create_preflight_service,
     create_runtime_decision_service,
     create_runtime_evidence_report_service,
@@ -31,10 +32,12 @@ from policynim.types import (
     MAX_TOP_K,
     EvalExecutionMode,
     PreflightRequest,
+    RouteRequest,
     RuntimeActionRequest,
     RuntimeDecisionResult,
     RuntimeExecutionOutcome,
     SearchRequest,
+    TaskType,
 )
 
 _RUNTIME_REQUEST_ADAPTER = TypeAdapter(RuntimeActionRequest)
@@ -207,6 +210,8 @@ def preflight(
         resolved_top_k = top_k if top_k is not None else settings.default_top_k
         service = create_preflight_service(settings)
         result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
+    except ValidationError as exc:
+        _exit_with_error(_format_validation_error("Preflight request", exc))
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
@@ -252,6 +257,61 @@ def search(
         _close_service(service)
 
     typer.echo(result.model_dump_json(indent=2))
+
+
+@app.command()
+def route(
+    task: Annotated[
+        str,
+        typer.Option("--task", help="Describe the coding task that needs policy selection."),
+    ],
+    domain: Annotated[
+        str | None,
+        typer.Option("--domain", help="Optional policy domain such as backend or security."),
+    ] = None,
+    top_k: Annotated[
+        int | None,
+        typer.Option(
+            "--top-k",
+            min=1,
+            max=MAX_TOP_K,
+            help="Selected evidence depth. Allowed range: 1-20.",
+        ),
+    ] = None,
+    task_type: Annotated[
+        TaskType | None,
+        typer.Option(
+            "--task-type",
+            help=(
+                "Optional task-type override. Supported values: bug_fix, refactor, "
+                "api_change, migration, test_change, feature_work, unknown."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Return task-aware selected policy evidence."""
+    settings = get_settings()
+    resolved_top_k = top_k if top_k is not None else settings.default_top_k
+    service = None
+    try:
+        request = RouteRequest(
+            task=task,
+            domain=domain,
+            top_k=resolved_top_k,
+            task_type=task_type,
+        )
+        service = create_policy_router_service(settings)
+        result = service.route(request)
+    except ValidationError as exc:
+        _exit_with_error(_format_validation_error("Route request", exc))
+    except PolicyNIMError as exc:
+        _exit_with_error(str(exc))
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+    finally:
+        _close_service(service)
+
+    typer.echo(result.packet.model_dump_json(indent=2))
 
 
 @runtime_app.command("decide")
@@ -498,6 +558,12 @@ def _exit_with_error(message: str) -> NoReturn:
     raise typer.Exit(code=1)
 
 
+def _format_validation_error(label: str, exc: ValidationError) -> str:
+    error = exc.errors()[0]
+    location = ".".join(str(part) for part in error["loc"]) or "request"
+    return f"{label} is invalid at {location}: {error['msg']}."
+
+
 def _read_json_input(input_value: str) -> object:
     source_label = _describe_runtime_input_source(input_value)
     try:
@@ -532,9 +598,7 @@ def _load_runtime_request_payload(input_value: str) -> RuntimeActionRequest:
     try:
         return _RUNTIME_REQUEST_ADAPTER.validate_python(payload)
     except ValidationError as exc:
-        error = exc.errors()[0]
-        location = ".".join(str(part) for part in error["loc"]) or "request"
-        raise PolicyNIMError(f"Runtime input is invalid at {location}: {error['msg']}.") from exc
+        raise PolicyNIMError(_format_validation_error("Runtime input", exc)) from exc
 
 
 def _build_cli_confirmer():

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from mcp.server.fastmcp import Context, FastMCP
+from pydantic import ValidationError
 from starlette.datastructures import Headers
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
@@ -111,6 +112,12 @@ def _validate_top_k(top_k: int) -> None:
     """Validate top_k across MCP tools."""
     if not MIN_TOP_K <= top_k <= MAX_TOP_K:
         raise ValueError(f"top_k must be between {MIN_TOP_K} and {MAX_TOP_K}.")
+
+
+def _format_validation_error(label: str, exc: ValidationError) -> str:
+    error = exc.errors()[0]
+    location = ".".join(str(part) for part in error["loc"]) or "request"
+    return f"{label} is invalid at {location}: {error['msg']}."
 
 
 def _close_service(service: object | None) -> None:
@@ -210,6 +217,8 @@ def _run_policy_preflight(
     try:
         result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
         return result.model_dump(mode="json")
+    except ValidationError as exc:
+        raise ValueError(_format_validation_error("Preflight request", exc)) from exc
     finally:
         _close_service(service)
 

--- a/src/policynim/runtime_paths.py
+++ b/src/policynim/runtime_paths.py
@@ -79,7 +79,7 @@ def _resolve_packaged_resource(*parts: str) -> Path | None:
     resource = resources.files("policynim")
     for part in parts:
         resource = resource.joinpath(part)
-    if not resource.exists():
+    if not resource.is_file() and not resource.is_dir():
         return None
     return _PACKAGED_RESOURCE_STACK.enter_context(resources.as_file(resource))
 

--- a/src/policynim/services/__init__.py
+++ b/src/policynim/services/__init__.py
@@ -10,6 +10,7 @@ from policynim.services.health import (
 )
 from policynim.services.ingest import IngestService, create_ingest_service
 from policynim.services.preflight import PreflightService, create_preflight_service
+from policynim.services.router import PolicyRouterService, create_policy_router_service
 from policynim.services.runtime_decision import (
     RuntimeDecisionService,
     create_runtime_decision_service,
@@ -30,6 +31,7 @@ __all__ = [
     "IndexDumpService",
     "IngestService",
     "PreflightService",
+    "PolicyRouterService",
     "RuntimeDecisionService",
     "RuntimeEvidenceReportService",
     "RuntimeExecutionService",
@@ -45,5 +47,6 @@ __all__ = [
     "create_index_dump_service",
     "create_ingest_service",
     "create_preflight_service",
+    "create_policy_router_service",
     "create_search_service",
 ]

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -793,7 +793,7 @@ class _OfflineReranker(Reranker):
         *,
         top_k: int,
     ) -> list[ScoredChunk]:
-        order = _OFFLINE_RERANK_ORDERS.get(query, [])
+        order = _OFFLINE_RERANK_ORDERS.get(_offline_rerank_key(query), [])
         positions = {chunk_id: index for index, chunk_id in enumerate(order)}
         ranked = sorted(
             list(candidates),
@@ -803,6 +803,10 @@ class _OfflineReranker(Reranker):
 
     def close(self) -> None:
         return None
+
+
+def _offline_rerank_key(query: str) -> str:
+    return query.split(" Task type:", 1)[0]
 
 
 class _OfflineGenerator(Generator):

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from types import TracebackType
 from typing import Any
 
 from policynim.contracts import Embedder, Generator, IndexStore, Reranker
-from policynim.errors import MissingIndexError
-from policynim.runtime_paths import resolve_runtime_path
+from policynim.services.router import PolicyRouterService, create_policy_router_service
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
 from policynim.types import (
     Citation,
     GeneratedPolicyGuidance,
@@ -19,13 +16,12 @@ from policynim.types import (
     PolicyGuidance,
     PreflightRequest,
     PreflightResult,
+    RouteRequest,
     ScoredChunk,
 )
 
 DraftPolicyGuidance = GeneratedPolicyGuidance
 
-_DEFAULT_RETRIEVAL_CANDIDATE_POOL = 15
-_MAX_CHUNKS_PER_POLICY = 2
 _INSUFFICIENT_CONTEXT_SUMMARY = (
     "PolicyNIM could not find enough grounded policy evidence for this task."
 )
@@ -37,14 +33,23 @@ class PreflightService:
     def __init__(
         self,
         *,
-        embedder: Embedder,
-        index_store: IndexStore,
-        reranker: Reranker,
         generator: Generator,
+        router: PolicyRouterService | None = None,
+        embedder: Embedder | None = None,
+        index_store: IndexStore | None = None,
+        reranker: Reranker | None = None,
     ) -> None:
-        self._embedder = embedder
-        self._index_store = index_store
-        self._reranker = reranker
+        if router is None:
+            if embedder is None or index_store is None or reranker is None:
+                raise ValueError(
+                    "PreflightService requires either a router or embedder/index_store/reranker."
+                )
+            router = PolicyRouterService(
+                embedder=embedder,
+                index_store=index_store,
+                reranker=reranker,
+            )
+        self._router = router
         self._generator = generator
 
     def __enter__(self) -> PreflightService:
@@ -60,35 +65,18 @@ class PreflightService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._embedder)
-        _close_component(self._reranker)
+        _close_component(self._router)
         _close_component(self._generator)
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
-        _ensure_index_ready(self._index_store)
-
-        task_embedding = self._embedder.embed_query(request.task)
-        dense_candidates = self._index_store.search(
-            task_embedding,
-            top_k=max(request.top_k, _DEFAULT_RETRIEVAL_CANDIDATE_POOL),
-            domain=request.domain,
+        route_result = self._router.route(
+            RouteRequest(task=request.task, domain=request.domain, top_k=request.top_k)
         )
-        if not dense_candidates:
+        if route_result.packet.insufficient_context or not route_result.retained_context:
             return _insufficient_context_result(request)
 
-        reranked_candidates = self._reranker.rerank(
-            request.task,
-            dense_candidates,
-            top_k=max(request.top_k, _DEFAULT_RETRIEVAL_CANDIDATE_POOL),
-        )
-        if not reranked_candidates:
-            return _insufficient_context_result(request)
-
-        retained_context = _retain_diverse_context(reranked_candidates, top_k=request.top_k)
-        if not retained_context:
-            return _insufficient_context_result(request)
-
+        retained_context = route_result.retained_context
         generated = self._generator.generate_preflight(request, retained_context)
         draft = _coerce_generated_draft(generated)
         validated = _validate_and_materialize_result(request, retained_context, draft)
@@ -100,47 +88,18 @@ class PreflightService:
 def create_preflight_service(settings: Settings | None = None) -> PreflightService:
     """Build the default preflight service from application settings."""
     active_settings = settings or get_settings()
-    embedder, reranker, generator = _create_default_preflight_components(active_settings)
+    router = create_policy_router_service(active_settings)
+    generator = _create_default_generator(active_settings)
     return PreflightService(
-        embedder=embedder,
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        ),
-        reranker=reranker,
+        router=router,
         generator=generator,
     )
 
 
-def _create_default_preflight_components(
-    settings: Settings,
-) -> tuple[Embedder, Reranker, Generator]:
-    from policynim.providers import NVIDIAEmbedder, NVIDIAGenerator, NVIDIAReranker
+def _create_default_generator(settings: Settings) -> Generator:
+    from policynim.providers import NVIDIAGenerator
 
-    return (
-        NVIDIAEmbedder.from_settings(settings),
-        NVIDIAReranker.from_settings(settings),
-        NVIDIAGenerator.from_settings(settings),
-    )
-
-
-def _ensure_index_ready(index_store: IndexStore) -> None:
-    if not index_store.exists() or index_store.count() == 0:
-        raise MissingIndexError("Run `policynim ingest` before using grounded preflight.")
-
-
-def _retain_diverse_context(chunks: Sequence[ScoredChunk], *, top_k: int) -> list[ScoredChunk]:
-    selected: list[ScoredChunk] = []
-    counts: dict[str, int] = defaultdict(int)
-    for chunk in chunks:
-        policy_id = chunk.policy.policy_id
-        if counts[policy_id] >= _MAX_CHUNKS_PER_POLICY:
-            continue
-        selected.append(chunk)
-        counts[policy_id] += 1
-        if len(selected) >= top_k:
-            break
-    return selected
+    return NVIDIAGenerator.from_settings(settings)
 
 
 def _coerce_generated_draft(generated: Any) -> GeneratedPreflightDraft:

--- a/src/policynim/services/router.py
+++ b/src/policynim/services/router.py
@@ -1,0 +1,362 @@
+"""Task-aware policy router for PolicyNIM selection packets."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Sequence
+from types import TracebackType
+
+from policynim.contracts import Embedder, IndexStore, Reranker
+from policynim.errors import MissingIndexError
+from policynim.runtime_paths import resolve_runtime_path
+from policynim.settings import Settings, get_settings
+from policynim.storage import LanceDBIndexStore
+from policynim.types import (
+    PolicyMetadata,
+    PolicySelectionPacket,
+    RouteRequest,
+    RouteResult,
+    ScoredChunk,
+    SelectedPolicy,
+    SelectedPolicyEvidence,
+    TaskProfile,
+    TaskType,
+)
+
+_DEFAULT_ROUTING_CANDIDATE_POOL = 15
+_MAX_CHUNKS_PER_POLICY = 2
+_TaskPattern = tuple[str, str]
+_ROUTABLE_TASK_TYPES: tuple[TaskType, ...] = (
+    "bug_fix",
+    "refactor",
+    "api_change",
+    "migration",
+    "test_change",
+    "feature_work",
+)
+_TASK_TYPE_PATTERNS: dict[TaskType, tuple[_TaskPattern, ...]] = {
+    "bug_fix": (
+        (r"\bbug\b", "bug"),
+        (r"\bfix(?:e[ds])?\b", "fix"),
+        (r"\bregression\b", "regression"),
+        (r"\berror\b", "error"),
+        (r"\bexception\b", "exception"),
+        (r"\bfail(?:s|ed|ing|ure)?\b", "failure"),
+        (r"\bbroken\b", "broken"),
+        (r"\bcrash(?:es|ed|ing)?\b", "crash"),
+    ),
+    "refactor": (
+        (r"\brefactor(?:ing|ed)?\b", "refactor"),
+        (r"\bcleanup\b", "cleanup"),
+        (r"\bsimplif(?:y|ies|ied|ication)\b", "simplify"),
+        (r"\brestructure\b", "restructure"),
+        (r"\breorganize\b", "reorganize"),
+        (r"\brename\b", "rename"),
+        (r"\bdeduplicate\b", "deduplicate"),
+    ),
+    "api_change": (
+        (r"\bapi\b", "api"),
+        (r"\bendpoint\b", "endpoint"),
+        (r"\bcontract\b", "contract"),
+        (r"\bschema\b", "schema"),
+        (r"\brequest\b", "request"),
+        (r"\bresponse\b", "response"),
+        (r"\bversion(?:ing)?\b", "versioning"),
+        (r"\bpublic interface\b", "public interface"),
+    ),
+    "migration": (
+        (r"\bmigration\b", "migration"),
+        (r"\bmigrate\b", "migrate"),
+        (r"\bbackfill\b", "backfill"),
+        (r"\bschema migration\b", "schema migration"),
+        (r"\bdata migration\b", "data migration"),
+    ),
+    "test_change": (
+        (r"\btest(?:s|ing)?\b", "test"),
+        (r"\bpytest\b", "pytest"),
+        (r"\bcoverage\b", "coverage"),
+        (r"\bassert(?:ion)?\b", "assertion"),
+        (r"\bfixture\b", "fixture"),
+        (r"\bmock\b", "mock"),
+    ),
+    "feature_work": (
+        (r"\bfeature\b", "feature"),
+        (r"\badd\b", "add"),
+        (r"\bimplement\b", "implement"),
+        (r"\bbuild\b", "build"),
+        (r"\bsupport\b", "support"),
+        (r"\bcreate\b", "create"),
+    ),
+}
+
+
+class PolicyRouterService:
+    """Profile tasks, retrieve/rerank evidence, and emit selection packets."""
+
+    def __init__(
+        self,
+        *,
+        embedder: Embedder,
+        index_store: IndexStore,
+        reranker: Reranker,
+    ) -> None:
+        self._embedder = embedder
+        self._index_store = index_store
+        self._reranker = reranker
+
+    def __enter__(self) -> PolicyRouterService:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release owned provider resources held by this service."""
+        _close_component(self._embedder)
+        _close_component(self._reranker)
+
+    def route(self, request: RouteRequest) -> RouteResult:
+        """Return task-aware selected policy evidence for a coding task."""
+        _ensure_index_ready(self._index_store)
+
+        profile = profile_task(request.task, explicit_task_type=request.task_type)
+        task_embedding = self._embedder.embed_query(request.task)
+        dense_candidates = self._index_store.search(
+            task_embedding,
+            top_k=max(request.top_k, _DEFAULT_ROUTING_CANDIDATE_POOL),
+            domain=request.domain,
+        )
+        if not dense_candidates:
+            return _empty_route_result(request, profile)
+
+        route_query = _build_route_query(profile, domain=request.domain)
+        reranked_candidates = self._reranker.rerank(
+            route_query,
+            dense_candidates,
+            top_k=max(request.top_k, _DEFAULT_ROUTING_CANDIDATE_POOL),
+        )
+        retained_context = _retain_policy_evidence(reranked_candidates, top_k=request.top_k)
+        if not retained_context:
+            return _empty_route_result(request, profile)
+
+        return RouteResult(
+            packet=_build_selection_packet(request, profile, retained_context),
+            retained_context=retained_context,
+        )
+
+
+def create_policy_router_service(settings: Settings | None = None) -> PolicyRouterService:
+    """Build the default policy router from application settings."""
+    active_settings = settings or get_settings()
+    embedder, reranker = _create_default_router_components(active_settings)
+    return PolicyRouterService(
+        embedder=embedder,
+        index_store=LanceDBIndexStore(
+            uri=resolve_runtime_path(active_settings.lancedb_uri),
+            table_name=active_settings.lancedb_table,
+        ),
+        reranker=reranker,
+    )
+
+
+def profile_task(task: str, *, explicit_task_type: TaskType | None = None) -> TaskProfile:
+    """Infer a deterministic task profile from freeform task text."""
+    normalized_task = task.strip()
+    if not normalized_task:
+        raise ValueError("Task must not be empty.")
+    if explicit_task_type is not None:
+        return TaskProfile(
+            task=normalized_task,
+            task_type=explicit_task_type,
+            explicit_task_type=explicit_task_type,
+            signals=[f"explicit:{explicit_task_type}"],
+        )
+
+    normalized_text = normalized_task.casefold()
+    signal_map = {
+        task_type: _matching_signals(normalized_text, _TASK_TYPE_PATTERNS[task_type])
+        for task_type in _ROUTABLE_TASK_TYPES
+    }
+    scores = {task_type: len(signal_map[task_type]) for task_type in _ROUTABLE_TASK_TYPES}
+    max_score = max(scores.values(), default=0)
+    matched_signals = [
+        signal for task_type in _ROUTABLE_TASK_TYPES for signal in signal_map[task_type]
+    ]
+    if max_score == 0:
+        return TaskProfile(task=normalized_task, task_type="unknown", signals=[])
+
+    best_types: list[TaskType] = [
+        task_type
+        for task_type in _ROUTABLE_TASK_TYPES
+        if scores[task_type] == max_score and scores[task_type] > 0
+    ]
+    if len(best_types) != 1:
+        return TaskProfile(
+            task=normalized_task,
+            task_type="unknown",
+            signals=matched_signals,
+        )
+
+    task_type: TaskType = best_types[0]
+    return TaskProfile(
+        task=normalized_task,
+        task_type=task_type,
+        signals=signal_map[task_type],
+    )
+
+
+def _create_default_router_components(settings: Settings) -> tuple[Embedder, Reranker]:
+    from policynim.providers import NVIDIAEmbedder, NVIDIAReranker
+
+    return (
+        NVIDIAEmbedder.from_settings(settings),
+        NVIDIAReranker.from_settings(settings),
+    )
+
+
+def _ensure_index_ready(index_store: IndexStore) -> None:
+    if not index_store.exists() or index_store.count() == 0:
+        raise MissingIndexError("Run `policynim ingest` before routing policy selection.")
+
+
+def _matching_signals(text: str, patterns: Sequence[_TaskPattern]) -> list[str]:
+    signals: list[str] = []
+    for pattern, label in patterns:
+        if re.search(pattern, text):
+            signals.append(label)
+    return signals
+
+
+def _build_route_query(profile: TaskProfile, *, domain: str | None) -> str:
+    task_type_label = profile.task_type.replace("_", " ")
+    parts = [profile.task, f"Task type: {task_type_label}."]
+    if domain is not None:
+        parts.append(f"Policy domain: {domain}.")
+    if profile.signals:
+        parts.append("Profile signals: " + ", ".join(profile.signals) + ".")
+    return " ".join(parts)
+
+
+def _retain_policy_evidence(chunks: Sequence[ScoredChunk], *, top_k: int) -> list[ScoredChunk]:
+    selected: list[ScoredChunk] = []
+    counts: dict[str, int] = defaultdict(int)
+    for chunk in chunks:
+        if len(selected) >= top_k:
+            break
+        if not _has_evidence_signal(chunk):
+            continue
+
+        policy_id = chunk.policy.policy_id
+        if counts[policy_id] >= _MAX_CHUNKS_PER_POLICY:
+            continue
+        selected.append(chunk)
+        counts[policy_id] += 1
+    return selected
+
+
+def _has_evidence_signal(chunk: ScoredChunk) -> bool:
+    return chunk.score is None or chunk.score > 0.0
+
+
+def _build_selection_packet(
+    request: RouteRequest,
+    profile: TaskProfile,
+    retained_context: Sequence[ScoredChunk],
+) -> PolicySelectionPacket:
+    policies_by_id: dict[str, list[ScoredChunk]] = defaultdict(list)
+    policy_order: list[PolicyMetadata] = []
+    for chunk in retained_context:
+        policy_id = chunk.policy.policy_id
+        if policy_id not in policies_by_id:
+            policy_order.append(chunk.policy)
+        policies_by_id[policy_id].append(chunk)
+
+    selected_policies = [
+        _selected_policy_from_chunks(profile, policy, policies_by_id[policy.policy_id])
+        for policy in policy_order
+    ]
+    return PolicySelectionPacket(
+        task=profile.task,
+        domain=request.domain,
+        top_k=request.top_k,
+        task_type=profile.task_type,
+        explicit_task_type=profile.explicit_task_type,
+        profile_signals=list(profile.signals),
+        selected_policies=selected_policies,
+        insufficient_context=not selected_policies,
+    )
+
+
+def _selected_policy_from_chunks(
+    profile: TaskProfile,
+    policy: PolicyMetadata,
+    chunks: Sequence[ScoredChunk],
+) -> SelectedPolicy:
+    return SelectedPolicy(
+        policy_id=policy.policy_id,
+        title=policy.title,
+        domain=policy.domain,
+        reason=_selection_reason(profile, policy, evidence_count=len(chunks)),
+        evidence=[_evidence_from_chunk(chunk) for chunk in chunks],
+    )
+
+
+def _selection_reason(
+    profile: TaskProfile,
+    policy: PolicyMetadata,
+    *,
+    evidence_count: int,
+) -> str:
+    task_type_label = profile.task_type.replace("_", " ")
+    if profile.explicit_task_type is not None:
+        signal_source = "the explicit task-type override"
+    elif profile.signals:
+        signal_source = "deterministic task-profile signals"
+    else:
+        signal_source = "the task text"
+    return (
+        f"Selected for {task_type_label} routing from {evidence_count} retained "
+        f"evidence chunk(s) in the {policy.domain} domain using {signal_source}."
+    )
+
+
+def _evidence_from_chunk(chunk: ScoredChunk) -> SelectedPolicyEvidence:
+    return SelectedPolicyEvidence(
+        chunk_id=chunk.chunk_id,
+        path=chunk.path,
+        section=chunk.section,
+        lines=chunk.lines,
+        text=chunk.text,
+        score=chunk.score,
+    )
+
+
+def _empty_route_result(request: RouteRequest, profile: TaskProfile) -> RouteResult:
+    return RouteResult(
+        packet=PolicySelectionPacket(
+            task=profile.task,
+            domain=request.domain,
+            top_k=request.top_k,
+            task_type=profile.task_type,
+            explicit_task_type=profile.explicit_task_type,
+            profile_signals=list(profile.signals),
+            selected_policies=[],
+            insufficient_context=True,
+        ),
+        retained_context=[],
+    )
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()
+
+
+__all__ = ["PolicyRouterService", "create_policy_router_service", "profile_task"]

--- a/src/policynim/settings.py
+++ b/src/policynim/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from pydantic import (
     AliasChoices,
@@ -22,6 +22,7 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+from pydantic_settings.sources.types import DotenvType, EnvPrefixTarget
 
 import policynim.config_discovery as config_discovery
 from policynim.errors import ConfigurationError
@@ -335,7 +336,7 @@ def _clone_filtered_dotenv_source(
     settings_cls: type[BaseSettings],
     template: DotEnvSettingsSource,
     *,
-    env_file: object,
+    env_file: DotenvType | None,
 ) -> DotEnvSettingsSource:
     """Clone the existing dotenv source while keeping config-file override process-env only."""
     return ProcessEnvOnlyConfigDotEnvSettingsSource(
@@ -344,7 +345,7 @@ def _clone_filtered_dotenv_source(
         env_file_encoding=template.env_file_encoding,
         case_sensitive=template.case_sensitive,
         env_prefix=template.env_prefix,
-        env_prefix_target=template.env_prefix_target,
+        env_prefix_target=cast(EnvPrefixTarget | None, template.env_prefix_target),
         env_nested_delimiter=template.env_nested_delimiter,
         env_nested_max_split=template.env_nested_max_split,
         env_ignore_empty=template.env_ignore_empty,

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -12,6 +12,15 @@ MIN_TOP_K = 1
 MAX_TOP_K = 20
 DEFAULT_TOP_K = 5
 TopK = Annotated[int, Field(ge=MIN_TOP_K, le=MAX_TOP_K)]
+TaskType = Literal[
+    "bug_fix",
+    "refactor",
+    "api_change",
+    "migration",
+    "test_change",
+    "feature_work",
+    "unknown",
+]
 RuntimeActionKind = Literal["shell_command", "file_write", "http_request"]
 RuntimeRuleEffect = Literal["confirm", "block"]
 RUNTIME_RULE_MATCHER_FIELDS = ("path_globs", "command_regexes", "url_host_patterns")
@@ -442,6 +451,79 @@ class SearchResult(StrictModel):
     top_k: int
     hits: list[ScoredChunk] = Field(default_factory=list)
     insufficient_context: bool = False
+
+
+class RouteRequest(StrictModel):
+    """Task-aware policy-routing request shared by CLI and services."""
+
+    task: str
+    domain: str | None = None
+    top_k: TopK = DEFAULT_TOP_K
+    task_type: TaskType | None = None
+
+    @field_validator("task", mode="before")
+    @classmethod
+    def validate_task(cls, value: object) -> str:
+        """Reject empty routing tasks before profile inference."""
+        return _validate_non_empty_string(value, field_name="task")
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def validate_domain(cls, value: object) -> str | None:
+        """Reject empty domain filters while preserving omitted filters."""
+        if value is None:
+            return None
+        return _validate_non_empty_string(value, field_name="domain")
+
+
+class TaskProfile(StrictModel):
+    """Deterministic profile inferred from a coding task."""
+
+    task: str
+    task_type: TaskType
+    explicit_task_type: TaskType | None = None
+    signals: list[str] = Field(default_factory=list)
+
+
+class SelectedPolicyEvidence(StrictModel):
+    """One selected chunk that supports a routed policy."""
+
+    chunk_id: str
+    path: str
+    section: str
+    lines: str
+    text: str
+    score: float | None = None
+
+
+class SelectedPolicy(StrictModel):
+    """One policy selected for the task-aware packet."""
+
+    policy_id: str
+    title: str
+    domain: str
+    reason: str
+    evidence: list[SelectedPolicyEvidence] = Field(default_factory=list)
+
+
+class PolicySelectionPacket(StrictModel):
+    """Inspection-friendly packet emitted by task-aware policy routing."""
+
+    task: str
+    domain: str | None = None
+    top_k: int
+    task_type: TaskType
+    explicit_task_type: TaskType | None = None
+    profile_signals: list[str] = Field(default_factory=list)
+    selected_policies: list[SelectedPolicy] = Field(default_factory=list)
+    insufficient_context: bool = False
+
+
+class RouteResult(StrictModel):
+    """Internal route result with packet JSON and generator-ready context."""
+
+    packet: PolicySelectionPacket
+    retained_context: list[ScoredChunk] = Field(default_factory=list)
 
 
 class IngestResult(StrictModel):

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,9 +15,12 @@ Current automated coverage includes:
 - Day 5 runtime docs parity for command forms, env examples, and policy authoring guidance
 - Day 6 eval orchestration, rerank on/off comparison, and isolated live-eval index handling
 - Day 4 grounded preflight orchestration, citation validation, and fallback behavior
+- Build 1 task-aware routing, task-profile inference, selected-policy grouping,
+  and weak-evidence fallback behavior
 - Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation and reranking payloads
-- CLI output for `ingest`, JSON-first `search`, and JSON-first `preflight`
+- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, and JSON-first
+  `preflight`
 - CLI output for `eval`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`
 - CLI output for `beta-admin` hosted operator commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
-from click.utils import strip_ansi
+from click import unstyle
 from typer.testing import CliRunner
 
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
@@ -31,21 +32,26 @@ from policynim.types import (
     PolicyChunk,
     PolicyGuidance,
     PolicyMetadata,
+    PolicySelectionPacket,
     PreflightRequest,
     PreflightResult,
+    RouteRequest,
+    RouteResult,
     RuntimeDecision,
     RuntimeDecisionResult,
     RuntimeExecutionResult,
     ScoredChunk,
     SearchRequest,
     SearchResult,
+    SelectedPolicy,
+    SelectedPolicyEvidence,
 )
 
 runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def clear_cached_settings() -> None:
+def clear_cached_settings() -> Generator[None, None, None]:
     """Prevent settings cache from leaking between CLI tests."""
     get_settings.cache_clear()
     yield
@@ -146,6 +152,52 @@ class MockSearchService:
                 )
             ],
         )
+
+
+class MockRouteService:
+    """Static route service for CLI tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.last_request: RouteRequest | None = None
+
+    def route(self, request: RouteRequest) -> RouteResult:
+        self.last_request = request
+        return RouteResult(
+            packet=PolicySelectionPacket(
+                task=request.task,
+                domain=request.domain,
+                top_k=request.top_k,
+                task_type=request.task_type or "bug_fix",
+                explicit_task_type=request.task_type,
+                profile_signals=(
+                    [f"explicit:{request.task_type}"] if request.task_type is not None else ["fix"]
+                ),
+                selected_policies=[
+                    SelectedPolicy(
+                        policy_id="SECURITY-TOKEN-001",
+                        title="Token handling",
+                        domain="security",
+                        reason="Selected for bug fix routing from 1 retained evidence chunk(s).",
+                        evidence=[
+                            SelectedPolicyEvidence(
+                                chunk_id="SECURITY-1",
+                                path="policies/security/tokens.md",
+                                section="Rules",
+                                lines="10-16",
+                                text="Never log token values.",
+                                score=0.99,
+                            )
+                        ],
+                    )
+                ],
+                insufficient_context=False,
+            ),
+            retained_context=[],
+        )
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockPreflightService:
@@ -527,6 +579,94 @@ def test_search_command_prints_json(monkeypatch) -> None:
     assert payload.hits[0].chunk_id == "BACKEND-1"
 
 
+def test_route_command_prints_policy_selection_packet(monkeypatch) -> None:
+    service = MockRouteService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_router_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "route",
+            "--task",
+            "fix token logging bug",
+            "--domain",
+            "security",
+            "--top-k",
+            "2",
+            "--task-type",
+            "bug_fix",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = PolicySelectionPacket.model_validate(json.loads(result.stdout))
+    assert payload.task == "fix token logging bug"
+    assert payload.domain == "security"
+    assert payload.top_k == 2
+    assert payload.task_type == "bug_fix"
+    assert payload.explicit_task_type == "bug_fix"
+    assert payload.selected_policies[0].evidence[0].chunk_id == "SECURITY-1"
+    assert service.last_request is not None
+    assert service.last_request.task_type == "bug_fix"
+    assert service.closed is True
+
+
+def test_route_command_rejects_invalid_task_type() -> None:
+    result = runner.invoke(
+        app,
+        ["route", "--task", "fix token logging bug", "--task-type", "not-a-task-type"],
+    )
+
+    assert result.exit_code != 0
+    assert "not-a-task-type" in result.output
+
+
+def test_route_command_surfaces_missing_index_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_router_service",
+        lambda settings: (_ for _ in ()).throw(
+            MissingIndexError("Run `policynim ingest` before routing policy selection.")
+        ),
+    )
+
+    result = runner.invoke(app, ["route", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert "Run `policynim ingest` before routing policy selection." in result.stderr
+
+
+def test_route_command_surfaces_configuration_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_router_service",
+        lambda settings: (_ for _ in ()).throw(ConfigurationError("missing NVIDIA key")),
+    )
+
+    result = runner.invoke(app, ["route", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert "missing NVIDIA key" in result.stderr
+
+
+def test_route_command_closes_service_when_it_errors(monkeypatch) -> None:
+    class FailingRouteService(MockRouteService):
+        def route(self, request: RouteRequest) -> RouteResult:
+            raise MissingIndexError("Run `policynim ingest` before routing policy selection.")
+
+    service = FailingRouteService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_router_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, ["route", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert service.closed is True
+
+
 def test_eval_command_prints_json(monkeypatch) -> None:
     service = MockEvalService()
     monkeypatch.setattr(
@@ -621,6 +761,44 @@ def test_preflight_command_prints_json(monkeypatch) -> None:
     assert service.closed is True
 
 
+@pytest.mark.parametrize(
+    ("args", "field", "message"),
+    [
+        (["preflight", "--task", "   "], "task", "task must not be empty"),
+        (
+            ["preflight", "--task", "refresh token cleanup", "--domain", "   "],
+            "domain",
+            "domain must not be empty",
+        ),
+    ],
+)
+def test_preflight_command_formats_route_validation_errors(
+    args: list[str],
+    field: str,
+    message: str,
+    monkeypatch,
+) -> None:
+    class FailingPreflightService(MockPreflightService):
+        def preflight(self, request: PreflightRequest) -> PreflightResult:
+            RouteRequest(task=request.task, domain=request.domain, top_k=request.top_k)
+            raise AssertionError("expected RouteRequest validation to fail")
+
+    service = FailingPreflightService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_preflight_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 1
+    assert f"Preflight request is invalid at {field}" in result.stderr
+    assert message in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "RouteRequest" not in result.stderr
+    assert service.closed is True
+
+
 def test_dump_index_command_prints_chunks(monkeypatch) -> None:
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
@@ -656,13 +834,14 @@ def test_help_includes_dump_index_command() -> None:
 
 def test_help_includes_runtime_and_evidence_commands() -> None:
     result = runner.invoke(app, ["--help"])
-    help_output = strip_ansi(result.stdout)
+    help_output = unstyle(result.stdout)
 
     assert result.exit_code == 0
     assert "--version" in help_output
     assert "init" in help_output
     assert "runtime" in help_output
     assert "evidence" in help_output
+    assert "route" in help_output
 
 
 def test_version_flag_prints_installed_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -770,6 +949,15 @@ def test_init_command_surfaces_unwritable_config_destination(
     assert "permission denied" in result.stderr
     assert not target_config.exists()
     assert list(target_config.parent.glob("*.tmp")) == []
+
+
+def test_route_help_mentions_task_type_override() -> None:
+    result = runner.invoke(app, ["route", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "--task-type" in help_output
+    assert "Selected evidence depth." in help_output
 
 
 def test_runtime_help_mentions_decide_and_execute_commands() -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -29,6 +29,7 @@ from policynim.types import (
     PolicyMetadata,
     PreflightRequest,
     PreflightResult,
+    RouteRequest,
     ScoredChunk,
     SearchRequest,
     SearchResult,
@@ -277,6 +278,26 @@ def test_policy_preflight_surfaces_missing_index_errors(monkeypatch) -> None:
 
     with pytest.raises(ToolError, match="Run `policynim ingest` first"):
         _call_tool("policy_preflight", {"task": "refresh token cleanup"})
+
+
+def test_policy_preflight_formats_route_validation_errors(monkeypatch) -> None:
+    class FailingPreflightService(MockPreflightService):
+        def preflight(self, request: PreflightRequest) -> PreflightResult:
+            RouteRequest(task=request.task, domain=request.domain, top_k=request.top_k)
+            raise AssertionError("expected RouteRequest validation to fail")
+
+    service = FailingPreflightService()
+    monkeypatch.setattr(mcp_module, "create_preflight_service", lambda settings: service)
+
+    with pytest.raises(ToolError) as exc_info:
+        _call_tool("policy_preflight", {"task": "   ", "top_k": 1})
+
+    message = str(exc_info.value)
+    assert "Preflight request is invalid at task" in message
+    assert "task must not be empty" in message
+    assert "1 validation error" not in message
+    assert "RouteRequest" not in message
+    assert service.closed is True
 
 
 def test_policy_search_surfaces_configuration_errors(monkeypatch) -> None:

--- a/tests/test_router_service.py
+++ b/tests/test_router_service.py
@@ -1,0 +1,294 @@
+"""Tests for the Build 1 task-aware policy router."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from policynim.errors import MissingIndexError
+from policynim.services.router import PolicyRouterService, profile_task
+from policynim.types import EmbeddedChunk, PolicyChunk, PolicyMetadata, RouteRequest, ScoredChunk
+
+
+class MockEmbedder:
+    """Returns deterministic embeddings and records the embedded task text."""
+
+    def __init__(self) -> None:
+        self.last_text: str | None = None
+        self.closed = False
+
+    def embed_query(self, text: str) -> list[float]:
+        self.last_text = text
+        return [1.0, 0.0]
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MockIndexStore:
+    """Returns deterministic dense candidates and records query parameters."""
+
+    def __init__(self, chunks: list[ScoredChunk], *, exists: bool = True) -> None:
+        self._chunks = list(chunks)
+        self._exists = exists
+        self.last_top_k: int | None = None
+        self.last_domain: str | None = None
+
+    def exists(self) -> bool:
+        return self._exists
+
+    def count(self) -> int:
+        return len(self._chunks) if self._exists else 0
+
+    def search(
+        self,
+        query_embedding: Sequence[float],
+        *,
+        top_k: int,
+        domain: str | None = None,
+    ) -> list[ScoredChunk]:
+        self.last_top_k = top_k
+        self.last_domain = domain
+        candidates = [
+            chunk for chunk in self._chunks if domain is None or chunk.policy.domain == domain
+        ]
+        return candidates[:top_k]
+
+    def replace(self, chunks: Sequence[EmbeddedChunk]) -> None:
+        self._chunks = [ScoredChunk(**chunk.model_dump(exclude={"vector"})) for chunk in chunks]
+
+    def list_chunks(self) -> list[PolicyChunk]:
+        return [PolicyChunk(**chunk.model_dump(exclude={"score"})) for chunk in self._chunks]
+
+
+class MockReranker:
+    """Reorders dense candidates and records the routing query."""
+
+    def __init__(self, *, order: list[str] | None = None) -> None:
+        self._order = order or []
+        self.last_query: str | None = None
+        self.last_candidates: list[ScoredChunk] = []
+        self.last_top_k: int | None = None
+        self.closed = False
+
+    def rerank(
+        self,
+        query: str,
+        candidates: Sequence[ScoredChunk],
+        *,
+        top_k: int,
+    ) -> list[ScoredChunk]:
+        self.last_query = query
+        self.last_candidates = list(candidates)
+        self.last_top_k = top_k
+        ordering = {chunk_id: index for index, chunk_id in enumerate(self._order)}
+        ranked = sorted(
+            list(candidates),
+            key=lambda chunk: ordering.get(chunk.chunk_id, len(ordering)),
+        )
+        return ranked[:top_k]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize(
+    ("task", "expected_task_type"),
+    [
+        ("fix failing auth redirect", "bug_fix"),
+        ("refactor auth token module", "refactor"),
+        ("change api response contract", "api_change"),
+        ("run database migration backfill", "migration"),
+        ("add pytest coverage fixture", "test_change"),
+        ("build policy export feature", "feature_work"),
+    ],
+)
+def test_profile_task_infers_task_type(task: str, expected_task_type: str) -> None:
+    profile = profile_task(task)
+
+    assert profile.task_type == expected_task_type
+    assert profile.explicit_task_type is None
+    assert profile.signals
+
+
+def test_profile_task_uses_explicit_task_type_override() -> None:
+    profile = profile_task("fix cleanup behavior", explicit_task_type="refactor")
+
+    assert profile.task_type == "refactor"
+    assert profile.explicit_task_type == "refactor"
+    assert profile.signals == ["explicit:refactor"]
+
+
+def test_profile_task_keeps_unknown_for_unmatched_or_mixed_tasks() -> None:
+    unmatched = profile_task("coordinate quarterly workspace notes")
+    mixed = profile_task("fix test")
+
+    assert unmatched.task_type == "unknown"
+    assert unmatched.signals == []
+    assert mixed.task_type == "unknown"
+    assert set(mixed.signals) == {"fix", "test"}
+
+
+def test_router_retrieves_reranks_and_groups_selected_policy_evidence() -> None:
+    embedder = MockEmbedder()
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-2",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.72,
+            ),
+            make_chunk(
+                chunk_id="SECURITY-1",
+                policy_id="SECURITY-TOKEN-001",
+                domain="security",
+                score=0.80,
+            ),
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.98,
+            ),
+        ]
+    )
+    reranker = MockReranker(order=["BACKEND-1", "BACKEND-2", "SECURITY-1"])
+    service = PolicyRouterService(embedder=embedder, index_store=store, reranker=reranker)
+
+    result = service.route(RouteRequest(task="fix backend logging bug", top_k=3))
+
+    assert embedder.last_text == "fix backend logging bug"
+    assert store.last_top_k == 15
+    assert reranker.last_top_k == 15
+    assert reranker.last_query is not None
+    assert "Task type: bug fix." in reranker.last_query
+    assert not result.packet.insufficient_context
+    assert result.packet.task_type == "bug_fix"
+    assert [policy.policy_id for policy in result.packet.selected_policies] == [
+        "BACKEND-LOG-001",
+        "SECURITY-TOKEN-001",
+    ]
+    assert [evidence.chunk_id for evidence in result.packet.selected_policies[0].evidence] == [
+        "BACKEND-1",
+        "BACKEND-2",
+    ]
+    assert [chunk.chunk_id for chunk in result.retained_context] == [
+        "BACKEND-1",
+        "BACKEND-2",
+        "SECURITY-1",
+    ]
+
+
+def test_router_applies_domain_filter_before_reranking() -> None:
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.98,
+            ),
+            make_chunk(
+                chunk_id="SECURITY-1",
+                policy_id="SECURITY-TOKEN-001",
+                domain="security",
+                score=0.90,
+            ),
+        ]
+    )
+    reranker = MockReranker(order=["BACKEND-1", "SECURITY-1"])
+    service = PolicyRouterService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        reranker=reranker,
+    )
+
+    result = service.route(RouteRequest(task="review api contract", domain="security", top_k=2))
+
+    assert store.last_domain == "security"
+    assert [chunk.chunk_id for chunk in reranker.last_candidates] == ["SECURITY-1"]
+    assert [policy.policy_id for policy in result.packet.selected_policies] == [
+        "SECURITY-TOKEN-001"
+    ]
+    assert result.packet.domain == "security"
+
+
+def test_router_marks_insufficient_context_for_weak_evidence() -> None:
+    service = PolicyRouterService(
+        embedder=MockEmbedder(),
+        index_store=MockIndexStore(
+            [
+                make_chunk(
+                    chunk_id="BACKEND-1",
+                    policy_id="BACKEND-LOG-001",
+                    domain="backend",
+                    score=0.0,
+                )
+            ]
+        ),
+        reranker=MockReranker(),
+    )
+
+    result = service.route(RouteRequest(task="fix backend logging bug", top_k=1))
+
+    assert result.packet.insufficient_context
+    assert result.packet.selected_policies == []
+    assert result.retained_context == []
+
+
+def test_router_requires_existing_index() -> None:
+    service = PolicyRouterService(
+        embedder=MockEmbedder(),
+        index_store=MockIndexStore([], exists=False),
+        reranker=MockReranker(),
+    )
+
+    with pytest.raises(MissingIndexError):
+        service.route(RouteRequest(task="fix backend logging bug", top_k=1))
+
+
+def test_router_close_closes_owned_components() -> None:
+    embedder = MockEmbedder()
+    reranker = MockReranker()
+    service = PolicyRouterService(
+        embedder=embedder,
+        index_store=MockIndexStore(
+            [make_chunk(chunk_id="BACKEND-1", policy_id="BACKEND-LOG-001", domain="backend")]
+        ),
+        reranker=reranker,
+    )
+
+    service.close()
+
+    assert embedder.closed is True
+    assert reranker.closed is True
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    policy_id: str,
+    domain: str,
+    score: float | None = 0.9,
+    text: str = "Sample policy text.",
+) -> ScoredChunk:
+    metadata = PolicyMetadata(
+        policy_id=policy_id,
+        title="Logging" if domain == "backend" else "Token handling",
+        doc_type="guidance",
+        domain=domain,
+    )
+    return ScoredChunk(
+        chunk_id=chunk_id,
+        path=f"policies/{domain}/policy.md",
+        section="Rules",
+        lines="1-4",
+        text=text,
+        policy=metadata,
+        score=score,
+    )

--- a/tests/test_runtime_evidence_report_service.py
+++ b/tests/test_runtime_evidence_report_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from pydantic import AnyHttpUrl
 
 from policynim.errors import PolicyNIMError
 from policynim.services.runtime_evidence_report import RuntimeEvidenceReportService
@@ -373,7 +374,7 @@ def test_runtime_evidence_report_service_summarizes_mixed_action_kinds(
                 cwd=tmp_path,
                 session_id="session-1",
                 method="GET",
-                url="https://example.com/api",
+                url=AnyHttpUrl("https://example.com/api"),
             ),
         )
     )
@@ -390,7 +391,7 @@ def test_runtime_evidence_report_service_summarizes_mixed_action_kinds(
                 cwd=tmp_path,
                 session_id="session-1",
                 method="GET",
-                url="https://example.com/api",
+                url=AnyHttpUrl("https://example.com/api"),
             ),
             result_metadata=HTTPRequestExecutionMetadata(
                 status_code=429,

--- a/tests/test_runtime_evidence_store.py
+++ b/tests/test_runtime_evidence_store.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
+from pydantic import AnyHttpUrl
+
 from policynim.storage import RuntimeEvidenceStore
 from policynim.types import (
     FileWriteExecutionMetadata,
@@ -206,7 +208,7 @@ def test_runtime_evidence_store_round_trips_http_request_payloads(tmp_path: Path
                 cwd=tmp_path,
                 session_id="session-1",
                 method="GET",
-                url="https://example.com/api",
+                url=AnyHttpUrl("https://example.com/api"),
             ),
             result_metadata=HTTPRequestExecutionMetadata(
                 status_code=204,

--- a/tests/test_service_factories.py
+++ b/tests/test_service_factories.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import policynim.services.eval as eval_module
 import policynim.services.ingest as ingest_module
 import policynim.services.preflight as preflight_module
+import policynim.services.router as router_module
 import policynim.services.runtime_decision as runtime_decision_module
 import policynim.services.runtime_evidence_report as runtime_evidence_report_module
 import policynim.services.runtime_execution as runtime_execution_module
@@ -53,6 +54,7 @@ import policynim.services.ingest
 import policynim.services.eval
 import policynim.services.search
 import policynim.services.preflight
+import policynim.services.router
 import policynim.services.runtime_decision
 import policynim.services.runtime_evidence_report
 import policynim.services.runtime_execution
@@ -113,30 +115,53 @@ def test_create_search_service_builds_default_components(monkeypatch, tmp_path: 
     assert service._index_store.table_name == settings.lancedb_table
 
 
-def test_create_preflight_service_builds_default_components(
+def test_create_policy_router_service_builds_default_components(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     mock_embedder = object()
     mock_reranker = object()
+    monkeypatch.setattr(
+        router_module,
+        "_create_default_router_components",
+        lambda settings: (mock_embedder, mock_reranker),
+    )
+    monkeypatch.setattr(router_module, "LanceDBIndexStore", MockIndexStore)
+
+    settings = Settings(lancedb_uri=tmp_path / "router-index")
+
+    service = router_module.create_policy_router_service(settings)
+
+    assert service._embedder is mock_embedder
+    assert service._reranker is mock_reranker
+    assert isinstance(service._index_store, MockIndexStore)
+    assert service._index_store.uri == (tmp_path / "router-index").resolve(strict=False)
+    assert service._index_store.table_name == settings.lancedb_table
+
+
+def test_create_preflight_service_builds_default_components(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    mock_router = object()
     mock_generator = object()
     monkeypatch.setattr(
         preflight_module,
-        "_create_default_preflight_components",
-        lambda settings: (mock_embedder, mock_reranker, mock_generator),
+        "create_policy_router_service",
+        lambda settings: mock_router,
     )
-    monkeypatch.setattr(preflight_module, "LanceDBIndexStore", MockIndexStore)
+    monkeypatch.setattr(
+        preflight_module,
+        "_create_default_generator",
+        lambda settings: mock_generator,
+    )
 
     settings = Settings(lancedb_uri=tmp_path / "preflight-index")
 
     service = preflight_module.create_preflight_service(settings)
 
-    assert service._embedder is mock_embedder
-    assert service._reranker is mock_reranker
+    assert service._router is mock_router
     assert service._generator is mock_generator
-    assert isinstance(service._index_store, MockIndexStore)
-    assert service._index_store.uri == (tmp_path / "preflight-index").resolve(strict=False)
-    assert service._index_store.table_name == settings.lancedb_table
 
 
 def test_create_runtime_decision_service_uses_runtime_paths(

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -336,7 +336,8 @@ def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces
         corpus_dir=custom_corpus,
     )
 
-    settings = Settings(_env_file=config_path)
+    settings_type = cast(Any, Settings)
+    settings = settings_type(_env_file=config_path)
 
     assert settings.nvidia_api_key == "quoted-key"
     assert settings.corpus_dir == custom_corpus.resolve(strict=False)


### PR DESCRIPTION
## Summary
- add Build 1 task-aware policy routing contracts and `PolicyRouterService`
- add `policynim route --task ...` JSON inspection output and wire preflight through routed evidence without changing `PreflightResult`
- update router, CLI, factory, docs, and typing coverage

## Verification
- uv run pytest -q
- uv run ruff check
- uvx pyright src tests
- uv run policynim route --help