### PR TITLE
Add Day 3 standalone packaging and installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,15 +125,24 @@ jobs:
           import tomllib
           from pathlib import Path
 
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          project_version = project["project"]["version"]
           if os.environ.get("GITHUB_REF_TYPE") == "tag":
               tag = os.environ["GITHUB_REF_NAME"]
+              requested_version = tag.removeprefix("v")
           else:
               requested = os.environ.get("REQUESTED_VERSION", "").strip()
               if requested:
-                  tag = requested if requested.startswith("v") else f"v{requested}"
+                  requested_version = requested.removeprefix("v")
+                  tag = f"v{requested_version}"
               else:
-                  project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-                  tag = f"v{project['project']['version']}"
+                  requested_version = project_version
+                  tag = f"v{project_version}"
+          if requested_version != project_version:
+              raise SystemExit(
+                  "Release version mismatch: "
+                  f"requested {requested_version}, pyproject.toml has {project_version}."
+              )
           print(f"RELEASE_TAG={tag}")
           PY
 
@@ -209,15 +218,24 @@ jobs:
           import tomllib
           from pathlib import Path
 
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          project_version = project["project"]["version"]
           if os.environ.get("GITHUB_REF_TYPE") == "tag":
               tag = os.environ["GITHUB_REF_NAME"]
+              requested_version = tag.removeprefix("v")
           else:
               requested = os.environ.get("REQUESTED_VERSION", "").strip()
               if requested:
-                  tag = requested if requested.startswith("v") else f"v{requested}"
+                  requested_version = requested.removeprefix("v")
+                  tag = f"v{requested_version}"
               else:
-                  project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-                  tag = f"v{project['project']['version']}"
+                  requested_version = project_version
+                  tag = f"v{project_version}"
+          if requested_version != project_version:
+              raise SystemExit(
+                  "Release version mismatch: "
+                  f"requested {requested_version}, pyproject.toml has {project_version}."
+              )
           print(f"RELEASE_TAG={tag}")
           PY
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,272 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version or tag, for example 0.1.0 or v0.1.0."
+        required: false
+        type: string
+      publish_pypi:
+        description: "Publish the built Python distribution to PyPI using trusted publishing."
+        required: false
+        default: false
+        type: boolean
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Sync dependencies
+        run: uv sync --group test --group dev
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Run Ruff
+        run: uv run ruff check .
+
+      - name: Run Pyright
+        run: uv run pyright
+
+      - name: Run offline pytest
+        run: uv run pytest -q -m "not live and not docker_live"
+
+      - name: Build Python distribution
+        run: uv build --out-dir dist
+
+      - name: Upload Python distribution
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-dist
+          path: dist/*
+          if-no-files-found: error
+
+  wheel-smoke:
+    runs-on: ubuntu-24.04
+    needs: verify
+    steps:
+      - name: Download Python distribution
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Smoke install built wheel
+        run: |
+          python -m venv /tmp/policynim-wheel-smoke
+          /tmp/policynim-wheel-smoke/bin/python -m pip install dist/*.whl
+          /tmp/policynim-wheel-smoke/bin/policynim --help
+          /tmp/policynim-wheel-smoke/bin/policynim --version
+
+  standalone-build:
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-amd64
+            archive: tar
+          - os: macos-13
+            platform: darwin-amd64
+            archive: tar
+          - os: macos-14
+            platform: darwin-arm64
+            archive: tar
+          - os: windows-2022
+            platform: windows-amd64
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Resolve release tag
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          python - <<'PY' >> "$GITHUB_ENV"
+          import os
+          import tomllib
+          from pathlib import Path
+
+          if os.environ.get("GITHUB_REF_TYPE") == "tag":
+              tag = os.environ["GITHUB_REF_NAME"]
+          else:
+              requested = os.environ.get("REQUESTED_VERSION", "").strip()
+              if requested:
+                  tag = requested if requested.startswith("v") else f"v{requested}"
+              else:
+                  project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+                  tag = f"v{project['project']['version']}"
+          print(f"RELEASE_TAG={tag}")
+          PY
+
+      - name: Sync release dependencies
+        run: uv sync --group release
+
+      - name: Build standalone bundle
+        run: uv run --group release pyinstaller --clean --noconfirm packaging/pyinstaller.spec
+
+      - name: Smoke standalone bundle
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" = "windows-amd64" ]; then
+            dist/policynim/policynim.exe --help
+            dist/policynim/policynim.exe --version
+          else
+            dist/policynim/policynim --help
+            dist/policynim/policynim --version
+          fi
+
+      - name: Archive Unix standalone bundle
+        if: matrix.archive == 'tar'
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          case "${{ matrix.platform }}" in
+            linux-amd64) ASSET_NAME="policynim-${RELEASE_TAG}-linux-amd64.tar.gz" ;;
+            darwin-amd64) ASSET_NAME="policynim-${RELEASE_TAG}-darwin-amd64.tar.gz" ;;
+            darwin-arm64) ASSET_NAME="policynim-${RELEASE_TAG}-darwin-arm64.tar.gz" ;;
+            *) echo "Unsupported release platform: ${{ matrix.platform }}" >&2; exit 1 ;;
+          esac
+          tar -C dist -czf "artifacts/${ASSET_NAME}" policynim
+
+      - name: Archive Windows standalone bundle
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          $RELEASE_TAG = $env:RELEASE_TAG
+          $AssetName = "policynim-${RELEASE_TAG}-windows-amd64.zip"
+          Compress-Archive -Path "dist/policynim/*" -DestinationPath "artifacts/$AssetName" -Force
+
+      - name: Upload standalone bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: standalone-${{ matrix.platform }}
+          path: artifacts/*
+          if-no-files-found: error
+
+  publish-github-release:
+    runs-on: ubuntu-24.04
+    needs:
+      - verify
+      - wheel-smoke
+      - standalone-build
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: release-downloads
+
+      - name: Resolve release tag
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY' >> "$GITHUB_ENV"
+          import os
+          import tomllib
+          from pathlib import Path
+
+          if os.environ.get("GITHUB_REF_TYPE") == "tag":
+              tag = os.environ["GITHUB_REF_NAME"]
+          else:
+              requested = os.environ.get("REQUESTED_VERSION", "").strip()
+              if requested:
+                  tag = requested if requested.startswith("v") else f"v{requested}"
+              else:
+                  project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+                  tag = f"v{project['project']['version']}"
+          print(f"RELEASE_TAG={tag}")
+          PY
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          find release-downloads -type f -exec cp {} release-assets/ \;
+          cp scripts/install.sh release-assets/install.sh
+          cp scripts/install.ps1 release-assets/install.ps1
+          (
+            cd release-assets
+            sha256sum * > SHA256SUMS
+          )
+          cat > release-notes.md <<'EOF'
+          PolicyNIM release artifacts:
+
+          - Python wheel and source distribution for `pipx install policynim`
+          - Standalone CLI bundles for Linux, macOS, and Windows
+          - Unix and PowerShell installer scripts
+          - SHA256SUMS for release asset verification
+          EOF
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            --draft \
+            --target "$GITHUB_SHA" \
+            --title "$RELEASE_TAG" \
+            --notes-file release-notes.md \
+            release-assets/*
+
+  publish-pypi:
+    runs-on: ubuntu-24.04
+    needs:
+      - verify
+      - wheel-smoke
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_pypi)
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download Python distribution
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir uv==0.7.12
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src ./src
 COPY policies ./policies
 COPY evals ./evals
@@ -37,6 +37,7 @@ COPY --from=builder /app/policies /app/policies
 COPY --from=builder /app/evals /app/evals
 COPY --from=builder /app/pyproject.toml /app/pyproject.toml
 COPY --from=builder /app/README.md /app/README.md
+COPY --from=builder /app/LICENSE /app/LICENSE
 COPY --from=builder /app/data/lancedb-baked /app/data/lancedb-baked
 
 CMD ["policynim", "mcp", "--transport", "streamable-http"]

--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir uv==0.7.12
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src ./src
 COPY policies ./policies
 COPY evals ./evals
@@ -39,6 +39,7 @@ COPY --from=builder /app/policies /app/policies
 COPY --from=builder /app/evals /app/evals
 COPY --from=builder /app/pyproject.toml /app/pyproject.toml
 COPY --from=builder /app/README.md /app/README.md
+COPY --from=builder /app/LICENSE /app/LICENSE
 COPY --from=builder /app/data/lancedb-baked /app/data/lancedb-baked
 
 CMD ["policynim", "mcp", "--transport", "streamable-http"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ PolicyNIM currently ships with two main user-facing surfaces:
 If you want the shortest path to a real preflight run, start with the hosted
 beta instead of cloning the repo.
 
+### Install The CLI Without Cloning
+
+Use the Python package path when you already have Python 3.11 or 3.12 and want
+`pipx` or `uv` to manage an isolated CLI environment:
+
+```bash
+pipx install policynim
+uv tool install policynim
+policynim --help
+policynim init
+policynim ingest
+```
+
+Use the GitHub release installers when you want a standalone `policynim` binary
+without managing Python dependencies yourself:
+
+```bash
+curl -fsSL https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.sh | sh
+```
+
+```powershell
+irm https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.ps1 | iex
+```
+
+Both installer paths verify release checksums before installing. After install,
+run `policynim init`, then `policynim ingest`, then `policynim --help` whenever
+you need to confirm the entrypoint is available.
+
 ### Self-Serve Hosted Beta
 
 <p align="center">
@@ -156,6 +184,8 @@ Start here when you want the longer version of a specific path:
   troubleshooting
 - [docs/hosted-beta-operations.md](docs/hosted-beta-operations.md): hosted beta
   quickstart, recovery, container build flow, and Railway deploy notes
+- [docs/release.md](docs/release.md): CLI packaging, GitHub release, PyPI
+  publish, and smoke-test checklist
 - [docs/architecture.md](docs/architecture.md): package boundaries, runtime flow,
   and interface rules
 - [docs/architecture-diagram.md](docs/architecture-diagram.md): Mermaid diagram

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -62,6 +62,34 @@ and `POLICYNIM_EVAL_WORKSPACE_DIR`.
 After that, run `policynim ingest` as usual. Source checkouts can keep using the
 checkout `.env` flow above and `uv run` for in-project commands.
 
+## Direct CLI Install
+
+Use `pipx` or `uv tool` when you want the Python package install path without
+cloning this repository:
+
+```bash
+pipx install policynim
+uv tool install policynim
+policynim --help
+policynim init
+policynim ingest
+```
+
+Use the GitHub release installers when you want a standalone binary bundle:
+
+```bash
+curl -fsSL https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.sh | sh
+```
+
+```powershell
+irm https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.ps1 | iex
+```
+
+Both installers download the latest GitHub release, verify `SHA256SUMS`, install
+the versioned bundle, and print PATH guidance. They do not prompt for or collect
+`NVIDIA_API_KEY`; run `policynim init` after installation to create the local
+config, then `policynim ingest` to build the local policy index.
+
 ## Environment Templates
 
 The repo ships three related templates:

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ operations into separate pages so the root README can stay short.
   troubleshooting handbook
 - [hosted-beta-operations.md](hosted-beta-operations.md): hosted beta quickstart,
   recovery, container build flow, and Railway deployment notes
+- [release.md](release.md): package, GitHub release, PyPI, and standalone
+  installer release checklist
 
 ## Examples
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,84 @@
+# PolicyNIM Release Checklist
+
+Use this guide when preparing a developer-facing CLI release. The default
+release path is offline and deterministic; live NVIDIA, hosted Railway, and
+Docker checks stay opt-in.
+
+## Release Channels
+
+PolicyNIM supports two direct install channels:
+
+- Python package users install the CLI with `pipx install policynim` or
+  `uv tool install policynim`.
+- Standalone users install GitHub release binaries with `install.sh` or
+  `install.ps1`, without cloning the repo or managing Python dependencies.
+
+Both paths should support:
+
+```bash
+policynim --help
+policynim init
+policynim ingest
+```
+
+## Before Tagging
+
+Run the deterministic gates locally:
+
+```bash
+uv lock --check
+uv run ruff check .
+uv run pyright
+uv run pytest -q -m "not live and not docker_live"
+uv build --out-dir dist
+```
+
+Then smoke the built wheel in a clean environment:
+
+```bash
+python -m venv /tmp/policynim-wheel-smoke
+/tmp/policynim-wheel-smoke/bin/python -m pip install dist/*.whl
+/tmp/policynim-wheel-smoke/bin/policynim --help
+/tmp/policynim-wheel-smoke/bin/policynim --version
+```
+
+## GitHub Release
+
+Create and push a version tag from the commit you want to release:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The `Release` workflow builds the wheel, source distribution, and standalone
+archives for Linux, macOS, and Windows. It creates a draft GitHub release with:
+
+- Python wheel and source distribution
+- `install.sh` and `install.ps1`
+- `policynim-vX.Y.Z-linux-amd64.tar.gz`
+- `policynim-vX.Y.Z-darwin-amd64.tar.gz`
+- `policynim-vX.Y.Z-darwin-arm64.tar.gz`
+- `policynim-vX.Y.Z-windows-amd64.zip`
+- `SHA256SUMS`
+
+Review the draft GitHub release before publishing. Confirm that the release
+asset names match the installer scripts and that `SHA256SUMS` includes every
+downloaded asset.
+
+## PyPI
+
+PyPI publishing uses PyPI trusted publishing through GitHub OIDC. Configure the
+PyPI project to trust this repository and the `pypi` GitHub environment before
+using the `publish-pypi` job.
+
+For normal releases, publish PyPI from the final `vX.Y.Z` tag. For manual
+workflow dispatches, leave `publish_pypi=false` unless you intentionally want to
+publish the built distribution from that exact commit.
+
+## Optional Hosted Smoke
+
+After the draft release artifacts pass local smoke tests, run the manual
+`Hosted Beta Smoke` workflow only when the deployed Railway beta and hosted MCP
+secrets are available. This is a deployment promotion check, not part of the
+offline release artifact build.

--- a/packaging/pyinstaller.spec
+++ b/packaging/pyinstaller.spec
@@ -1,0 +1,62 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for PolicyNIM standalone release bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import copy_metadata
+
+project_root = Path(SPECPATH).parent
+entrypoint = project_root / "src/policynim/interfaces/cli.py"
+
+datas = [
+    (str(project_root / "policies"), "policynim/policies"),
+    (str(project_root / "evals"), "policynim/evals"),
+    (str(project_root / "src/policynim/assets"), "policynim/assets"),
+    (str(project_root / "src/policynim/templates"), "policynim/templates"),
+]
+datas += copy_metadata("policynim")
+
+a = Analysis(
+    [str(entrypoint)],
+    pathex=[str(project_root / "src")],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="policynim",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="policynim",
+)

--- a/packaging/pyinstaller.spec
+++ b/packaging/pyinstaller.spec
@@ -18,7 +18,7 @@ datas = [
 ]
 datas += copy_metadata("policynim")
 
-a = Analysis(
+analysis = Analysis(
     [str(entrypoint)],
     pathex=[str(project_root / "src")],
     binaries=[],
@@ -31,11 +31,11 @@ a = Analysis(
     noarchive=False,
     optimize=0,
 )
-pyz = PYZ(a.pure)
+pyz = PYZ(analysis.pure)
 
 exe = EXE(
     pyz,
-    a.scripts,
+    analysis.scripts,
     [],
     exclude_binaries=True,
     name="policynim",
@@ -53,8 +53,8 @@ exe = EXE(
 
 coll = COLLECT(
     exe,
-    a.binaries,
-    a.datas,
+    analysis.binaries,
+    analysis.datas,
     strip=False,
     upx=False,
     upx_exclude=[],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
   "pre-commit==4.3.0",
   "ruff==0.15.7",
 ]
+release = [
+  "pyinstaller==6.19.0",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ dev = [
   "pyright==1.1.409",
   "ruff==0.15.7",
 ]
+release = [
+  "pyinstaller==6.19.0",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,29 @@ version = "0.1.0"
 description = "A policy-aware NVIDIA NIM engineering preflight layer for AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
+authors = [
+  { name = "Nnenna Ndukwe" },
+]
+license = { file = "LICENSE" }
+keywords = ["ai-agents", "mcp", "nvidia-nim", "policy", "preflight"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Quality Assurance",
+]
 dependencies = [
   "arize-phoenix==13.21.0",
   "arize-phoenix-evals==2.12.0",
   "httpx==0.27.2",
   "itsdangerous==2.2.0",
   "jinja2==3.1.6",
+  "lance-namespace==0.6.1",
+  "lance-namespace-urllib3-client==0.6.1",
   "lancedb==0.27.1",
   "markdown-it-py==4.0.0",
   "mcp[cli]==1.26.0",
@@ -20,6 +37,11 @@ dependencies = [
   "pydantic-settings==2.13.1",
   "typer==0.24.1",
 ]
+
+[project.urls]
+Documentation = "https://github.com/nnennandukwe/policyNIM/tree/main/docs"
+Issues = "https://github.com/nnennandukwe/policyNIM/issues"
+Repository = "https://github.com/nnennandukwe/policyNIM"
 
 [project.optional-dependencies]
 nvidia-guardrails = [
@@ -48,8 +70,6 @@ packages = ["src/policynim"]
 [tool.hatch.build.targets.wheel.force-include]
 "policies" = "policynim/policies"
 "evals" = "policynim/evals"
-"src/policynim/assets" = "policynim/assets"
-"src/policynim/templates" = "policynim/templates"
 
 [dependency-groups]
 test = [

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,158 @@
+param(
+    [string]$Version = $(if ($env:POLICYNIM_VERSION) { $env:POLICYNIM_VERSION } else { "latest" })
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+$RepositoryUrl = if ($env:POLICYNIM_REPOSITORY_URL) { $env:POLICYNIM_REPOSITORY_URL } else { "https://github.com/nnennandukwe/policyNIM" }
+$ChecksumsFile = "SHA256SUMS"
+
+function Stop-Install([string]$Message) {
+    Write-Error $Message
+    exit 1
+}
+
+function Get-NormalizedArchitecture {
+    $rawArch = if ($env:POLICYNIM_INSTALLER_TEST_ARCH) { $env:POLICYNIM_INSTALLER_TEST_ARCH } else { $env:PROCESSOR_ARCHITECTURE }
+    if ([string]::IsNullOrWhiteSpace($rawArch)) {
+        return "unknown"
+    }
+    switch -Regex ($rawArch) {
+        "^(AMD64|x86_64)$" { "amd64"; return }
+        default { $rawArch.ToLowerInvariant(); return }
+    }
+}
+
+function Resolve-LatestVersion {
+    try {
+        $response = Invoke-WebRequest -Uri "$RepositoryUrl/releases/latest" -MaximumRedirection 10 -UseBasicParsing
+        $resolvedUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+    } catch {
+        Stop-Install "Could not resolve the latest PolicyNIM release version. Pass a version as POLICYNIM_VERSION or as the first argument."
+    }
+
+    $latestTag = ($resolvedUrl.TrimEnd("/") -split "/")[-1]
+    if (-not $latestTag.StartsWith("v")) {
+        Stop-Install "Could not resolve the latest PolicyNIM release version. Pass a version as POLICYNIM_VERSION or as the first argument."
+    }
+    return $latestTag.Substring(1)
+}
+
+function Download-Asset([string]$SourceUrl, [string]$Destination, [string]$Label) {
+    try {
+        Invoke-WebRequest -Uri $SourceUrl -OutFile $Destination -UseBasicParsing
+    } catch {
+        Stop-Install "Could not download release asset $Label from $SourceUrl. Check the release page or retry the install."
+    }
+}
+
+function Replace-InstallDirectory([string]$StagingDir, [string]$InstallDir, [string]$Version) {
+    $installParent = Split-Path -Parent $InstallDir
+    $backupDir = Join-Path $installParent ".$Version.backup.$PID"
+    if (Test-Path $backupDir) {
+        Remove-Item -Recurse -Force $backupDir
+    }
+    if (Test-Path $InstallDir) {
+        Move-Item -Path $InstallDir -Destination $backupDir
+    }
+    try {
+        Move-Item -Path $StagingDir -Destination $InstallDir
+        if (Test-Path $backupDir) {
+            Remove-Item -Recurse -Force $backupDir
+        }
+    } catch {
+        if (Test-Path $backupDir) {
+            Move-Item -Path $backupDir -Destination $InstallDir
+        }
+        Stop-Install "Could not replace install directory $InstallDir. Existing install was restored."
+    }
+}
+
+function Write-Launcher([string]$InstallDir, [string]$LauncherPath) {
+    $launcherDir = Split-Path -Parent $LauncherPath
+    New-Item -ItemType Directory -Force -Path $launcherDir | Out-Null
+    $binaryPath = Join-Path $InstallDir "policynim.exe"
+    $launcher = @"
+@echo off
+"$binaryPath" %*
+"@
+    Set-Content -Path $LauncherPath -Value $launcher -Encoding ASCII
+}
+
+$osName = if ($env:POLICYNIM_INSTALLER_TEST_OS) { $env:POLICYNIM_INSTALLER_TEST_OS.ToLowerInvariant() } else { "windows" }
+$archName = Get-NormalizedArchitecture
+$platform = "$osName-$archName"
+if ($platform -ne "windows-amd64") {
+    Stop-Install "Unsupported platform: $platform. Supported platform: windows-amd64."
+}
+
+if ($Version -eq "latest") {
+    $Version = Resolve-LatestVersion
+}
+$Version = $Version.TrimStart("v")
+$tag = "v$Version"
+$assetName = "policynim-$tag-$platform"
+$releaseBaseUrl = if ($env:POLICYNIM_RELEASE_BASE_URL) { $env:POLICYNIM_RELEASE_BASE_URL } else { "$RepositoryUrl/releases/download/$tag" }
+$releasePageUrl = "$RepositoryUrl/releases/tag/$tag"
+$installDir = Join-Path $env:LocalAppData "PolicyNIM\$Version"
+$installParent = Split-Path -Parent $installDir
+$launcherDir = Join-Path $env:LocalAppData "PolicyNIM\bin"
+$launcherPath = Join-Path $launcherDir "policynim.cmd"
+
+$workDir = Join-Path ([System.IO.Path]::GetTempPath()) "policynim-install-$PID"
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+try {
+    $assetPath = Join-Path $workDir $assetName
+    $checksumsPath = Join-Path $workDir $ChecksumsFile
+    $extractDir = Join-Path $workDir "extract"
+    $assetZipPath = Join-Path $workDir "$assetName.zip"
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+
+    Download-Asset "$releaseBaseUrl/$assetName" $assetPath $assetName
+    Download-Asset "$releaseBaseUrl/$ChecksumsFile" $checksumsPath $ChecksumsFile
+
+    $checksumLine = Get-Content $checksumsPath | Where-Object { ($_ -split "\s+")[-1] -eq $assetName } | Select-Object -First 1
+    if (-not $checksumLine) {
+        Stop-Install "Checksum entry for $assetName was not found in $ChecksumsFile. Check $releasePageUrl and retry."
+    }
+    $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+    $actualChecksum = (Get-FileHash -Algorithm SHA256 -Path $assetPath).Hash.ToLowerInvariant()
+    if ($actualChecksum -ne $expectedChecksum) {
+        Stop-Install "Checksum mismatch for $assetName. Check $releasePageUrl and retry the install."
+    }
+
+    Copy-Item -Path $assetPath -Destination $assetZipPath
+    try {
+        Expand-Archive -Path $assetZipPath -DestinationPath $extractDir -Force
+    } catch {
+        Stop-Install "Could not extract PolicyNIM bundle. Delete the downloaded asset and retry the install."
+    }
+
+    $bundleBinary = Get-ChildItem -Path $extractDir -Filter "policynim.exe" -File -Recurse | Select-Object -First 1
+    if (-not $bundleBinary) {
+        Stop-Install "Extracted asset $assetName did not contain policynim.exe. Check $releasePageUrl and retry."
+    }
+
+    $stagingDir = Join-Path $installParent ".$Version.staging.$PID"
+    if (Test-Path $stagingDir) {
+        Remove-Item -Recurse -Force $stagingDir
+    }
+    New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+    Copy-Item -Path (Join-Path $bundleBinary.DirectoryName "*") -Destination $stagingDir -Recurse -Force
+
+    New-Item -ItemType Directory -Force -Path $installParent | Out-Null
+    Replace-InstallDirectory $stagingDir $installDir $Version
+    Write-Launcher $installDir $launcherPath
+
+    Write-Host "Installed PolicyNIM $Version to $installDir."
+    Write-Host "Launcher: $launcherPath"
+    if (($env:Path -split ";") -notcontains $launcherDir) {
+        Write-Host "Add PolicyNIM to PATH for future PowerShell sessions:"
+        Write-Host '$launcherDir = Join-Path $env:LocalAppData "PolicyNIM\bin"; [Environment]::SetEnvironmentVariable("Path", ([Environment]::GetEnvironmentVariable("Path", "User") + ";" + $launcherDir).Trim(";"), "User")'
+    }
+    Write-Host "Run ``policynim init`` to configure your local NVIDIA API key."
+} finally {
+    if (Test-Path $workDir) {
+        Remove-Item -Recurse -Force $workDir
+    }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -91,7 +91,7 @@ if ($Version -eq "latest") {
 }
 $Version = $Version.TrimStart("v")
 $tag = "v$Version"
-$assetName = "policynim-$tag-$platform"
+$assetName = "policynim-$tag-windows-amd64.zip"
 $releaseBaseUrl = if ($env:POLICYNIM_RELEASE_BASE_URL) { $env:POLICYNIM_RELEASE_BASE_URL } else { "$RepositoryUrl/releases/download/$tag" }
 $releasePageUrl = "$RepositoryUrl/releases/tag/$tag"
 $installDir = Join-Path $env:LocalAppData "PolicyNIM\$Version"
@@ -105,7 +105,6 @@ try {
     $assetPath = Join-Path $workDir $assetName
     $checksumsPath = Join-Path $workDir $ChecksumsFile
     $extractDir = Join-Path $workDir "extract"
-    $assetZipPath = Join-Path $workDir "$assetName.zip"
     New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
 
     Download-Asset "$releaseBaseUrl/$assetName" $assetPath $assetName
@@ -121,9 +120,8 @@ try {
         Stop-Install "Checksum mismatch for $assetName. Check $releasePageUrl and retry the install."
     }
 
-    Copy-Item -Path $assetPath -Destination $assetZipPath
     try {
-        Expand-Archive -Path $assetZipPath -DestinationPath $extractDir -Force
+        Expand-Archive -Path $assetPath -DestinationPath $extractDir -Force
     } catch {
         Stop-Install "Could not extract PolicyNIM bundle. Delete the downloaded asset and retry the install."
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+set -eu
+
+REPO_URL="${POLICYNIM_REPOSITORY_URL:-https://github.com/nnennandukwe/policyNIM}"
+VERSION="${POLICYNIM_VERSION:-${1:-latest}}"
+CHECKSUMS_FILE="SHA256SUMS"
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+need_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1. Install it and retry."
+}
+
+normalize_os() {
+  raw_os="${POLICYNIM_INSTALLER_TEST_OS:-$(uname -s)}"
+  case "$raw_os" in
+    Darwin | darwin) printf 'darwin' ;;
+    Linux | linux) printf 'linux' ;;
+    *) printf '%s' "$raw_os" | tr '[:upper:]' '[:lower:]' ;;
+  esac
+}
+
+normalize_arch() {
+  raw_arch="${POLICYNIM_INSTALLER_TEST_ARCH:-$(uname -m)}"
+  case "$raw_arch" in
+    arm64 | aarch64) printf 'arm64' ;;
+    x86_64 | amd64) printf 'amd64' ;;
+    *) printf '%s' "$raw_arch" | tr '[:upper:]' '[:lower:]' ;;
+  esac
+}
+
+supported_platform() {
+  case "$1" in
+    darwin-arm64 | darwin-amd64 | linux-amd64) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_latest_version() {
+  need_command curl
+  latest_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$REPO_URL/releases/latest" || true)"
+  latest_tag="${latest_url##*/}"
+  case "$latest_tag" in
+    v[0-9]*)
+      printf '%s' "${latest_tag#v}"
+      ;;
+    *)
+      fail "Could not resolve the latest PolicyNIM release version. Pass a version as POLICYNIM_VERSION or as the first argument."
+      ;;
+  esac
+}
+
+download_asset() {
+  source_url="$1"
+  destination="$2"
+  label="$3"
+  if ! curl -fsSL --retry 2 --retry-delay 1 -o "$destination" "$source_url"; then
+    fail "Could not download release asset $label from $source_url. Check the release page or retry the install."
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    fail "Missing required command: sha256sum or shasum. Install one and retry."
+  fi
+}
+
+extract_bundle() {
+  archive_path="$1"
+  destination="$2"
+  if ! tar -xzf "$archive_path" -C "$destination"; then
+    fail "Could not extract PolicyNIM bundle. Delete the downloaded asset and retry the install."
+  fi
+}
+
+replace_install_dir() {
+  staging_dir="$1"
+  install_dir="$2"
+  install_parent="$(dirname "$install_dir")"
+  backup_dir="$install_parent/.${VERSION}.backup.$$"
+
+  rm -rf "$backup_dir"
+  if [ -d "$install_dir" ]; then
+    mv "$install_dir" "$backup_dir"
+  fi
+
+  if mv "$staging_dir" "$install_dir"; then
+    rm -rf "$backup_dir"
+    return 0
+  fi
+
+  if [ -d "$backup_dir" ]; then
+    mv "$backup_dir" "$install_dir"
+  fi
+  fail "Could not replace install directory $install_dir. Existing install was restored."
+}
+
+write_launcher() {
+  install_dir="$1"
+  launcher_path="$2"
+  launcher_tmp="${launcher_path}.tmp.$$"
+
+  mkdir -p "$(dirname "$launcher_path")"
+  cat >"$launcher_tmp" <<EOF
+#!/bin/sh
+exec "$install_dir/policynim" "\$@"
+EOF
+  chmod 755 "$launcher_tmp"
+  mv "$launcher_tmp" "$launcher_path"
+}
+
+print_path_guidance() {
+  launcher_dir="$1"
+  printf 'Installed PolicyNIM %s to %s.\n' "$VERSION" "$INSTALL_DIR"
+  printf 'Launcher: %s\n' "$launcher_dir/policynim"
+  case ":$PATH:" in
+    *":$launcher_dir:"*) ;;
+    *)
+      printf 'Add PolicyNIM to PATH for this shell:\n'
+      printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+      ;;
+  esac
+  printf 'Run `policynim init` to configure your local NVIDIA API key.\n'
+}
+
+OS_NAME="$(normalize_os)"
+ARCH_NAME="$(normalize_arch)"
+PLATFORM="${OS_NAME}-${ARCH_NAME}"
+if ! supported_platform "$PLATFORM"; then
+  fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-arm64, darwin-amd64, linux-amd64."
+fi
+
+need_command curl
+need_command tar
+need_command awk
+
+if [ "$VERSION" = "latest" ]; then
+  VERSION="$(resolve_latest_version)"
+fi
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+ASSET_NAME="policynim-${TAG}-${PLATFORM}"
+RELEASE_BASE_URL="${POLICYNIM_RELEASE_BASE_URL:-$REPO_URL/releases/download/$TAG}"
+RELEASE_PAGE_URL="$REPO_URL/releases/tag/$TAG"
+INSTALL_DIR="$HOME/.local/share/policynim/$VERSION"
+INSTALL_PARENT="$(dirname "$INSTALL_DIR")"
+LAUNCHER_DIR="$HOME/.local/bin"
+LAUNCHER_PATH="$LAUNCHER_DIR/policynim"
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT INT TERM
+
+asset_path="$WORK_DIR/$ASSET_NAME"
+checksums_path="$WORK_DIR/$CHECKSUMS_FILE"
+extract_dir="$WORK_DIR/extract"
+mkdir -p "$extract_dir"
+
+download_asset "$RELEASE_BASE_URL/$ASSET_NAME" "$asset_path" "$ASSET_NAME"
+download_asset "$RELEASE_BASE_URL/$CHECKSUMS_FILE" "$checksums_path" "$CHECKSUMS_FILE"
+
+expected_checksum="$(awk -v asset="$ASSET_NAME" '$2 == asset {print $1}' "$checksums_path" | head -n 1)"
+if [ -z "$expected_checksum" ]; then
+  fail "Checksum entry for $ASSET_NAME was not found in $CHECKSUMS_FILE. Check $RELEASE_PAGE_URL and retry."
+fi
+
+actual_checksum="$(sha256_file "$asset_path")"
+if [ "$actual_checksum" != "$expected_checksum" ]; then
+  fail "Checksum mismatch for $ASSET_NAME. Check $RELEASE_PAGE_URL and retry the install."
+fi
+
+extract_bundle "$asset_path" "$extract_dir"
+bundle_binary="$(find "$extract_dir" -type f -name policynim -perm -111 | head -n 1)"
+if [ -z "$bundle_binary" ]; then
+  fail "Extracted asset $ASSET_NAME did not contain an executable policynim binary. Check $RELEASE_PAGE_URL and retry."
+fi
+
+bundle_root="$(dirname "$bundle_binary")"
+staging_dir="$INSTALL_PARENT/.${VERSION}.staging.$$"
+rm -rf "$staging_dir"
+mkdir -p "$staging_dir"
+cp -R "$bundle_root/." "$staging_dir/"
+chmod 755 "$staging_dir/policynim"
+
+mkdir -p "$INSTALL_PARENT"
+replace_install_dir "$staging_dir" "$INSTALL_DIR"
+write_launcher "$INSTALL_DIR" "$LAUNCHER_PATH"
+print_path_guidance "$LAUNCHER_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,12 @@ if [ "$VERSION" = "latest" ]; then
 fi
 VERSION="${VERSION#v}"
 TAG="v${VERSION}"
-ASSET_NAME="policynim-${TAG}-${PLATFORM}"
+case "$PLATFORM" in
+  darwin-arm64) ASSET_NAME="policynim-$TAG-darwin-arm64.tar.gz" ;;
+  darwin-amd64) ASSET_NAME="policynim-$TAG-darwin-amd64.tar.gz" ;;
+  linux-amd64) ASSET_NAME="policynim-$TAG-linux-amd64.tar.gz" ;;
+  *) fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-arm64, darwin-amd64, linux-amd64." ;;
+esac
 RELEASE_BASE_URL="${POLICYNIM_RELEASE_BASE_URL:-$REPO_URL/releases/download/$TAG}"
 RELEASE_PAGE_URL="$REPO_URL/releases/tag/$TAG"
 INSTALL_DIR="$HOME/.local/share/policynim/$VERSION"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ normalize_os() {
   case "$raw_os" in
     Darwin | darwin) printf 'darwin' ;;
     Linux | linux) printf 'linux' ;;
-    *) printf '%s' "$raw_os" | tr '[:upper:]' '[:lower:]' ;;
+    *) printf '%s' "$raw_os" ;;
   esac
 }
 
@@ -28,7 +28,7 @@ normalize_arch() {
   case "$raw_arch" in
     arm64 | aarch64) printf 'arm64' ;;
     x86_64 | amd64) printf 'amd64' ;;
-    *) printf '%s' "$raw_arch" | tr '[:upper:]' '[:lower:]' ;;
+    *) printf '%s' "$raw_arch" ;;
   esac
 }
 
@@ -130,6 +130,10 @@ print_path_guidance() {
   printf 'Run `policynim init` to configure your local NVIDIA API key.\n'
 }
 
+if [ -z "${POLICYNIM_INSTALLER_TEST_OS:-}" ] || [ -z "${POLICYNIM_INSTALLER_TEST_ARCH:-}" ]; then
+  need_command uname
+fi
+
 OS_NAME="$(normalize_os)"
 ARCH_NAME="$(normalize_arch)"
 PLATFORM="${OS_NAME}-${ARCH_NAME}"
@@ -140,11 +144,16 @@ fi
 need_command curl
 need_command tar
 need_command awk
-need_command mktemp
+need_command cat
+need_command chmod
+need_command cp
+need_command dirname
 need_command find
 need_command head
-need_command cp
-need_command chmod
+need_command mkdir
+need_command mktemp
+need_command mv
+need_command rm
 
 if [ "$VERSION" = "latest" ]; then
   VERSION="$(resolve_latest_version)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -140,6 +140,11 @@ fi
 need_command curl
 need_command tar
 need_command awk
+need_command mktemp
+need_command find
+need_command head
+need_command cp
+need_command chmod
 
 if [ "$VERSION" = "latest" ]; then
   VERSION="$(resolve_latest_version)"

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -24,6 +24,7 @@ from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Redire
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
     BetaAuthService,
     create_beta_auth_service,
@@ -542,11 +543,11 @@ def _derive_beta_url(settings: Settings) -> str | None:
 
 
 def _beta_asset_path(filename: str) -> Path:
-    return Path(__file__).resolve().parent.parent / "assets" / "beta" / filename
+    return resolve_asset_path("beta", filename)
 
 
 def _beta_template_root() -> Path:
-    return Path(__file__).resolve().parent.parent / "templates"
+    return resolve_template_root()
 
 
 @lru_cache(maxsize=1)

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -25,6 +25,7 @@ from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Redire
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
     BetaAuthService,
     create_beta_auth_service,
@@ -554,11 +555,11 @@ def _derive_beta_url(settings: Settings) -> str | None:
 
 
 def _beta_asset_path(filename: str) -> Path:
-    return Path(__file__).resolve().parent.parent / "assets" / "beta" / filename
+    return resolve_asset_path("beta", filename)
 
 
 def _beta_template_root() -> Path:
-    return Path(__file__).resolve().parent.parent / "templates"
+    return resolve_template_root()
 
 
 @lru_cache(maxsize=1)

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -24,7 +24,12 @@ from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.errors import (
+    ConfigurationError,
+    InvalidPolicyDocumentError,
+    PolicyNIMError,
+    ProviderError,
+)
 from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
     BetaAuthService,
@@ -575,7 +580,10 @@ def _beta_template_environment() -> Environment:
 
 
 def _render_beta_asset(filename: str, *, media_type: str) -> Response:
-    asset_path = _beta_asset_path(filename)
+    try:
+        asset_path = _beta_asset_path(filename)
+    except InvalidPolicyDocumentError:
+        return Response("Missing beta asset.", status_code=404)
     if not asset_path.is_file():
         return Response("Missing beta asset.", status_code=404)
     return FileResponse(

--- a/src/policynim/runtime_paths.py
+++ b/src/policynim/runtime_paths.py
@@ -21,6 +21,34 @@ def resolve_runtime_path(path: Path) -> Path:
     return (Path.cwd() / path).resolve(strict=False)
 
 
+def resolve_template_root() -> Path:
+    """Resolve the bundled Jinja template root from package data or a source checkout."""
+    return _resolve_required_resource(
+        "templates",
+        predicate=Path.is_dir,
+        description="PolicyNIM templates",
+        recovery_hint=(
+            "Reinstall PolicyNIM or run from a source checkout that contains "
+            "`src/policynim/templates`."
+        ),
+    )
+
+
+def resolve_asset_path(*parts: str) -> Path:
+    """Resolve one bundled asset path from package data or a source checkout."""
+    normalized_parts = _normalize_resource_parts(parts)
+    return _resolve_required_resource(
+        "assets",
+        *normalized_parts,
+        predicate=Path.is_file,
+        description=f"PolicyNIM asset assets/{'/'.join(normalized_parts)}",
+        recovery_hint=(
+            "Reinstall PolicyNIM or run from a source checkout that contains "
+            "`src/policynim/assets`."
+        ),
+    )
+
+
 def _normalize_optional_path(value: Path | str | None) -> Path | None:
     """Normalize optional path-like input and discard empty-string overrides."""
     if value is None:
@@ -95,3 +123,41 @@ def _resolve_checkout_resource(
         if predicate(candidate):
             return candidate
     return None
+
+
+def _resolve_required_resource(
+    *parts: str,
+    predicate: Callable[[Path], bool],
+    description: str,
+    recovery_hint: str,
+) -> Path:
+    """Resolve a required packaged resource and raise with recovery guidance."""
+    bundled_resource = _resolve_packaged_resource(*parts)
+    if bundled_resource is not None and predicate(bundled_resource):
+        return bundled_resource
+
+    checkout_resource = _resolve_checkout_resource(*parts, predicate=predicate)
+    if checkout_resource is not None:
+        return checkout_resource
+
+    raise InvalidPolicyDocumentError(
+        f"Could not locate {description} at {'/'.join(parts)}. {recovery_hint}"
+    )
+
+
+def _normalize_resource_parts(parts: tuple[str, ...]) -> tuple[str, ...]:
+    """Reject package resource paths that escape their resource root."""
+    normalized: list[str] = []
+    for part in parts:
+        raw_part = str(part).strip()
+        if not raw_part:
+            raise InvalidPolicyDocumentError("Packaged resource path parts must not be empty.")
+        candidate = Path(raw_part)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise InvalidPolicyDocumentError(
+                "Packaged resource paths must stay within the package."
+            )
+        normalized.extend(candidate.parts)
+    if not normalized:
+        raise InvalidPolicyDocumentError("Packaged resource path parts must not be empty.")
+    return tuple(normalized)

--- a/src/policynim/runtime_paths.py
+++ b/src/policynim/runtime_paths.py
@@ -118,7 +118,7 @@ def _resolve_checkout_resource(
 ) -> Path | None:
     """Resolve a checkout-relative fallback by walking parents of the package path."""
     package_root = Path(__file__).resolve().parent
-    for parent in package_root.parents:
+    for parent in (package_root, *package_root.parents):
         candidate = parent.joinpath(*parts)
         if predicate(candidate):
             return candidate

--- a/tests/test_beta_portal.py
+++ b/tests/test_beta_portal.py
@@ -259,6 +259,7 @@ def test_beta_portal_serves_packaged_logo_assets(monkeypatch) -> None:
 
 
 def test_beta_portal_missing_packaged_asset_returns_404(monkeypatch) -> None:
+    """Return the existing 404 response when packaged beta assets are missing."""
     monkeypatch.setattr(
         mcp_module,
         "create_beta_auth_service",

--- a/tests/test_beta_portal.py
+++ b/tests/test_beta_portal.py
@@ -258,6 +258,24 @@ def test_beta_portal_serves_packaged_logo_assets(monkeypatch) -> None:
     assert favicon.headers["content-type"].startswith("image/png")
 
 
+def test_beta_portal_missing_packaged_asset_returns_404(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp_module,
+        "create_beta_auth_service",
+        lambda settings: StubBetaAuthService(),
+    )
+    monkeypatch.setattr(mcp_module, "_BETA_CSS_FILENAME", "missing.css")
+    mcp_module._beta_template_environment.cache_clear()
+
+    app = mcp_module._build_streamable_http_app(_signup_settings())
+
+    with TestClient(app) as client:
+        response = client.get(mcp_module._BETA_CSS_ROUTE)
+
+    assert response.status_code == 404
+    assert response.text == "Missing beta asset."
+
+
 def test_beta_portal_uses_secure_session_cookie_for_https_deployments(monkeypatch) -> None:
     monkeypatch.setattr(
         mcp_module,

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -98,3 +98,13 @@ def test_release_workflow_uploads_expected_install_artifacts() -> None:
         "--draft",
     ):
         assert token in text
+
+
+def test_release_workflow_rejects_mismatched_manual_versions() -> None:
+    """Prevent manual release dispatches from publishing inconsistent artifacts."""
+    text = _read_text(RELEASE_WORKFLOW)
+
+    assert 'project_version = project["project"]["version"]' in text
+    assert 'requested_version = requested.removeprefix("v")' in text
+    assert "requested_version != project_version" in text
+    assert "Release version mismatch:" in text

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -8,6 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 
 def _read_text(path: Path) -> str:
@@ -43,3 +44,57 @@ def test_hosted_smoke_workflow_uses_pinned_actions() -> None:
     action_refs = re.findall(r"uses: [^@\n]+@([0-9a-f]{40})", text)
 
     assert len(action_refs) == 3
+
+
+def test_release_workflow_runs_offline_verification_before_release_artifacts() -> None:
+    """Ensure release automation builds from the same offline quality gate as CI."""
+    text = _read_text(RELEASE_WORKFLOW)
+
+    for token in (
+        "workflow_dispatch:",
+        "tags:",
+        '- "v*.*.*"',
+        "uv lock --check",
+        "uv run ruff check .",
+        "uv run pyright",
+        'uv run pytest -q -m "not live and not docker_live"',
+        "uv build --out-dir dist",
+        "wheel-smoke:",
+        "standalone-build:",
+        "publish-github-release:",
+    ):
+        assert token in text
+    assert "tests/test_hosted_mcp_live.py" not in text
+    assert "POLICYNIM_BETA_MCP_TOKEN" not in text
+
+
+def test_release_workflow_uses_pinned_actions_and_trusted_pypi_publish() -> None:
+    """Ensure release actions are pinned and PyPI publish uses OIDC, not secrets."""
+    text = _read_text(RELEASE_WORKFLOW)
+    uses_lines = re.findall(r"uses: [^\n]+", text)
+
+    assert uses_lines
+    for line in uses_lines:
+        assert re.search(r"@[0-9a-f]{40}(?:\s+#.*)?$", line), line
+    assert "id-token: write" in text
+    assert "pypa/gh-action-pypi-publish@" in text
+    assert "password:" not in text
+    assert "TWINE_PASSWORD" not in text
+
+
+def test_release_workflow_uploads_expected_install_artifacts() -> None:
+    """Lock the public artifact contract used by curl and PowerShell installers."""
+    text = _read_text(RELEASE_WORKFLOW)
+
+    for token in (
+        "policynim-${RELEASE_TAG}-linux-amd64.tar.gz",
+        "policynim-${RELEASE_TAG}-darwin-amd64.tar.gz",
+        "policynim-${RELEASE_TAG}-darwin-arm64.tar.gz",
+        "policynim-${RELEASE_TAG}-windows-amd64.zip",
+        "scripts/install.sh",
+        "scripts/install.ps1",
+        "SHA256SUMS",
+        "gh release create",
+        "--draft",
+    ):
+        assert token in text

--- a/tests/test_dockerfile_contract.py
+++ b/tests/test_dockerfile_contract.py
@@ -42,6 +42,14 @@ def test_railway_uses_a_dedicated_compatible_dockerfile() -> None:
     assert "--mount=type=secret" not in dockerfile_text
 
 
+def test_container_builds_include_project_metadata_files() -> None:
+    """Keep minimal Docker build contexts compatible with package metadata."""
+    for path in (DOCKERFILE, RAILWAY_DOCKERFILE):
+        text = _read_text(path)
+
+        assert "COPY pyproject.toml uv.lock README.md LICENSE ./" in text
+
+
 def test_hosted_operations_doc_explains_railway_dockerfile_split() -> None:
     text = " ".join(_read_text(HOSTED_OPERATIONS).split())
 

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -10,6 +10,7 @@ WORKFLOWS_GUIDE = REPO_ROOT / "docs" / "workflows.md"
 CONTRIBUTOR_GUIDE = REPO_ROOT / "docs" / "contributor-guide.md"
 POLICY_TEMPLATE = REPO_ROOT / "policies" / "TEMPLATE.md"
 TESTS_README = REPO_ROOT / "tests" / "README.md"
+RELEASE_GUIDE = REPO_ROOT / "docs" / "release.md"
 STANDALONE_SETUP_DOCS = (README, WORKFLOWS_GUIDE, CONTRIBUTOR_GUIDE)
 ENV_EXAMPLES = (
     REPO_ROOT / ".env.example",
@@ -126,3 +127,45 @@ def test_hosted_operations_documents_operator_beta_release_gate() -> None:
         "policynim beta-admin audit-log",
     ):
         assert token in text
+
+
+def test_install_docs_cover_direct_cli_channels() -> None:
+    """Document install paths that do not require cloning the repo."""
+    readme = _read_text(README)
+    contributor = _read_text(CONTRIBUTOR_GUIDE)
+
+    for text in (readme, contributor):
+        for token in (
+            "pipx install policynim",
+            "uv tool install policynim",
+            (
+                "curl -fsSL "
+                "https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.sh | sh"
+            ),
+            (
+                "irm "
+                "https://github.com/nnennandukwe/policyNIM/releases/latest/download/"
+                "install.ps1 | iex"
+            ),
+            "policynim init",
+            "policynim ingest",
+            "policynim --help",
+        ):
+            assert token in text
+
+
+def test_release_guide_documents_publish_checklist() -> None:
+    """Keep GitHub and PyPI release steps discoverable."""
+    index_text = _read_text(REPO_ROOT / "docs" / "index.md")
+    release_text = _read_text(RELEASE_GUIDE)
+
+    assert "release.md" in index_text
+    for token in (
+        "git tag v",
+        "Release",
+        "draft GitHub release",
+        "SHA256SUMS",
+        "PyPI trusted publishing",
+        "Hosted Beta Smoke",
+    ):
+        assert token in release_text

--- a/tests/test_installer_contract.py
+++ b/tests/test_installer_contract.py
@@ -1,0 +1,189 @@
+"""Contract tests for standalone packaging and installer scripts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+PYINSTALLER_SPEC = REPO_ROOT / "packaging" / "pyinstaller.spec"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+VERSION = "0.1.0"
+LINUX_ASSET = f"policynim-v{VERSION}-linux-amd64"
+
+
+def test_pyinstaller_is_release_only_and_pinned() -> None:
+    project = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+    release_deps = project["dependency-groups"]["release"]
+    assert any(dep.lower().startswith("pyinstaller==") for dep in release_deps)
+
+    runtime_deps = project["project"]["dependencies"]
+    dev_deps = project["dependency-groups"]["dev"]
+    test_deps = project["dependency-groups"]["test"]
+    non_release_deps = [*runtime_deps, *dev_deps, *test_deps]
+    assert not any(dep.lower().startswith("pyinstaller") for dep in non_release_deps)
+
+
+def test_pyinstaller_spec_packages_runtime_resources() -> None:
+    spec = PYINSTALLER_SPEC.read_text(encoding="utf-8")
+
+    assert "src/policynim/interfaces/cli.py" in spec
+    assert 'copy_metadata("policynim")' in spec
+    assert '"policynim/policies"' in spec
+    assert '"policynim/evals"' in spec
+    assert '"policynim/assets"' in spec
+    assert '"policynim/templates"' in spec
+    assert "collect_submodules" not in spec
+
+
+def test_installer_scripts_lock_supported_artifact_contract() -> None:
+    install_sh = INSTALL_SH.read_text(encoding="utf-8")
+    install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
+
+    for platform in ("darwin-arm64", "darwin-amd64", "linux-amd64"):
+        assert platform in install_sh
+    assert "windows-amd64" in install_ps1
+    assert "SHA256SUMS" in install_sh
+    assert "SHA256SUMS" in install_ps1
+    assert "NVIDIA_API_KEY" not in install_sh
+    assert "NVIDIA_API_KEY" not in install_ps1
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_rejects_unsupported_platform(tmp_path: Path) -> None:
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+
+    result, home = run_unix_installer(
+        tmp_path,
+        release_dir,
+        arch="aarch64",
+        path="",
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Unsupported platform: linux-arm64" in output
+    assert "Supported platforms: darwin-arm64, darwin-amd64, linux-amd64." in output
+    assert not (home / ".local" / "bin" / "policynim").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_stops_before_extracting_on_checksum_mismatch(tmp_path: Path) -> None:
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    create_unix_release_asset(release_dir, checksum="0" * 64)
+
+    result, home = run_unix_installer(tmp_path, release_dir)
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Checksum mismatch for policynim-v0.1.0-linux-amd64." in output
+    assert not (home / ".local" / "share" / "policynim" / VERSION).exists()
+    assert not (home / ".local" / "bin" / "policynim").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_reports_missing_release_asset(tmp_path: Path) -> None:
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    (release_dir / "SHA256SUMS").write_text(f"{'0' * 64}  {LINUX_ASSET}\n", encoding="utf-8")
+
+    result, home = run_unix_installer(tmp_path, release_dir)
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Could not download release asset policynim-v0.1.0-linux-amd64" in output
+    assert "Check the release page or retry the install." in output
+    assert not (home / ".local" / "bin" / "policynim").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_installs_launcher_and_prints_path_guidance(tmp_path: Path) -> None:
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    create_unix_release_asset(release_dir)
+
+    result, home = run_unix_installer(tmp_path, release_dir)
+
+    installed_binary = home / ".local" / "share" / "policynim" / VERSION / "policynim"
+    launcher = home / ".local" / "bin" / "policynim"
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert installed_binary.is_file()
+    assert launcher.is_file()
+    assert f".local/share/policynim/{VERSION}/policynim" in launcher.read_text(encoding="utf-8")
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in result.stdout
+    assert "Run `policynim init` to configure your local NVIDIA API key." in result.stdout
+
+
+def test_windows_installer_contract_is_actionable() -> None:
+    script = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "Get-FileHash" in script
+    assert "Expand-Archive" in script
+    assert "policynim.cmd" in script
+    assert "LocalAppData" in script
+    assert "SetEnvironmentVariable" in script
+    assert "policynim init" in script
+    assert "Read-Host" not in script
+
+
+def create_unix_release_asset(release_dir: Path, *, checksum: str | None = None) -> Path:
+    build_root = release_dir / "build"
+    bundle_root = build_root / "policynim"
+    bundle_root.mkdir(parents=True)
+    binary = bundle_root / "policynim"
+    binary.write_text("#!/bin/sh\nprintf 'fake policynim\\n'\n", encoding="utf-8")
+    binary.chmod(0o755)
+    (bundle_root / "_internal").mkdir()
+
+    asset_path = release_dir / LINUX_ASSET
+    with tarfile.open(asset_path, "w:gz") as archive:
+        archive.add(bundle_root, arcname="policynim")
+
+    digest = checksum or hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    (release_dir / "SHA256SUMS").write_text(f"{digest}  {LINUX_ASSET}\n", encoding="utf-8")
+    return asset_path
+
+
+def run_unix_installer(
+    tmp_path: Path,
+    release_dir: Path,
+    *,
+    os_name: str = "Linux",
+    arch: str = "x86_64",
+    path: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "POLICYNIM_VERSION": VERSION,
+            "POLICYNIM_RELEASE_BASE_URL": release_dir.as_uri(),
+            "POLICYNIM_INSTALLER_TEST_OS": os_name,
+            "POLICYNIM_INSTALLER_TEST_ARCH": arch,
+        }
+    )
+    if path is not None:
+        env["PATH"] = path
+
+    result = subprocess.run(
+        [shutil.which("sh") or "sh", str(INSTALL_SH)],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    return result, home

--- a/tests/test_installer_contract.py
+++ b/tests/test_installer_contract.py
@@ -62,7 +62,22 @@ def test_installer_scripts_lock_supported_artifact_contract() -> None:
     assert "policynim-$tag-windows-amd64.zip" in install_ps1
     assert "SHA256SUMS" in install_sh
     assert "SHA256SUMS" in install_ps1
-    for command in ("curl", "tar", "awk", "mktemp", "find", "head", "cp", "chmod"):
+    for command in (
+        "awk",
+        "cat",
+        "chmod",
+        "cp",
+        "curl",
+        "dirname",
+        "find",
+        "head",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "rm",
+        "tar",
+        "uname",
+    ):
         assert f"need_command {command}" in install_sh
     assert "NVIDIA_API_KEY" not in install_sh
     assert "NVIDIA_API_KEY" not in install_ps1
@@ -117,6 +132,20 @@ def test_unix_installer_reports_missing_release_asset(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "Could not download release asset policynim-v0.1.0-linux-amd64.tar.gz" in output
     assert "Check the release page or retry the install." in output
+    assert not (home / ".local" / "bin" / "policynim").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_reports_missing_required_command(tmp_path: Path) -> None:
+    """Fail with installer guidance when a required Unix tool is unavailable."""
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+
+    result, home = run_unix_installer(tmp_path, release_dir, path="")
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Missing required command: curl. Install it and retry." in output
     assert not (home / ".local" / "bin" / "policynim").exists()
 
 

--- a/tests/test_installer_contract.py
+++ b/tests/test_installer_contract.py
@@ -22,6 +22,7 @@ LINUX_ASSET = f"policynim-v{VERSION}-linux-amd64.tar.gz"
 
 
 def test_pyinstaller_is_release_only_and_pinned() -> None:
+    """Keep PyInstaller scoped to release builds instead of runtime installs."""
     project = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
 
     release_deps = project["dependency-groups"]["release"]
@@ -35,6 +36,7 @@ def test_pyinstaller_is_release_only_and_pinned() -> None:
 
 
 def test_pyinstaller_spec_packages_runtime_resources() -> None:
+    """Ensure standalone bundles include the package resources used at runtime."""
     spec = PYINSTALLER_SPEC.read_text(encoding="utf-8")
 
     assert "src/policynim/interfaces/cli.py" in spec
@@ -47,6 +49,7 @@ def test_pyinstaller_spec_packages_runtime_resources() -> None:
 
 
 def test_installer_scripts_lock_supported_artifact_contract() -> None:
+    """Keep installer asset names and security assumptions aligned with releases."""
     install_sh = INSTALL_SH.read_text(encoding="utf-8")
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
 
@@ -59,12 +62,15 @@ def test_installer_scripts_lock_supported_artifact_contract() -> None:
     assert "policynim-$tag-windows-amd64.zip" in install_ps1
     assert "SHA256SUMS" in install_sh
     assert "SHA256SUMS" in install_ps1
+    for command in ("curl", "tar", "awk", "mktemp", "find", "head", "cp", "chmod"):
+        assert f"need_command {command}" in install_sh
     assert "NVIDIA_API_KEY" not in install_sh
     assert "NVIDIA_API_KEY" not in install_ps1
 
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
 def test_unix_installer_rejects_unsupported_platform(tmp_path: Path) -> None:
+    """Reject unsupported Unix platform tuples before downloading anything."""
     release_dir = tmp_path / "release"
     release_dir.mkdir()
 
@@ -84,6 +90,7 @@ def test_unix_installer_rejects_unsupported_platform(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
 def test_unix_installer_stops_before_extracting_on_checksum_mismatch(tmp_path: Path) -> None:
+    """Abort before extraction when the downloaded archive checksum is wrong."""
     release_dir = tmp_path / "release"
     release_dir.mkdir()
     create_unix_release_asset(release_dir, checksum="0" * 64)
@@ -99,6 +106,7 @@ def test_unix_installer_stops_before_extracting_on_checksum_mismatch(tmp_path: P
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
 def test_unix_installer_reports_missing_release_asset(tmp_path: Path) -> None:
+    """Surface actionable guidance when a release asset is unavailable."""
     release_dir = tmp_path / "release"
     release_dir.mkdir()
     (release_dir / "SHA256SUMS").write_text(f"{'0' * 64}  {LINUX_ASSET}\n", encoding="utf-8")
@@ -114,6 +122,7 @@ def test_unix_installer_reports_missing_release_asset(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
 def test_unix_installer_installs_launcher_and_prints_path_guidance(tmp_path: Path) -> None:
+    """Install the bundle, create a launcher, and print follow-up setup guidance."""
     release_dir = tmp_path / "release"
     release_dir.mkdir()
     create_unix_release_asset(release_dir)
@@ -131,6 +140,7 @@ def test_unix_installer_installs_launcher_and_prints_path_guidance(tmp_path: Pat
 
 
 def test_windows_installer_contract_is_actionable() -> None:
+    """Check the PowerShell installer keeps checksum and PATH behavior discoverable."""
     script = INSTALL_PS1.read_text(encoding="utf-8")
 
     assert "Get-FileHash" in script
@@ -143,6 +153,7 @@ def test_windows_installer_contract_is_actionable() -> None:
 
 
 def create_unix_release_asset(release_dir: Path, *, checksum: str | None = None) -> Path:
+    """Create a fake Unix release archive and matching checksum file."""
     build_root = release_dir / "build"
     bundle_root = build_root / "policynim"
     bundle_root.mkdir(parents=True)
@@ -168,6 +179,7 @@ def run_unix_installer(
     arch: str = "x86_64",
     path: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run the Unix installer against a local fake release directory."""
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
     env = os.environ.copy()

--- a/tests/test_installer_contract.py
+++ b/tests/test_installer_contract.py
@@ -18,7 +18,7 @@ INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
 PYINSTALLER_SPEC = REPO_ROOT / "packaging" / "pyinstaller.spec"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 VERSION = "0.1.0"
-LINUX_ASSET = f"policynim-v{VERSION}-linux-amd64"
+LINUX_ASSET = f"policynim-v{VERSION}-linux-amd64.tar.gz"
 
 
 def test_pyinstaller_is_release_only_and_pinned() -> None:
@@ -50,9 +50,13 @@ def test_installer_scripts_lock_supported_artifact_contract() -> None:
     install_sh = INSTALL_SH.read_text(encoding="utf-8")
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
 
-    for platform in ("darwin-arm64", "darwin-amd64", "linux-amd64"):
-        assert platform in install_sh
-    assert "windows-amd64" in install_ps1
+    for asset in (
+        "policynim-$TAG-darwin-arm64.tar.gz",
+        "policynim-$TAG-darwin-amd64.tar.gz",
+        "policynim-$TAG-linux-amd64.tar.gz",
+    ):
+        assert asset in install_sh
+    assert "policynim-$tag-windows-amd64.zip" in install_ps1
     assert "SHA256SUMS" in install_sh
     assert "SHA256SUMS" in install_ps1
     assert "NVIDIA_API_KEY" not in install_sh
@@ -88,7 +92,7 @@ def test_unix_installer_stops_before_extracting_on_checksum_mismatch(tmp_path: P
 
     output = result.stdout + result.stderr
     assert result.returncode != 0
-    assert "Checksum mismatch for policynim-v0.1.0-linux-amd64." in output
+    assert "Checksum mismatch for policynim-v0.1.0-linux-amd64.tar.gz." in output
     assert not (home / ".local" / "share" / "policynim" / VERSION).exists()
     assert not (home / ".local" / "bin" / "policynim").exists()
 
@@ -103,7 +107,7 @@ def test_unix_installer_reports_missing_release_asset(tmp_path: Path) -> None:
 
     output = result.stdout + result.stderr
     assert result.returncode != 0
-    assert "Could not download release asset policynim-v0.1.0-linux-amd64" in output
+    assert "Could not download release asset policynim-v0.1.0-linux-amd64.tar.gz" in output
     assert "Check the release page or retry the install." in output
     assert not (home / ".local" / "bin" / "policynim").exists()
 

--- a/tests/test_package_release.py
+++ b/tests/test_package_release.py
@@ -1,0 +1,44 @@
+"""Package metadata checks for direct CLI installs."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _project() -> dict[str, Any]:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def test_runtime_dependencies_pin_lance_namespace_for_clean_wheel_installs() -> None:
+    """Prevent pip/pipx from resolving a lancedb-incompatible namespace client."""
+    dependencies = set(_project()["project"]["dependencies"])
+
+    assert "lance-namespace==0.6.1" in dependencies
+    assert "lance-namespace-urllib3-client==0.6.1" in dependencies
+
+
+def test_package_metadata_is_ready_for_public_install_channels() -> None:
+    """Keep PyPI and GitHub release metadata useful for first-time installers."""
+    project = _project()["project"]
+
+    assert project["license"] == {"file": "LICENSE"}
+    assert project["authors"] == [{"name": "Nnenna Ndukwe"}]
+    assert project["keywords"] == ["ai-agents", "mcp", "nvidia-nim", "policy", "preflight"]
+    assert project["urls"]["Repository"] == "https://github.com/nnennandukwe/policyNIM"
+    assert project["urls"]["Issues"] == "https://github.com/nnennandukwe/policyNIM/issues"
+    assert "Programming Language :: Python :: 3.11" in project["classifiers"]
+
+
+def test_wheel_force_include_avoids_duplicate_package_resources() -> None:
+    """Assets and templates already live under the package and must not be duplicated."""
+    force_include = _project()["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+
+    assert force_include == {
+        "policies": "policynim/policies",
+        "evals": "policynim/evals",
+    }

--- a/tests/test_package_release.py
+++ b/tests/test_package_release.py
@@ -11,6 +11,7 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 
 def _project() -> dict[str, Any]:
+    """Load pyproject data for package release contract assertions."""
     return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
 
 

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -8,9 +8,11 @@ import pytest
 
 from policynim.errors import InvalidPolicyDocumentError
 from policynim.runtime_paths import (
+    resolve_asset_path,
     resolve_corpus_root,
     resolve_eval_suite_path,
     resolve_runtime_path,
+    resolve_template_root,
 )
 
 
@@ -203,3 +205,52 @@ def test_resolve_eval_suite_path_error_no_longer_references_cases_flag(
         resolve_eval_suite_path()
 
     assert "--cases" not in str(exc.value)
+
+
+def test_resolve_template_root_finds_bundled_package_templates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "site-packages" / "policynim"
+    bundled_templates = package_root / "templates"
+    bundled_templates.mkdir(parents=True)
+    monkeypatch.setattr(
+        "policynim.runtime_paths._resolve_packaged_resource",
+        lambda *parts: package_root.joinpath(*parts),
+    )
+
+    assert resolve_template_root() == bundled_templates
+
+
+def test_resolve_asset_path_finds_bundled_package_asset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "site-packages" / "policynim"
+    bundled_asset = package_root / "assets" / "beta" / "beta.css"
+    bundled_asset.parent.mkdir(parents=True)
+    bundled_asset.write_text("body { color: black; }", encoding="utf-8")
+    monkeypatch.setattr(
+        "policynim.runtime_paths._resolve_packaged_resource",
+        lambda *parts: package_root.joinpath(*parts),
+    )
+
+    assert resolve_asset_path("beta", "beta.css") == bundled_asset
+
+
+def test_resolve_asset_path_raises_with_reinstall_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    isolated_package = tmp_path / "isolated" / "policynim"
+    isolated_package.mkdir(parents=True)
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr(
+        "policynim.runtime_paths.__file__", str(isolated_package / "runtime_paths.py")
+    )
+
+    with pytest.raises(InvalidPolicyDocumentError) as exc:
+        resolve_asset_path("beta", "missing.css")
+
+    message = str(exc.value)
+    assert "assets/beta/missing.css" in message
+    assert "Reinstall PolicyNIM" in message

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -236,6 +236,31 @@ def test_resolve_asset_path_finds_bundled_package_asset(
     assert resolve_asset_path("beta", "beta.css") == bundled_asset
 
 
+def test_resolve_template_root_falls_back_to_checkout_package_templates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "checkout" / "src" / "policynim"
+    checkout_templates = package_root / "templates"
+    checkout_templates.mkdir(parents=True)
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+    monkeypatch.setattr("policynim.runtime_paths._resolve_packaged_resource", lambda *parts: None)
+
+    assert resolve_template_root() == checkout_templates
+
+
+def test_resolve_asset_path_falls_back_to_checkout_package_assets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "checkout" / "src" / "policynim"
+    checkout_asset = package_root / "assets" / "beta" / "beta.css"
+    checkout_asset.parent.mkdir(parents=True)
+    checkout_asset.write_text("body { color: black; }", encoding="utf-8")
+    monkeypatch.setattr("policynim.runtime_paths.__file__", str(package_root / "runtime_paths.py"))
+    monkeypatch.setattr("policynim.runtime_paths._resolve_packaged_resource", lambda *parts: None)
+
+    assert resolve_asset_path("beta", "beta.css") == checkout_asset
+
+
 def test_resolve_asset_path_raises_with_reinstall_guidance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +623,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -926,6 +947,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2023.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload-time = "2023-02-07T12:23:55.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload-time = "2023-02-07T12:28:36.678Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -981,6 +1011,9 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
 ]
+release = [
+    { name = "pyinstaller" },
+]
 test = [
     { name = "pytest" },
 ]
@@ -1007,6 +1040,7 @@ dev = [
     { name = "pre-commit", specifier = "==4.3.0" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
+release = [{ name = "pyinstaller", specifier = "==6.19.0" }]
 test = [{ name = "pytest", specifier = "==8.3.4" }]
 
 [[package]]
@@ -1163,6 +1197,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1254,6 +1329,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
     { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
     { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1509,6 +1593,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
     { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
     { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1757,6 +1766,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2745,6 +2766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2023.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload-time = "2023-02-07T12:23:55.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload-time = "2023-02-07T12:28:36.678Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2816,6 +2846,9 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
 ]
+release = [
+    { name = "pyinstaller" },
+]
 test = [
     { name = "pytest" },
 ]
@@ -2851,6 +2884,7 @@ dev = [
     { name = "pyright", specifier = "==1.1.409" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
+release = [{ name = "pyinstaller", specifier = "==6.19.0" }]
 test = [{ name = "pytest", specifier = "==8.3.4" }]
 
 [[package]]
@@ -3193,6 +3227,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3331,6 +3406,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
     { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
     { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1754,6 +1754,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1763,18 +1775,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
-]
-
-[[package]]
-name = "macholib"
-version = "1.16.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "altgraph" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -2702,6 +2702,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2023.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload-time = "2023-02-07T12:23:55.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload-time = "2023-02-07T12:28:36.678Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2766,15 +2775,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pefile"
-version = "2023.2.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload-time = "2023-02-07T12:23:55.958Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload-time = "2023-02-07T12:28:36.678Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2815,6 +2815,8 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "lance-namespace" },
+    { name = "lance-namespace-urllib3-client" },
     { name = "lancedb" },
     { name = "markdown-it-py" },
     { name = "mcp", extra = ["cli"] },
@@ -2860,6 +2862,8 @@ requires-dist = [
     { name = "httpx", specifier = "==0.27.2" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "lance-namespace", specifier = "==0.6.1" },
+    { name = "lance-namespace-urllib3-client", specifier = "==0.6.1" },
     { name = "lancedb", specifier = "==0.27.1" },
     { name = "markdown-it-py", specifier = "==4.0.0" },
     { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },


### PR DESCRIPTION
## Summary
- add the PyInstaller standalone bundle spec with policies, evals, assets, templates, and package metadata
- add Unix and Windows installer scripts with platform detection, checksum verification, launcher creation, PATH guidance, and no secret collection
- route beta portal assets/templates through packaged-resource runtime path helpers
- add packaged-resource and installer contract coverage, including unsupported platform, missing asset, checksum mismatch, and PATH guidance cases

## Verification
- uv run pytest -q
- uv run ruff check
- uv lock --check
- sh -n scripts/install.sh
- uv run pyinstaller --clean --noconfirm packaging/pyinstaller.spec
- dist/policynim/policynim --version
- dist/policynim/policynim --help
- dist/policynim/policynim init --help
- pwsh parser check for scripts/install.ps1
- pwsh Windows installer happy-path smoke against a temporary localhost release asset
