### PR TITLE
Add Build 2 policy compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - NVIDIA-hosted embeddings and reranking for retrieval.
 - Local LanceDB storage for the retrievable policy index.
 - Task-aware policy routing with citation-preserving selected-policy packets.
-- Grounded preflight synthesis with citation validation and fail-closed fallback.
+- Policy compilation into citation-backed planning and generation constraints.
+- Grounded preflight synthesis with compiled plan steps, citation validation, and
+  fail-closed fallback.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `preflight`,
-  `eval`, `mcp`, `runtime`, and `evidence`.
+- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
+  `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
@@ -96,6 +98,7 @@ After the index is built, the fastest local sanity checks are:
 ```bash
 uv run policynim search --query "refresh token cleanup background job" --top-k 5
 uv run policynim route --task "Implement a refresh-token cleanup background job" --top-k 5
+uv run policynim compile --task "Implement a refresh-token cleanup background job" --top-k 5
 uv run policynim preflight --task "Implement a refresh-token cleanup background job" --top-k 5
 ```
 
@@ -112,8 +115,9 @@ Start here when you want the longer version of a specific path:
 - [docs/index.md](docs/index.md): documentation hub by audience and task
 - [docs/contributor-guide.md](docs/contributor-guide.md): local setup, env vars,
   model references, and quality gates
-- [docs/workflows.md](docs/workflows.md): CLI surfaces, ingest/search/route/preflight,
-  eval, MCP, runtime/evidence, and troubleshooting
+- [docs/workflows.md](docs/workflows.md): CLI surfaces,
+  ingest/search/route/compile/preflight, eval, MCP, runtime/evidence, and
+  troubleshooting
 - [docs/hosted-beta-operations.md](docs/hosted-beta-operations.md): hosted beta
   quickstart, recovery, container build flow, and Railway deploy notes
 - [docs/architecture.md](docs/architecture.md): package boundaries, runtime flow,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,8 @@ The architecture stays intentionally small:
 
 - typed contracts shared by CLI and MCP
 - explicit provider and storage adapters
-- application services for ingest, retrieval, task-aware routing, preflight, and
-  evaluation
+- application services for ingest, retrieval, task-aware routing, policy
+  compilation, preflight, and evaluation
 - application services for runtime decisions, runtime execution, and durable
   evidence capture
 - fail-closed grounding rules instead of best-effort freeform answers
@@ -89,9 +89,26 @@ Routing flow:
 6. retain bounded policy evidence with source chunk IDs and line spans
 7. return a JSON-first `PolicySelectionPacket`
 
-Build 1 routing intentionally does not compile policies into planning
-constraints. Weak or empty routing evidence becomes `insufficient_context=true`;
-missing configuration or a missing local index remains an explicit error.
+Weak or empty routing evidence becomes `insufficient_context=true`; missing
+configuration or a missing local index remains an explicit error.
+
+### Policy Compiler Flow
+
+`PolicyCompilerService` turns selected policy evidence into a
+citation-backed `CompiledPolicyPacket` for planning and generation.
+
+Compiler flow:
+
+1. route the task into a retained `PolicySelectionPacket`
+2. stop before NVIDIA compilation when routed evidence is weak
+3. send selected policy evidence to the NVIDIA policy compiler
+4. validate every compiled constraint citation against retained chunk IDs
+5. materialize public citations and source policy IDs
+6. return a JSON-first `CompiledPolicyPacket`
+
+Build 2 compilation adds no new environment variable or artifact directory. It
+reuses the existing NVIDIA chat model setting and fails closed when generated
+constraints are malformed, unsupported, or uncited.
 
 ### Grounded Preflight Flow
 
@@ -99,12 +116,14 @@ missing configuration or a missing local index remains an explicit error.
 
 Preflight flow:
 
-1. route the task into a retained `PolicySelectionPacket`
-2. send retained policy evidence to the grounded generator
+1. compile the task into a retained `CompiledPolicyPacket`
+2. pass compiled constraints plus retained policy evidence to the grounded
+   generator
 3. receive a structured draft that cites retrieved chunk IDs
-4. validate every cited chunk ID against the retained result set
-5. materialize public citations and policy guidance
-6. return a JSON-first `PreflightResult`
+4. merge compiled plan steps, guidance, flags, and test expectations
+5. validate every cited chunk ID against the retained result set
+6. materialize public citations and policy guidance
+7. return a JSON-first `PreflightResult`
 
 Fail-closed rules are central here:
 
@@ -189,8 +208,10 @@ Important evaluation rules:
 - `SearchService` handles query embedding, retrieval, and reranking.
 - `PolicyRouterService` handles deterministic task profiling, broad retrieval,
   reranking, selected-policy grouping, and citation-preserving route packets.
-- `PreflightService` handles routed evidence selection, grounded synthesis, and
-  citation validation.
+- `PolicyCompilerService` handles routed evidence selection, constraint
+  compilation, and compiled-packet citation validation.
+- `PreflightService` handles compiled evidence conditioning, grounded synthesis,
+  and citation validation.
 - `RuntimeDecisionService` compiles and matches runtime rules against the local
   index by loading the compiled runtime rules artifact, matching actions
   against it, and linking the matched rules back to indexed evidence.
@@ -237,6 +258,7 @@ Important evaluation rules:
 - `policynim dump-index`
 - `policynim search --query ...`
 - `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
+- `policynim compile --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim preflight --task ...`
 - `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
@@ -270,8 +292,9 @@ Important evaluation rules:
 Shared interface guarantees:
 
 - CLI `search` and MCP `policy_search` use the same `SearchResult` shape.
-- CLI `route` returns a `PolicySelectionPacket`; there is no MCP route tool in
-  Build 1.
+- CLI `route` returns a `PolicySelectionPacket`; there is no MCP route tool.
+- CLI `compile` returns a `CompiledPolicyPacket`; there is no MCP compile tool
+  in Build 2.
 - CLI `preflight` and MCP `policy_preflight` use the same `PreflightResult`
   shape.
 - CLI `runtime decide` and `runtime execute` use the same `RuntimeActionRequest`
@@ -295,6 +318,7 @@ NVIDIA-hosted APIs are used for:
 - document embeddings during ingest
 - query embeddings during search, route, and preflight
 - reranking retrieved candidates
+- policy compilation for planning and generation constraints
 - grounded generation for preflight
 
 These steps require `NVIDIA_API_KEY`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -11,6 +11,7 @@ reference that used to live in the root README.
 - `policynim dump-index`
 - `policynim search --query "..."`
 - `policynim route --task "..."`
+- `policynim compile --task "..."`
 - `policynim preflight --task "..."`
 - `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
@@ -111,7 +112,30 @@ uv run policynim route \
   --top-k 5
 ```
 
-### 5. Run Grounded Preflight
+### 5. Compile Policy Constraints
+
+```bash
+uv run policynim compile \
+  --task "Implement a refresh-token cleanup background job" \
+  --top-k 5
+```
+
+`compile` is the inspection path between task-aware routing and grounded
+preflight. It returns a JSON `CompiledPolicyPacket` with:
+
+- selected policies
+- required steps
+- forbidden patterns
+- architectural expectations
+- test expectations
+- style constraints
+- citations
+- `insufficient_context`
+
+Build 2 compilation reuses the existing NVIDIA chat model setting and adds no
+new environment variable or artifact directory.
+
+### 6. Run Grounded Preflight
 
 ```bash
 uv run policynim preflight \
@@ -123,6 +147,7 @@ uv run policynim preflight \
 
 - a grounded summary
 - applicable policies
+- plan steps
 - implementation guidance
 - review flags
 - tests required
@@ -132,7 +157,11 @@ uv run policynim preflight \
 If citation validation fails or the grounded answer is too weak, PolicyNIM
 returns `insufficient_context=true` instead of bluffing.
 
-### 6. Run Evaluations
+`preflight` compiles routed policy evidence before generation and uses the
+compiled packet to condition plan steps, implementation guidance, review flags,
+and test expectations.
+
+### 7. Run Evaluations
 
 ```bash
 uv run policynim eval
@@ -327,8 +356,9 @@ PolicyNIM keeps the retrieval stack explicit:
 3. retrieve dense candidates from LanceDB
 4. rerank candidates with NVIDIA
 5. route retained evidence into selected-policy packets
-6. generate grounded guidance from routed evidence only
-7. validate every citation against retrieved chunks before returning results
+6. compile selected policy evidence into constraint packets
+7. generate grounded guidance from routed evidence and compiled constraints
+8. validate every citation against retrieved chunks before returning results
 
 The system is designed to fail closed:
 
@@ -358,6 +388,15 @@ uv run policynim route \
   --top-k 5 | jq
 ```
 
+Then inspect compiled constraints:
+
+```bash
+uv run policynim compile \
+  --task "Implement a refresh-token cleanup background job" \
+  --domain security \
+  --top-k 5 | jq
+```
+
 Then compare that with:
 
 ```bash
@@ -367,11 +406,11 @@ uv run policynim preflight \
   --top-k 5 | jq
 ```
 
-If `search` returns strong hits and `route` returns selected policies while
-`preflight` returns `insufficient_context=true`, the failure is in grounded
-answer validation, not indexing. If `route` also returns
-`insufficient_context=true`, inspect the task type, domain filter, and indexed
-policy coverage first.
+If `search` returns strong hits, `route` returns selected policies, and
+`compile` returns constraints while `preflight` returns
+`insufficient_context=true`, the failure is in grounded answer validation, not
+indexing. If `route` or `compile` also returns `insufficient_context=true`,
+inspect the task type, domain filter, and indexed policy coverage first.
 
 ### Negative Search Scores
 
@@ -381,8 +420,8 @@ higher is better for that query.
 
 ### Missing Index
 
-If `search`, `preflight`, or MCP tool calls fail because the index is missing,
-run:
+If `search`, `route`, `compile`, `preflight`, or MCP tool calls fail because the
+index is missing, run:
 
 ```bash
 uv run policynim ingest
@@ -390,5 +429,5 @@ uv run policynim ingest
 
 ### Missing NVIDIA Credentials
 
-`ingest`, `search`, `preflight`, and live eval mode require `NVIDIA_API_KEY`.
-Offline eval mode does not.
+`ingest`, `search`, `route`, `compile`, `preflight`, and live eval mode require
+`NVIDIA_API_KEY`. Offline eval mode does not.

--- a/src/policynim/contracts.py
+++ b/src/policynim/contracts.py
@@ -8,9 +8,13 @@ from typing import Protocol
 import httpx
 
 from policynim.types import (
+    CompiledPolicyPacket,
+    CompileRequest,
     EmbeddedChunk,
+    GeneratedCompiledPolicyDraft,
     GeneratedPreflightDraft,
     PolicyChunk,
+    PolicySelectionPacket,
     PreflightRequest,
     RuntimeActionRequest,
     RuntimeDecisionResult,
@@ -52,8 +56,23 @@ class Generator(Protocol):
         self,
         request: PreflightRequest,
         context: Sequence[ScoredChunk],
+        *,
+        compiled_packet: CompiledPolicyPacket | None = None,
     ) -> GeneratedPreflightDraft:
         """Generate a grounded preflight draft."""
+        ...
+
+
+class PolicyCompiler(Protocol):
+    """Compiles routed policy evidence into planning and generation constraints."""
+
+    def compile_policy_packet(
+        self,
+        request: CompileRequest,
+        selection_packet: PolicySelectionPacket,
+        context: Sequence[ScoredChunk],
+    ) -> GeneratedCompiledPolicyDraft:
+        """Compile grounded policy evidence into a draft constraint packet."""
         ...
 
 

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -347,10 +347,10 @@ def compile(
     ] = None,
 ) -> None:
     """Return compiled policy constraints for planning and generation."""
-    settings = get_settings()
-    resolved_top_k = top_k if top_k is not None else settings.default_top_k
     service = None
     try:
+        settings = _load_setup_dependent_settings()
+        resolved_top_k = top_k if top_k is not None else settings.default_top_k
         request = CompileRequest(
             task=task,
             domain=domain,

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -20,6 +20,7 @@ from policynim.services import (
     create_eval_service,
     create_index_dump_service,
     create_ingest_service,
+    create_policy_compiler_service,
     create_policy_router_service,
     create_preflight_service,
     create_runtime_decision_service,
@@ -30,6 +31,7 @@ from policynim.services import (
 from policynim.settings import Settings, get_settings
 from policynim.types import (
     MAX_TOP_K,
+    CompileRequest,
     EvalExecutionMode,
     PreflightRequest,
     RouteRequest,
@@ -306,6 +308,61 @@ def route(
         _exit_with_error(_format_validation_error("Route request", exc))
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+    finally:
+        _close_service(service)
+
+    typer.echo(result.packet.model_dump_json(indent=2))
+
+
+@app.command()
+def compile(
+    task: Annotated[
+        str,
+        typer.Option("--task", help="Describe the coding task that needs policy compilation."),
+    ],
+    domain: Annotated[
+        str | None,
+        typer.Option("--domain", help="Optional policy domain such as backend or security."),
+    ] = None,
+    top_k: Annotated[
+        int | None,
+        typer.Option(
+            "--top-k",
+            min=1,
+            max=MAX_TOP_K,
+            help="Selected evidence depth. Allowed range: 1-20.",
+        ),
+    ] = None,
+    task_type: Annotated[
+        TaskType | None,
+        typer.Option(
+            "--task-type",
+            help=(
+                "Optional task-type override. Supported values: bug_fix, refactor, "
+                "api_change, migration, test_change, feature_work, unknown."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Return compiled policy constraints for planning and generation."""
+    settings = get_settings()
+    resolved_top_k = top_k if top_k is not None else settings.default_top_k
+    service = None
+    try:
+        request = CompileRequest(
+            task=task,
+            domain=domain,
+            top_k=resolved_top_k,
+            task_type=task_type,
+        )
+        service = create_policy_compiler_service(settings)
+        result = service.compile(request)
+    except ValidationError as exc:
+        _exit_with_error(_format_validation_error("Compile request", exc))
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:

--- a/src/policynim/providers/__init__.py
+++ b/src/policynim/providers/__init__.py
@@ -1,5 +1,15 @@
 """Provider adapters for PolicyNIM."""
 
-from policynim.providers.nvidia import NVIDIAEmbedder, NVIDIAGenerator, NVIDIAReranker
+from policynim.providers.nvidia import (
+    NVIDIAEmbedder,
+    NVIDIAGenerator,
+    NVIDIAPolicyCompiler,
+    NVIDIAReranker,
+)
 
-__all__ = ["NVIDIAEmbedder", "NVIDIAGenerator", "NVIDIAReranker"]
+__all__ = [
+    "NVIDIAEmbedder",
+    "NVIDIAGenerator",
+    "NVIDIAPolicyCompiler",
+    "NVIDIAReranker",
+]

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -24,7 +24,15 @@ from pydantic import ValidationError
 from policynim.contracts import Embedder, Generator, Reranker
 from policynim.errors import ConfigurationError, ProviderError
 from policynim.settings import Settings
-from policynim.types import GeneratedPreflightDraft, PreflightRequest, ScoredChunk
+from policynim.types import (
+    CompiledPolicyPacket,
+    CompileRequest,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPreflightDraft,
+    PolicySelectionPacket,
+    PreflightRequest,
+    ScoredChunk,
+)
 
 logging.getLogger("openai").setLevel(logging.WARNING)
 logging.getLogger("openai._base_client").setLevel(logging.WARNING)
@@ -324,6 +332,7 @@ class NVIDIAGenerator(Generator):
 
         self._model = model
         self._max_retries = max_retries
+        self._owns_client = client is None
         self._client = client or OpenAI(
             api_key=api_key,
             base_url=base_url,
@@ -346,76 +355,160 @@ class NVIDIAGenerator(Generator):
         self,
         request: PreflightRequest,
         context: Sequence[ScoredChunk],
+        *,
+        compiled_packet: CompiledPolicyPacket | None = None,
     ) -> GeneratedPreflightDraft:
         """Generate a grounded preflight draft from retrieved context."""
-        messages = _build_generation_messages(request, context)
-        content = self._request_generation(messages)
+        messages = _build_generation_messages(request, context, compiled_packet=compiled_packet)
+        content = _request_chat_completion(
+            self._client,
+            model=self._model,
+            messages=messages,
+            max_retries=self._max_retries,
+            operation="grounded generation",
+        )
         return _parse_generation_draft(content)
 
-    def _request_generation(self, messages: list[ChatCompletionMessageParam]) -> str:
-        for attempt in range(self._max_retries + 1):
-            try:
-                response = self._client.chat.completions.create(
-                    model=self._model,
-                    messages=messages,
-                    temperature=0,
-                    top_p=1,
-                )
-                return _extract_chat_content(response)
-            except AuthenticationError as exc:
-                raise _auth_error("grounded generation") from exc
-            except BadRequestError as exc:
-                raise ProviderError(
-                    f"NVIDIA grounded generation request was rejected: {exc}",
-                    failure_class="bad_request",
-                ) from exc
-            except RateLimitError as exc:
-                if attempt < self._max_retries:
+    def close(self) -> None:
+        """Release the owned OpenAI client when supported by the SDK."""
+        if self._owns_client:
+            _close_client(self._client)
+
+
+class NVIDIAPolicyCompiler:
+    """Compiles routed policy evidence into grounded constraint drafts."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int,
+        client: OpenAI | Any | None = None,
+    ) -> None:
+        api_key = api_key.strip()
+        if not api_key:
+            raise ConfigurationError("NVIDIA_API_KEY is required for policy compilation.")
+
+        self._model = model
+        self._max_retries = max_retries
+        self._owns_client = client is None
+        self._client = client or OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout_seconds,
+            max_retries=0,
+        )
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> NVIDIAPolicyCompiler:
+        """Construct a policy compiler from application settings."""
+        return cls(
+            api_key=settings.nvidia_api_key or "",
+            model=settings.nvidia_chat_model,
+            base_url=settings.nvidia_base_url,
+            timeout_seconds=settings.nvidia_timeout_seconds,
+            max_retries=settings.nvidia_max_retries,
+        )
+
+    def compile_policy_packet(
+        self,
+        request: CompileRequest,
+        selection_packet: PolicySelectionPacket,
+        context: Sequence[ScoredChunk],
+    ) -> GeneratedCompiledPolicyDraft:
+        """Compile a routed policy-selection packet into grounded constraints."""
+        messages = _build_policy_compiler_messages(request, selection_packet, context)
+        content = _request_chat_completion(
+            self._client,
+            model=self._model,
+            messages=messages,
+            max_retries=self._max_retries,
+            operation="policy compilation",
+        )
+        return _parse_compiled_policy_draft(content)
+
+    def close(self) -> None:
+        """Release the owned OpenAI client when supported by the SDK."""
+        if self._owns_client:
+            _close_client(self._client)
+
+
+def _request_chat_completion(
+    client: OpenAI | Any,
+    *,
+    model: str,
+    messages: list[ChatCompletionMessageParam],
+    max_retries: int,
+    operation: str,
+) -> str:
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0,
+                top_p=1,
+            )
+            return _extract_chat_content(response, operation=operation)
+        except AuthenticationError as exc:
+            raise _auth_error(operation) from exc
+        except BadRequestError as exc:
+            raise ProviderError(
+                f"NVIDIA {operation} request was rejected: {exc}",
+                failure_class="bad_request",
+            ) from exc
+        except RateLimitError as exc:
+            if attempt < max_retries:
+                continue
+            raise ProviderError(
+                f"NVIDIA {operation} request failed after retries.",
+                failure_class="rate_limit",
+            ) from exc
+        except APIStatusError as exc:
+            if exc.status_code in {401, 403}:
+                raise _auth_error(operation) from exc
+            if exc.status_code == 429:
+                if attempt < max_retries:
                     continue
                 raise ProviderError(
-                    "NVIDIA grounded generation request failed after retries.",
+                    f"NVIDIA {operation} request failed after retries.",
                     failure_class="rate_limit",
                 ) from exc
-            except APIStatusError as exc:
-                if exc.status_code in {401, 403}:
-                    raise _auth_error("grounded generation") from exc
-                if exc.status_code == 429:
-                    if attempt < self._max_retries:
-                        continue
-                    raise ProviderError(
-                        "NVIDIA grounded generation request failed after retries.",
-                        failure_class="rate_limit",
-                    ) from exc
-                if _should_retry_status(exc.status_code) and attempt < self._max_retries:
-                    continue
-                raise ProviderError(
-                    f"NVIDIA grounded generation request failed with status {exc.status_code}.",
-                    failure_class="http_status",
-                ) from exc
-            except APITimeoutError as exc:
-                if attempt < self._max_retries:
-                    continue
-                raise ProviderError(
-                    "NVIDIA grounded generation request failed after retries.",
-                    failure_class="timeout",
-                ) from exc
-            except APIConnectionError as exc:
-                if attempt < self._max_retries:
-                    continue
-                raise ProviderError(
-                    "NVIDIA grounded generation request failed after retries.",
-                    failure_class="connection",
-                ) from exc
-            except Exception as exc:  # pragma: no cover - defensive guard.
-                raise ProviderError(
-                    "Unexpected NVIDIA grounded generation failure.",
-                    failure_class="unexpected",
-                ) from exc
+            if _should_retry_status(exc.status_code) and attempt < max_retries:
+                continue
+            raise ProviderError(
+                f"NVIDIA {operation} request failed with status {exc.status_code}.",
+                failure_class="http_status",
+            ) from exc
+        except APITimeoutError as exc:
+            if attempt < max_retries:
+                continue
+            raise ProviderError(
+                f"NVIDIA {operation} request failed after retries.",
+                failure_class="timeout",
+            ) from exc
+        except APIConnectionError as exc:
+            if attempt < max_retries:
+                continue
+            raise ProviderError(
+                f"NVIDIA {operation} request failed after retries.",
+                failure_class="connection",
+            ) from exc
+        except ProviderError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard.
+            raise ProviderError(
+                f"Unexpected NVIDIA {operation} failure.",
+                failure_class="unexpected",
+            ) from exc
 
-        raise ProviderError(
-            "NVIDIA grounded generation request failed after retries.",
-            failure_class="unexpected",
-        )
+    raise ProviderError(
+        f"NVIDIA {operation} request failed after retries.",
+        failure_class="unexpected",
+    )
 
 
 def _auth_error(operation: str) -> ConfigurationError:
@@ -550,6 +643,8 @@ def _extract_row_score(row: dict[str, Any]) -> float:
 def _build_generation_messages(
     request: PreflightRequest,
     context: Sequence[ScoredChunk],
+    *,
+    compiled_packet: CompiledPolicyPacket | None,
 ) -> list[ChatCompletionMessageParam]:
     system_prompt = (
         "You are PolicyNIM's grounded policy synthesis engine.\n"
@@ -565,6 +660,7 @@ def _build_generation_messages(
         '      "citation_ids": ["chunk-id"]\n'
         "    }\n"
         "  ],\n"
+        '  "plan_steps": ["string"],\n'
         '  "implementation_guidance": ["string"],\n'
         '  "review_flags": ["string"],\n'
         '  "tests_required": ["string"],\n'
@@ -576,12 +672,21 @@ def _build_generation_messages(
         "- Do not invent new chunk IDs.\n"
         "- If the evidence is insufficient, set insufficient_context to true and "
         "keep the lists empty.\n"
+        "- When compiled policy constraints are provided, use them as the main "
+        "planning and implementation requirements.\n"
         "- Keep the summary concise and task-specific."
+    )
+    compiled_constraints = (
+        _format_compiled_policy_packet(compiled_packet)
+        if compiled_packet is not None
+        else "(no compiled policy constraints provided)"
     )
     user_prompt = (
         f"Task: {request.task}\n"
         f"Domain: {request.domain or 'none'}\n"
         f"Target top_k: {request.top_k}\n"
+        "Compiled policy constraints:\n"
+        f"{compiled_constraints}\n"
         "Retrieved context:\n"
         f"{_format_generation_context(context)}"
     )
@@ -614,11 +719,76 @@ def _format_generation_context(context: Sequence[ScoredChunk]) -> str:
     return "\n\n".join(blocks)
 
 
-def _extract_chat_content(response: Any) -> str:
+def _build_policy_compiler_messages(
+    request: CompileRequest,
+    selection_packet: PolicySelectionPacket,
+    context: Sequence[ScoredChunk],
+) -> list[ChatCompletionMessageParam]:
+    system_prompt = (
+        "You are PolicyNIM's policy compiler.\n"
+        "Return ONLY valid JSON. Do not use markdown fences or commentary.\n"
+        "The JSON must match this shape exactly:\n"
+        "{\n"
+        '  "required_steps": [{"statement": "string", "citation_ids": ["chunk-id"]}],\n'
+        '  "forbidden_patterns": [{"statement": "string", "citation_ids": ["chunk-id"]}],\n'
+        '  "architectural_expectations": ['
+        '{"statement": "string", "citation_ids": ["chunk-id"]}],\n'
+        '  "test_expectations": [{"statement": "string", "citation_ids": ["chunk-id"]}],\n'
+        '  "style_constraints": [{"statement": "string", "citation_ids": ["chunk-id"]}],\n'
+        '  "insufficient_context": false\n'
+        "}\n"
+        "Rules:\n"
+        "- Cite only by chunk_id values that appear in the provided retained context.\n"
+        "- Do not invent chunk IDs, policy IDs, files, or requirements.\n"
+        "- Include a constraint only when the retained evidence directly supports it.\n"
+        "- If evidence is weak or unsupported, set insufficient_context to true and "
+        "leave every constraint list empty.\n"
+        "- Keep constraint statements concrete and task-specific."
+    )
+    user_prompt = (
+        f"Task: {request.task}\n"
+        f"Domain: {request.domain or 'none'}\n"
+        f"Target top_k: {request.top_k}\n"
+        f"Task type: {selection_packet.task_type}\n"
+        "Selected policy packet:\n"
+        f"{selection_packet.model_dump_json(indent=2)}\n"
+        "Retained context:\n"
+        f"{_format_generation_context(context)}"
+    )
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+def _format_compiled_policy_packet(compiled_packet: CompiledPolicyPacket) -> str:
+    if compiled_packet.insufficient_context:
+        return "(compiled policy packet has insufficient context)"
+
+    blocks: list[str] = []
+    categories = (
+        ("required_steps", compiled_packet.required_steps),
+        ("forbidden_patterns", compiled_packet.forbidden_patterns),
+        ("architectural_expectations", compiled_packet.architectural_expectations),
+        ("test_expectations", compiled_packet.test_expectations),
+        ("style_constraints", compiled_packet.style_constraints),
+    )
+    for category_name, constraints in categories:
+        if not constraints:
+            continue
+        blocks.append(f"{category_name}:")
+        for constraint in constraints:
+            blocks.append(
+                f"- {constraint.statement} (citations: {', '.join(constraint.citation_ids)})"
+            )
+    return "\n".join(blocks) if blocks else "(no compiled constraints)"
+
+
+def _extract_chat_content(response: Any, *, operation: str) -> str:
     choices = getattr(response, "choices", [])
     if not choices:
         raise ProviderError(
-            "NVIDIA grounded generation returned no choices.",
+            f"NVIDIA {operation} returned no choices.",
             failure_class="invalid_response",
         )
 
@@ -626,30 +796,51 @@ def _extract_chat_content(response: Any) -> str:
     content = getattr(message, "content", None)
     if not isinstance(content, str) or not content.strip():
         raise ProviderError(
-            "NVIDIA grounded generation returned an empty response.",
+            f"NVIDIA {operation} returned an empty response.",
             failure_class="invalid_response",
         )
     return content
 
 
 def _parse_generation_draft(content: str) -> GeneratedPreflightDraft:
+    json_object = _parse_json_object_response(content, operation="grounded generation")
     try:
-        payload = json.loads(content)
-    except json.JSONDecodeError as exc:
-        payload = _extract_embedded_json_object(content)
-        if payload is None:
-            raise ProviderError(
-                "NVIDIA grounded generation returned invalid JSON.",
-                failure_class="invalid_response",
-            ) from exc
-
-    try:
-        return GeneratedPreflightDraft.model_validate(payload)
+        return GeneratedPreflightDraft.model_validate(json_object)
     except ValidationError as exc:
         raise ProviderError(
             "NVIDIA grounded generation returned malformed JSON.",
             failure_class="invalid_response",
         ) from exc
+
+
+def _parse_compiled_policy_draft(content: str) -> GeneratedCompiledPolicyDraft:
+    json_object = _parse_json_object_response(content, operation="policy compilation")
+    try:
+        return GeneratedCompiledPolicyDraft.model_validate(json_object)
+    except ValidationError as exc:
+        raise ProviderError(
+            "NVIDIA policy compilation returned malformed JSON.",
+            failure_class="invalid_response",
+        ) from exc
+
+
+def _parse_json_object_response(content: str, *, operation: str) -> dict[str, Any]:
+    try:
+        json_object = json.loads(content)
+    except json.JSONDecodeError as exc:
+        json_object = _extract_embedded_json_object(content)
+        if json_object is None:
+            raise ProviderError(
+                f"NVIDIA {operation} returned invalid JSON.",
+                failure_class="invalid_response",
+            ) from exc
+
+    if not isinstance(json_object, dict):
+        raise ProviderError(
+            f"NVIDIA {operation} returned malformed JSON.",
+            failure_class="invalid_response",
+        )
+    return json_object
 
 
 def _extract_embedded_json_object(content: str) -> dict[str, Any] | None:
@@ -664,3 +855,9 @@ def _extract_embedded_json_object(content: str) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _close_client(client: object) -> None:
+    close = getattr(client, "close", None)
+    if callable(close):
+        close()

--- a/src/policynim/services/__init__.py
+++ b/src/policynim/services/__init__.py
@@ -1,6 +1,7 @@
 """Application services for PolicyNIM."""
 
 from policynim.services.beta_auth import BetaAuthService, create_beta_auth_service
+from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
 from policynim.services.dump import IndexDumpService, create_index_dump_service
 from policynim.services.eval import EvalService, create_eval_service
 from policynim.services.health import (
@@ -31,6 +32,7 @@ __all__ = [
     "IndexDumpService",
     "IngestService",
     "PreflightService",
+    "PolicyCompilerService",
     "PolicyRouterService",
     "RuntimeDecisionService",
     "RuntimeEvidenceReportService",
@@ -38,6 +40,7 @@ __all__ = [
     "RuntimeHealthService",
     "SearchService",
     "create_beta_auth_service",
+    "create_policy_compiler_service",
     "create_eval_service",
     "create_runtime_decision_service",
     "create_runtime_evidence_report_service",

--- a/src/policynim/services/compiler.py
+++ b/src/policynim/services/compiler.py
@@ -1,0 +1,264 @@
+"""Policy compiler service for citation-backed planning constraints."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import TracebackType
+
+from policynim.contracts import Embedder, IndexStore, PolicyCompiler, Reranker
+from policynim.services.router import PolicyRouterService, create_policy_router_service
+from policynim.settings import Settings, get_settings
+from policynim.types import (
+    Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    CompileRequest,
+    CompileResult,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConstraint,
+    PolicySelectionPacket,
+    RouteRequest,
+    ScoredChunk,
+)
+
+
+class PolicyCompilerService:
+    """Route policy evidence and compile it into grounded constraint packets."""
+
+    def __init__(
+        self,
+        *,
+        compiler: PolicyCompiler,
+        router: PolicyRouterService | None = None,
+        embedder: Embedder | None = None,
+        index_store: IndexStore | None = None,
+        reranker: Reranker | None = None,
+    ) -> None:
+        if router is None:
+            if embedder is None or index_store is None or reranker is None:
+                raise ValueError(
+                    "PolicyCompilerService requires either a router or "
+                    "embedder/index_store/reranker."
+                )
+            router = PolicyRouterService(
+                embedder=embedder,
+                index_store=index_store,
+                reranker=reranker,
+            )
+        self._router = router
+        self._compiler = compiler
+
+    def __enter__(self) -> PolicyCompilerService:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release owned provider resources held by this service."""
+        _close_component(self._router)
+        _close_component(self._compiler)
+
+    def compile(self, request: CompileRequest) -> CompileResult:
+        """Compile routed policy evidence into a grounded policy packet."""
+        route_result = self._router.route(
+            RouteRequest(
+                task=request.task,
+                domain=request.domain,
+                top_k=request.top_k,
+                task_type=request.task_type,
+            )
+        )
+        selection_packet = route_result.packet
+        if selection_packet.insufficient_context or not route_result.retained_context:
+            return CompileResult(
+                packet=_insufficient_packet_from_selection(selection_packet),
+                retained_context=route_result.retained_context,
+            )
+
+        generated_draft = self._compiler.compile_policy_packet(
+            request,
+            selection_packet,
+            route_result.retained_context,
+        )
+        compiled_packet = _materialize_compiled_packet(
+            selection_packet,
+            route_result.retained_context,
+            generated_draft,
+        )
+        return CompileResult(
+            packet=compiled_packet,
+            retained_context=route_result.retained_context,
+        )
+
+
+def create_policy_compiler_service(settings: Settings | None = None) -> PolicyCompilerService:
+    """Build the default policy compiler service from application settings."""
+    active_settings = settings or get_settings()
+    router = create_policy_router_service(active_settings)
+    compiler = _create_default_policy_compiler(active_settings)
+    return PolicyCompilerService(
+        router=router,
+        compiler=compiler,
+    )
+
+
+def _create_default_policy_compiler(settings: Settings) -> PolicyCompiler:
+    from policynim.providers import NVIDIAPolicyCompiler
+
+    return NVIDIAPolicyCompiler.from_settings(settings)
+
+
+def _materialize_compiled_packet(
+    selection_packet: PolicySelectionPacket,
+    retained_context: Sequence[ScoredChunk],
+    generated_draft: GeneratedCompiledPolicyDraft,
+) -> CompiledPolicyPacket:
+    if generated_draft.insufficient_context:
+        return _insufficient_packet_from_selection(selection_packet)
+
+    context_by_id = {chunk.chunk_id: chunk for chunk in retained_context}
+    if not context_by_id:
+        return _insufficient_packet_from_selection(selection_packet)
+
+    required_steps = _compile_constraint_list(generated_draft.required_steps, context_by_id)
+    forbidden_patterns = _compile_constraint_list(
+        generated_draft.forbidden_patterns,
+        context_by_id,
+    )
+    architectural_expectations = _compile_constraint_list(
+        generated_draft.architectural_expectations,
+        context_by_id,
+    )
+    test_expectations = _compile_constraint_list(generated_draft.test_expectations, context_by_id)
+    style_constraints = _compile_constraint_list(generated_draft.style_constraints, context_by_id)
+    compiled_categories = [
+        required_steps,
+        forbidden_patterns,
+        architectural_expectations,
+        test_expectations,
+        style_constraints,
+    ]
+    if any(category is None for category in compiled_categories):
+        return _insufficient_packet_from_selection(selection_packet)
+
+    all_constraints = [
+        constraint
+        for category in compiled_categories
+        if category is not None
+        for constraint in category
+    ]
+    if not all_constraints:
+        return _insufficient_packet_from_selection(selection_packet)
+
+    citation_ids = _ordered_unique(
+        [citation_id for constraint in all_constraints for citation_id in constraint.citation_ids]
+    )
+    citations = [_citation_from_chunk(context_by_id[citation_id]) for citation_id in citation_ids]
+    if not citations:
+        return _insufficient_packet_from_selection(selection_packet)
+
+    return CompiledPolicyPacket(
+        task=selection_packet.task,
+        domain=selection_packet.domain,
+        top_k=selection_packet.top_k,
+        task_type=selection_packet.task_type,
+        explicit_task_type=selection_packet.explicit_task_type,
+        profile_signals=list(selection_packet.profile_signals),
+        selected_policies=list(selection_packet.selected_policies),
+        required_steps=required_steps or [],
+        forbidden_patterns=forbidden_patterns or [],
+        architectural_expectations=architectural_expectations or [],
+        test_expectations=test_expectations or [],
+        style_constraints=style_constraints or [],
+        citations=citations,
+        insufficient_context=False,
+    )
+
+
+def _compile_constraint_list(
+    generated_constraints: Sequence[GeneratedPolicyConstraint],
+    context_by_id: dict[str, ScoredChunk],
+) -> list[CompiledPolicyConstraint] | None:
+    compiled_constraints: list[CompiledPolicyConstraint] = []
+    for generated_constraint in generated_constraints:
+        statement = generated_constraint.statement.strip()
+        citation_ids = _ordered_unique(
+            [citation_id.strip() for citation_id in generated_constraint.citation_ids]
+        )
+        if not statement or not citation_ids:
+            return None
+        if any(citation_id not in context_by_id for citation_id in citation_ids):
+            return None
+
+        source_policy_ids = _ordered_unique(
+            [context_by_id[citation_id].policy.policy_id for citation_id in citation_ids]
+        )
+        compiled_constraints.append(
+            CompiledPolicyConstraint(
+                statement=statement,
+                citation_ids=citation_ids,
+                source_policy_ids=source_policy_ids,
+            )
+        )
+    return compiled_constraints
+
+
+def _insufficient_packet_from_selection(
+    selection_packet: PolicySelectionPacket,
+) -> CompiledPolicyPacket:
+    return CompiledPolicyPacket(
+        task=selection_packet.task,
+        domain=selection_packet.domain,
+        top_k=selection_packet.top_k,
+        task_type=selection_packet.task_type,
+        explicit_task_type=selection_packet.explicit_task_type,
+        profile_signals=list(selection_packet.profile_signals),
+        selected_policies=list(selection_packet.selected_policies),
+        required_steps=[],
+        forbidden_patterns=[],
+        architectural_expectations=[],
+        test_expectations=[],
+        style_constraints=[],
+        citations=[],
+        insufficient_context=True,
+    )
+
+
+def _citation_from_chunk(chunk: ScoredChunk) -> Citation:
+    return Citation(
+        policy_id=chunk.policy.policy_id,
+        title=chunk.policy.title,
+        path=chunk.path,
+        section=chunk.section,
+        lines=chunk.lines,
+        chunk_id=chunk.chunk_id,
+    )
+
+
+def _ordered_unique(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()
+
+
+__all__ = [
+    "PolicyCompilerService",
+    "create_policy_compiler_service",
+]

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -25,6 +25,8 @@ from policynim.services.search import SearchService
 from policynim.settings import Settings, get_settings
 from policynim.storage import LanceDBIndexStore
 from policynim.types import (
+    CompiledPolicyPacket,
+    CompileRequest,
     EvalAggregateMetrics,
     EvalCase,
     EvalCaseMetrics,
@@ -34,10 +36,13 @@ from policynim.types import (
     EvalModeRunResult,
     EvalRunResult,
     EvalSuite,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConstraint,
     GeneratedPolicyGuidance,
     GeneratedPreflightDraft,
     PolicyChunk,
     PolicyMetadata,
+    PolicySelectionPacket,
     PreflightRequest,
     PreflightResult,
     ScoredChunk,
@@ -190,6 +195,7 @@ class EvalService:
             index_store=store,
             reranker=_OfflineReranker() if rerank_enabled else _PassThroughReranker(),
             generator=_OfflineGenerator(),
+            compiler=_OfflinePolicyCompiler(),
         )
         try:
             return _score_suite_cases(
@@ -693,7 +699,12 @@ def _create_live_preflight_service(
     *,
     rerank_enabled: bool,
 ) -> PreflightService:
-    from policynim.providers import NVIDIAEmbedder, NVIDIAGenerator, NVIDIAReranker
+    from policynim.providers import (
+        NVIDIAEmbedder,
+        NVIDIAGenerator,
+        NVIDIAPolicyCompiler,
+        NVIDIAReranker,
+    )
 
     return PreflightService(
         embedder=NVIDIAEmbedder.from_settings(settings),
@@ -705,6 +716,7 @@ def _create_live_preflight_service(
             NVIDIAReranker.from_settings(settings) if rerank_enabled else _PassThroughReranker()
         ),
         generator=NVIDIAGenerator.from_settings(settings),
+        compiler=NVIDIAPolicyCompiler.from_settings(settings),
     )
 
 
@@ -816,7 +828,10 @@ class _OfflineGenerator(Generator):
         self,
         request: PreflightRequest,
         context: Sequence[ScoredChunk],
+        *,
+        compiled_packet: CompiledPolicyPacket | None = None,
     ) -> GeneratedPreflightDraft:
+        del compiled_packet
         context_by_id = {chunk.chunk_id: chunk for chunk in context}
         if request.task == "Implement a refresh-token cleanup background job":
             return _cleanup_job_draft(context_by_id)
@@ -839,6 +854,66 @@ class _OfflineGenerator(Generator):
                 citation_ids=["BACKEND-LOG-1"],
             )
         return _insufficient_draft()
+
+    def close(self) -> None:
+        return None
+
+
+class _OfflinePolicyCompiler:
+    """Produce deterministic compiled constraints from retained offline context."""
+
+    def compile_policy_packet(
+        self,
+        request: CompileRequest,
+        selection_packet: PolicySelectionPacket,
+        context: Sequence[ScoredChunk],
+    ) -> GeneratedCompiledPolicyDraft:
+        del request, selection_packet
+        context_by_id = {chunk.chunk_id: chunk for chunk in context}
+        required_steps: list[GeneratedPolicyConstraint] = []
+        test_expectations: list[GeneratedPolicyConstraint] = []
+        forbidden_patterns: list[GeneratedPolicyConstraint] = []
+
+        if "BACKGROUND-JOB-1" in context_by_id:
+            required_steps.append(
+                GeneratedPolicyConstraint(
+                    statement="Make the cleanup job idempotent and observable.",
+                    citation_ids=["BACKGROUND-JOB-1"],
+                )
+            )
+            test_expectations.append(
+                GeneratedPolicyConstraint(
+                    statement="Add coverage for repeated cleanup runs.",
+                    citation_ids=["BACKGROUND-JOB-1"],
+                )
+            )
+        if "SECURITY-TOKEN-1" in context_by_id:
+            forbidden_patterns.append(
+                GeneratedPolicyConstraint(
+                    statement="Do not log raw refresh-token values.",
+                    citation_ids=["SECURITY-TOKEN-1"],
+                )
+            )
+            test_expectations.append(
+                GeneratedPolicyConstraint(
+                    statement="Add a test that active tokens are preserved.",
+                    citation_ids=["SECURITY-TOKEN-1"],
+                )
+            )
+        if "BACKEND-LOG-1" in context_by_id:
+            required_steps.append(
+                GeneratedPolicyConstraint(
+                    statement="Thread request ids through log context.",
+                    citation_ids=["BACKEND-LOG-1"],
+                )
+            )
+
+        return GeneratedCompiledPolicyDraft(
+            required_steps=required_steps,
+            forbidden_patterns=forbidden_patterns,
+            test_expectations=test_expectations,
+            insufficient_context=not (required_steps or forbidden_patterns or test_expectations),
+        )
 
     def close(self) -> None:
         return None

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -6,17 +6,20 @@ from collections.abc import Mapping, Sequence
 from types import TracebackType
 from typing import Any
 
-from policynim.contracts import Embedder, Generator, IndexStore, Reranker
-from policynim.services.router import PolicyRouterService, create_policy_router_service
+from policynim.contracts import Embedder, Generator, IndexStore, PolicyCompiler, Reranker
+from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
+from policynim.services.router import PolicyRouterService
 from policynim.settings import Settings, get_settings
 from policynim.types import (
     Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    CompileRequest,
     GeneratedPolicyGuidance,
     GeneratedPreflightDraft,
     PolicyGuidance,
     PreflightRequest,
     PreflightResult,
-    RouteRequest,
     ScoredChunk,
 )
 
@@ -34,22 +37,37 @@ class PreflightService:
         self,
         *,
         generator: Generator,
+        compiler_service: PolicyCompilerService | None = None,
+        compiler: PolicyCompiler | None = None,
         router: PolicyRouterService | None = None,
         embedder: Embedder | None = None,
         index_store: IndexStore | None = None,
         reranker: Reranker | None = None,
     ) -> None:
-        if router is None:
-            if embedder is None or index_store is None or reranker is None:
+        if compiler_service is None:
+            if compiler is None:
                 raise ValueError(
-                    "PreflightService requires either a router or embedder/index_store/reranker."
+                    "PreflightService requires either a compiler service or a policy compiler."
                 )
-            router = PolicyRouterService(
-                embedder=embedder,
-                index_store=index_store,
-                reranker=reranker,
+            if router is None and (embedder is None or index_store is None or reranker is None):
+                raise ValueError(
+                    "PreflightService requires either a compiler service or "
+                    "router or embedder/index_store/reranker."
+                )
+            if router is None:
+                assert embedder is not None
+                assert index_store is not None
+                assert reranker is not None
+                router = PolicyRouterService(
+                    embedder=embedder,
+                    index_store=index_store,
+                    reranker=reranker,
+                )
+            compiler_service = PolicyCompilerService(
+                router=router,
+                compiler=compiler,
             )
-        self._router = router
+        self._compiler_service = compiler_service
         self._generator = generator
 
     def __enter__(self) -> PreflightService:
@@ -65,20 +83,26 @@ class PreflightService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._router)
+        _close_component(self._compiler_service)
         _close_component(self._generator)
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
-        route_result = self._router.route(
-            RouteRequest(task=request.task, domain=request.domain, top_k=request.top_k)
+        compile_result = self._compiler_service.compile(
+            CompileRequest(task=request.task, domain=request.domain, top_k=request.top_k)
         )
-        if route_result.packet.insufficient_context or not route_result.retained_context:
+        compiled_packet = compile_result.packet
+        if compiled_packet.insufficient_context or not compile_result.retained_context:
             return _insufficient_context_result(request)
 
-        retained_context = route_result.retained_context
-        generated = self._generator.generate_preflight(request, retained_context)
+        retained_context = compile_result.retained_context
+        generated = self._generator.generate_preflight(
+            request,
+            retained_context,
+            compiled_packet=compiled_packet,
+        )
         draft = _coerce_generated_draft(generated)
+        draft = _apply_compiled_packet_to_draft(draft, compiled_packet)
         validated = _validate_and_materialize_result(request, retained_context, draft)
         if validated is None:
             return _insufficient_context_result(request)
@@ -88,10 +112,10 @@ class PreflightService:
 def create_preflight_service(settings: Settings | None = None) -> PreflightService:
     """Build the default preflight service from application settings."""
     active_settings = settings or get_settings()
-    router = create_policy_router_service(active_settings)
+    compiler_service = create_policy_compiler_service(active_settings)
     generator = _create_default_generator(active_settings)
     return PreflightService(
-        router=router,
+        compiler_service=compiler_service,
         generator=generator,
     )
 
@@ -114,6 +138,7 @@ def _coerce_generated_draft(generated: Any) -> GeneratedPreflightDraft:
             _coerce_generated_policy_guidance(item)
             for item in getattr(generated, "applicable_policies", [])
         ],
+        "plan_steps": list(getattr(generated, "plan_steps", [])),
         "implementation_guidance": list(getattr(generated, "implementation_guidance", [])),
         "review_flags": list(getattr(generated, "review_flags", [])),
         "tests_required": list(getattr(generated, "tests_required", [])),
@@ -201,6 +226,7 @@ def _validate_and_materialize_result(
         domain=request.domain,
         summary=draft.summary,
         applicable_policies=applicable_policies,
+        plan_steps=list(draft.plan_steps),
         implementation_guidance=list(draft.implementation_guidance),
         review_flags=list(draft.review_flags),
         tests_required=list(draft.tests_required),
@@ -215,6 +241,7 @@ def _insufficient_context_result(request: PreflightRequest) -> PreflightResult:
         domain=request.domain,
         summary=_INSUFFICIENT_CONTEXT_SUMMARY,
         applicable_policies=[],
+        plan_steps=[],
         implementation_guidance=[],
         review_flags=[],
         tests_required=[],
@@ -232,6 +259,49 @@ def _ordered_unique(values: Sequence[str]) -> list[str]:
         seen.add(value)
         ordered.append(value)
     return ordered
+
+
+def _apply_compiled_packet_to_draft(
+    draft: GeneratedPreflightDraft,
+    compiled_packet: CompiledPolicyPacket,
+) -> GeneratedPreflightDraft:
+    if compiled_packet.insufficient_context:
+        return draft
+
+    compiled_plan_steps = _constraint_statements(compiled_packet.required_steps)
+    compiled_guidance = _constraint_statements(
+        [
+            *compiled_packet.architectural_expectations,
+            *compiled_packet.style_constraints,
+        ]
+    )
+    compiled_review_flags = [
+        f"Avoid: {statement}"
+        for statement in _constraint_statements(compiled_packet.forbidden_patterns)
+    ]
+    compiled_tests = _constraint_statements(compiled_packet.test_expectations)
+    compiled_citation_ids = [citation.chunk_id for citation in compiled_packet.citations]
+    draft_citation_ids = draft.citation_ids or [
+        citation_id for policy in draft.applicable_policies for citation_id in policy.citation_ids
+    ]
+
+    return draft.model_copy(
+        update={
+            "plan_steps": _ordered_unique([*compiled_plan_steps, *draft.plan_steps]),
+            "implementation_guidance": _ordered_unique(
+                [*compiled_guidance, *draft.implementation_guidance]
+            ),
+            "review_flags": _ordered_unique([*compiled_review_flags, *draft.review_flags]),
+            "tests_required": _ordered_unique([*compiled_tests, *draft.tests_required]),
+            "citation_ids": _ordered_unique([*draft_citation_ids, *compiled_citation_ids]),
+        }
+    )
+
+
+def _constraint_statements(
+    constraints: Sequence[CompiledPolicyConstraint],
+) -> list[str]:
+    return [constraint.statement for constraint in constraints]
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -526,6 +526,81 @@ class RouteResult(StrictModel):
     retained_context: list[ScoredChunk] = Field(default_factory=list)
 
 
+class CompileRequest(StrictModel):
+    """Policy-compiler request shared by CLI and services."""
+
+    task: str
+    domain: str | None = None
+    top_k: TopK = DEFAULT_TOP_K
+    task_type: TaskType | None = None
+
+    @field_validator("task", mode="before")
+    @classmethod
+    def validate_task(cls, value: object) -> str:
+        """Reject empty compiler tasks before routing."""
+        return _validate_non_empty_string(value, field_name="task")
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def validate_domain(cls, value: object) -> str | None:
+        """Reject empty domain filters while preserving omitted filters."""
+        if value is None:
+            return None
+        return _validate_non_empty_string(value, field_name="domain")
+
+
+class GeneratedPolicyConstraint(StrictModel):
+    """One untrusted model-generated policy constraint before local grounding."""
+
+    statement: str
+    citation_ids: list[str] = Field(default_factory=list)
+
+
+class GeneratedCompiledPolicyDraft(StrictModel):
+    """Untrusted compiler draft returned by the NVIDIA policy compiler."""
+
+    required_steps: list[GeneratedPolicyConstraint] = Field(default_factory=list)
+    forbidden_patterns: list[GeneratedPolicyConstraint] = Field(default_factory=list)
+    architectural_expectations: list[GeneratedPolicyConstraint] = Field(default_factory=list)
+    test_expectations: list[GeneratedPolicyConstraint] = Field(default_factory=list)
+    style_constraints: list[GeneratedPolicyConstraint] = Field(default_factory=list)
+    insufficient_context: bool = False
+
+
+class CompiledPolicyConstraint(StrictModel):
+    """One locally validated policy constraint with grounded source policy IDs."""
+
+    statement: str = Field(min_length=1)
+    citation_ids: list[str] = Field(min_length=1)
+    source_policy_ids: list[str] = Field(min_length=1)
+
+
+class CompiledPolicyPacket(StrictModel):
+    """Citation-backed policy constraints for planning and generation."""
+
+    task: str
+    domain: str | None = None
+    top_k: int
+    task_type: TaskType
+    explicit_task_type: TaskType | None = None
+    profile_signals: list[str] = Field(default_factory=list)
+    selected_policies: list[SelectedPolicy] = Field(default_factory=list)
+    required_steps: list[CompiledPolicyConstraint] = Field(default_factory=list)
+    forbidden_patterns: list[CompiledPolicyConstraint] = Field(default_factory=list)
+    architectural_expectations: list[CompiledPolicyConstraint] = Field(default_factory=list)
+    test_expectations: list[CompiledPolicyConstraint] = Field(default_factory=list)
+    style_constraints: list[CompiledPolicyConstraint] = Field(default_factory=list)
+    citations: list[Citation] = Field(default_factory=list)
+    insufficient_context: bool = False
+
+
+class CompileResult(StrictModel):
+    """Internal compile result with packet JSON and generator-ready context."""
+
+    packet: CompiledPolicyPacket
+    retained_context: list[ScoredChunk] = Field(default_factory=list)
+
+
 class IngestResult(StrictModel):
     """Summary of one completed ingest run."""
 
@@ -640,6 +715,7 @@ class GeneratedPreflightDraft(StrictModel):
 
     summary: str
     applicable_policies: list[GeneratedPolicyGuidance] = Field(default_factory=list)
+    plan_steps: list[str] = Field(default_factory=list)
     implementation_guidance: list[str] = Field(default_factory=list)
     review_flags: list[str] = Field(default_factory=list)
     tests_required: list[str] = Field(default_factory=list)
@@ -654,6 +730,7 @@ class PreflightResult(StrictModel):
     domain: str | None = None
     summary: str
     applicable_policies: list[PolicyGuidance] = Field(default_factory=list)
+    plan_steps: list[str] = Field(default_factory=list)
     implementation_guidance: list[str] = Field(default_factory=list)
     review_flags: list[str] = Field(default_factory=list)
     tests_required: list[str] = Field(default_factory=list)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,10 +17,13 @@ Current automated coverage includes:
 - Day 4 grounded preflight orchestration, citation validation, and fallback behavior
 - Build 1 task-aware routing, task-profile inference, selected-policy grouping,
   and weak-evidence fallback behavior
+- Build 2 policy compilation, compiled constraint citation validation,
+  fail-closed handling, and preflight conditioning
 - Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
-- NVIDIA response-validation coverage for malformed grounded-generation and reranking payloads
-- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, and JSON-first
-  `preflight`
+- NVIDIA response-validation coverage for malformed grounded-generation,
+  policy-compilation, and reranking payloads
+- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
+  `compile`, and JSON-first `preflight`
 - CLI output for `eval`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`
 - CLI output for `beta-admin` hosted operator commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,10 @@ from policynim.storage import RuntimeEvidenceStore
 from policynim.types import (
     BetaAccount,
     Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    CompileRequest,
+    CompileResult,
     EvalAggregateMetrics,
     EvalCaseMetrics,
     EvalCaseResult,
@@ -195,6 +199,74 @@ class MockRouteService:
             ),
             retained_context=[],
         )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MockCompileService:
+    """Static compile service for CLI tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.last_request: CompileRequest | None = None
+
+    def compile(self, request: CompileRequest) -> CompileResult:
+        self.last_request = request
+        packet = CompiledPolicyPacket(
+            task=request.task,
+            domain=request.domain,
+            top_k=request.top_k,
+            task_type=request.task_type or "bug_fix",
+            explicit_task_type=request.task_type,
+            profile_signals=(
+                [f"explicit:{request.task_type}"] if request.task_type is not None else ["fix"]
+            ),
+            selected_policies=[
+                SelectedPolicy(
+                    policy_id="SECURITY-TOKEN-001",
+                    title="Token handling",
+                    domain="security",
+                    reason="Selected for bug fix routing from 1 retained evidence chunk(s).",
+                    evidence=[
+                        SelectedPolicyEvidence(
+                            chunk_id="SECURITY-1",
+                            path="policies/security/tokens.md",
+                            section="Rules",
+                            lines="10-16",
+                            text="Never log token values.",
+                            score=0.99,
+                        )
+                    ],
+                )
+            ],
+            required_steps=[
+                CompiledPolicyConstraint(
+                    statement="Preserve token revocation checks.",
+                    citation_ids=["SECURITY-1"],
+                    source_policy_ids=["SECURITY-TOKEN-001"],
+                )
+            ],
+            forbidden_patterns=[
+                CompiledPolicyConstraint(
+                    statement="Do not log raw token values.",
+                    citation_ids=["SECURITY-1"],
+                    source_policy_ids=["SECURITY-TOKEN-001"],
+                )
+            ],
+            citations=[
+                Citation(
+                    policy_id="SECURITY-TOKEN-001",
+                    title="Token handling",
+                    path="policies/security/tokens.md",
+                    section="Rules",
+                    lines="10-16",
+                    chunk_id="SECURITY-1",
+                )
+            ],
+            insufficient_context=False,
+        )
+        return CompileResult(packet=packet, retained_context=[])
 
     def close(self) -> None:
         self.closed = True
@@ -667,6 +739,103 @@ def test_route_command_closes_service_when_it_errors(monkeypatch) -> None:
     assert service.closed is True
 
 
+def test_compile_command_prints_compiled_policy_packet(monkeypatch) -> None:
+    service = MockCompileService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_compiler_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "compile",
+            "--task",
+            "fix token logging bug",
+            "--domain",
+            "security",
+            "--top-k",
+            "2",
+            "--task-type",
+            "bug_fix",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = CompiledPolicyPacket.model_validate(json.loads(result.stdout))
+    assert payload.task == "fix token logging bug"
+    assert payload.domain == "security"
+    assert payload.top_k == 2
+    assert payload.task_type == "bug_fix"
+    assert payload.required_steps[0].statement == "Preserve token revocation checks."
+    assert payload.citations[0].chunk_id == "SECURITY-1"
+    assert service.last_request is not None
+    assert service.last_request.task_type == "bug_fix"
+    assert service.closed is True
+
+
+def test_compile_command_rejects_invalid_task_type() -> None:
+    result = runner.invoke(
+        app,
+        ["compile", "--task", "fix token logging bug", "--task-type", "not-a-task-type"],
+    )
+
+    assert result.exit_code != 0
+    assert "not-a-task-type" in result.output
+
+
+def test_compile_command_formats_request_validation_errors() -> None:
+    result = runner.invoke(app, ["compile", "--task", "   "])
+
+    assert result.exit_code == 1
+    assert "Compile request is invalid at task" in result.stderr
+    assert "task must not be empty" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_compile_command_surfaces_missing_index_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_compiler_service",
+        lambda settings: (_ for _ in ()).throw(
+            MissingIndexError("Run `policynim ingest` before compiling policy constraints.")
+        ),
+    )
+
+    result = runner.invoke(app, ["compile", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert "Run `policynim ingest` before compiling policy constraints." in result.stderr
+
+
+def test_compile_command_surfaces_configuration_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_compiler_service",
+        lambda settings: (_ for _ in ()).throw(ConfigurationError("missing NVIDIA key")),
+    )
+
+    result = runner.invoke(app, ["compile", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert "missing NVIDIA key" in result.stderr
+
+
+def test_compile_command_closes_service_when_it_errors(monkeypatch) -> None:
+    class FailingCompileService(MockCompileService):
+        def compile(self, request: CompileRequest) -> CompileResult:
+            raise MissingIndexError("Run `policynim ingest` before compiling policy constraints.")
+
+    service = FailingCompileService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_policy_compiler_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, ["compile", "--task", "fix token logging bug"])
+
+    assert result.exit_code == 1
+    assert service.closed is True
+
+
 def test_eval_command_prints_json(monkeypatch) -> None:
     service = MockEvalService()
     monkeypatch.setattr(
@@ -842,6 +1011,7 @@ def test_help_includes_runtime_and_evidence_commands() -> None:
     assert "runtime" in help_output
     assert "evidence" in help_output
     assert "route" in help_output
+    assert "compile" in help_output
 
 
 def test_version_flag_prints_installed_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -953,6 +1123,15 @@ def test_init_command_surfaces_unwritable_config_destination(
 
 def test_route_help_mentions_task_type_override() -> None:
     result = runner.invoke(app, ["route", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "--task-type" in help_output
+    assert "Selected evidence depth." in help_output
+
+
+def test_compile_help_mentions_task_type_override() -> None:
+    result = runner.invoke(app, ["compile", "--help"])
     help_output = unstyle(result.stdout)
 
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1228,6 +1228,7 @@ def test_search_command_points_to_ingest_when_config_exists_but_index_is_missing
         (["ingest"], None),
         (["search", "--query", "backend logs"], None),
         (["preflight", "--task", "refresh token cleanup"], None),
+        (["compile", "--task", "refresh token cleanup"], None),
         (["dump-index"], None),
         (["eval", "--headless"], None),
         (

--- a/tests/test_compiler_service.py
+++ b/tests/test_compiler_service.py
@@ -1,0 +1,303 @@
+"""Tests for the Build 2 policy compiler service."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import pytest
+
+from policynim.errors import MissingIndexError
+from policynim.services.compiler import PolicyCompilerService
+from policynim.types import (
+    CompileRequest,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConstraint,
+    PolicyMetadata,
+    PolicySelectionPacket,
+    RouteResult,
+    ScoredChunk,
+    SelectedPolicy,
+    SelectedPolicyEvidence,
+)
+
+
+class MockRouter:
+    """Static router double for compiler tests."""
+
+    def __init__(self, route_result: RouteResult) -> None:
+        self._route_result = route_result
+        self.last_request: object | None = None
+        self.closed = False
+
+    def route(self, request) -> RouteResult:
+        self.last_request = request
+        return self._route_result
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MissingIndexRouter:
+    """Router double that preserves missing-index failures."""
+
+    def route(self, request) -> RouteResult:
+        raise MissingIndexError("Run `policynim ingest` before compiling policy constraints.")
+
+    def close(self) -> None:
+        return None
+
+
+class MockCompiler:
+    """Static policy compiler double for compiler tests."""
+
+    def __init__(self, draft: GeneratedCompiledPolicyDraft) -> None:
+        self._draft = draft
+        self.calls = 0
+        self.closed = False
+
+    def compile_policy_packet(
+        self,
+        request: CompileRequest,
+        selection_packet: PolicySelectionPacket,
+        context: Sequence[ScoredChunk],
+    ) -> GeneratedCompiledPolicyDraft:
+        self.calls += 1
+        assert request.task == selection_packet.task
+        assert context
+        return self._draft
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_compiler_service_materializes_grounded_constraints_and_citations() -> None:
+    route_result = make_route_result()
+    compiler = MockCompiler(
+        GeneratedCompiledPolicyDraft(
+            required_steps=[
+                GeneratedPolicyConstraint(
+                    statement="Thread request ids through backend log context.",
+                    citation_ids=["BACKEND-1"],
+                )
+            ],
+            forbidden_patterns=[
+                GeneratedPolicyConstraint(
+                    statement="Do not log raw token values.",
+                    citation_ids=["SECURITY-1"],
+                )
+            ],
+            architectural_expectations=[
+                GeneratedPolicyConstraint(
+                    statement="Keep logging changes in the backend service layer.",
+                    citation_ids=["BACKEND-1"],
+                )
+            ],
+            test_expectations=[
+                GeneratedPolicyConstraint(
+                    statement="Add a regression test for token redaction.",
+                    citation_ids=["SECURITY-1"],
+                )
+            ],
+            style_constraints=[
+                GeneratedPolicyConstraint(
+                    statement="Use explicit request-id naming in log fields.",
+                    citation_ids=["BACKEND-1"],
+                )
+            ],
+        )
+    )
+    service = PolicyCompilerService(
+        router=cast(Any, MockRouter(route_result)),
+        compiler=compiler,
+    )
+
+    result = service.compile(CompileRequest(task="fix backend logging bug", top_k=2))
+
+    assert compiler.calls == 1
+    assert not result.packet.insufficient_context
+    assert result.packet.task_type == "bug_fix"
+    assert result.packet.required_steps[0].source_policy_ids == ["BACKEND-LOG-001"]
+    assert result.packet.forbidden_patterns[0].source_policy_ids == ["SECURITY-TOKEN-001"]
+    assert [citation.chunk_id for citation in result.packet.citations] == [
+        "BACKEND-1",
+        "SECURITY-1",
+    ]
+    assert [chunk.chunk_id for chunk in result.retained_context] == ["BACKEND-1", "SECURITY-1"]
+
+
+def test_compiler_service_bypasses_provider_for_insufficient_route_context() -> None:
+    route_result = make_route_result(insufficient_context=True, retained_context=[])
+    compiler = MockCompiler(
+        GeneratedCompiledPolicyDraft(
+            required_steps=[
+                GeneratedPolicyConstraint(statement="Should not run.", citation_ids=["BACKEND-1"])
+            ]
+        )
+    )
+    service = PolicyCompilerService(
+        router=cast(Any, MockRouter(route_result)),
+        compiler=compiler,
+    )
+
+    result = service.compile(CompileRequest(task="unknown task", top_k=1))
+
+    assert compiler.calls == 0
+    assert result.packet.insufficient_context
+    assert result.packet.required_steps == []
+    assert result.retained_context == []
+
+
+def test_compiler_service_fails_closed_for_unknown_citation_ids() -> None:
+    service = PolicyCompilerService(
+        router=cast(Any, MockRouter(make_route_result())),
+        compiler=MockCompiler(
+            GeneratedCompiledPolicyDraft(
+                required_steps=[
+                    GeneratedPolicyConstraint(
+                        statement="Unsupported citation should fail closed.",
+                        citation_ids=["UNKNOWN"],
+                    )
+                ]
+            )
+        ),
+    )
+
+    result = service.compile(CompileRequest(task="fix backend logging bug", top_k=2))
+
+    assert result.packet.insufficient_context
+    assert result.packet.citations == []
+    assert result.packet.required_steps == []
+
+
+@pytest.mark.parametrize(
+    "draft",
+    [
+        GeneratedCompiledPolicyDraft(
+            required_steps=[GeneratedPolicyConstraint(statement="   ", citation_ids=["BACKEND-1"])]
+        ),
+        GeneratedCompiledPolicyDraft(
+            required_steps=[
+                GeneratedPolicyConstraint(statement="Missing citation.", citation_ids=[])
+            ]
+        ),
+        GeneratedCompiledPolicyDraft(),
+    ],
+)
+def test_compiler_service_fails_closed_for_empty_or_unsupported_constraints(
+    draft: GeneratedCompiledPolicyDraft,
+) -> None:
+    service = PolicyCompilerService(
+        router=cast(Any, MockRouter(make_route_result())),
+        compiler=MockCompiler(draft),
+    )
+
+    result = service.compile(CompileRequest(task="fix backend logging bug", top_k=2))
+
+    assert result.packet.insufficient_context
+    assert result.packet.citations == []
+
+
+def test_compiler_service_surfaces_missing_index_errors() -> None:
+    service = PolicyCompilerService(
+        router=cast(Any, MissingIndexRouter()),
+        compiler=MockCompiler(GeneratedCompiledPolicyDraft()),
+    )
+
+    with pytest.raises(MissingIndexError, match="policynim ingest"):
+        service.compile(CompileRequest(task="fix backend logging bug", top_k=2))
+
+
+def test_compiler_service_close_closes_owned_components() -> None:
+    router = MockRouter(make_route_result())
+    compiler = MockCompiler(GeneratedCompiledPolicyDraft())
+    service = PolicyCompilerService(router=cast(Any, router), compiler=compiler)
+
+    service.close()
+
+    assert router.closed is True
+    assert compiler.closed is True
+
+
+def make_route_result(
+    *,
+    insufficient_context: bool = False,
+    retained_context: list[ScoredChunk] | None = None,
+) -> RouteResult:
+    backend = make_chunk(
+        chunk_id="BACKEND-1",
+        policy_id="BACKEND-LOG-001",
+        title="Backend Logging",
+        domain="backend",
+        text="Use request ids in backend logs.",
+    )
+    security = make_chunk(
+        chunk_id="SECURITY-1",
+        policy_id="SECURITY-TOKEN-001",
+        title="Token Handling",
+        domain="security",
+        text="Never log token values.",
+    )
+    selected_policies = [
+        make_selected_policy(backend),
+        make_selected_policy(security),
+    ]
+    selected_context = retained_context if retained_context is not None else [backend, security]
+    if retained_context is None and insufficient_context:
+        selected_context = []
+    return RouteResult(
+        packet=PolicySelectionPacket(
+            task="fix backend logging bug",
+            domain=None,
+            top_k=2,
+            task_type="bug_fix",
+            explicit_task_type=None,
+            profile_signals=["fix", "bug"],
+            selected_policies=selected_policies,
+            insufficient_context=insufficient_context,
+        ),
+        retained_context=selected_context,
+    )
+
+
+def make_selected_policy(chunk: ScoredChunk) -> SelectedPolicy:
+    return SelectedPolicy(
+        policy_id=chunk.policy.policy_id,
+        title=chunk.policy.title,
+        domain=chunk.policy.domain,
+        reason="Selected for compiler tests.",
+        evidence=[
+            SelectedPolicyEvidence(
+                chunk_id=chunk.chunk_id,
+                path=chunk.path,
+                section=chunk.section,
+                lines=chunk.lines,
+                text=chunk.text,
+                score=chunk.score,
+            )
+        ],
+    )
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    policy_id: str,
+    title: str,
+    domain: str,
+    text: str,
+) -> ScoredChunk:
+    return ScoredChunk(
+        chunk_id=chunk_id,
+        path=f"policies/{domain}/policy.md",
+        section="Rules",
+        lines="1-4",
+        text=text,
+        policy=PolicyMetadata(
+            policy_id=policy_id,
+            title=title,
+            doc_type="guidance",
+            domain=domain,
+        ),
+        score=0.99,
+    )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -22,6 +22,8 @@ from policynim.types import (
     BetaAuthDecision,
     Citation,
     EmbeddedChunk,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConstraint,
     GeneratedPreflightDraft,
     HealthCheckResult,
     PolicyChunk,
@@ -648,8 +650,25 @@ def test_call_tool_logs_failure_class_when_policy_preflight_generator_times_out(
             self,
             request: PreflightRequest,
             context: Sequence[ScoredChunk],
+            *,
+            compiled_packet=None,
         ) -> GeneratedPreflightDraft:
+            del compiled_packet
             raise ProviderError("upstream timeout", failure_class="timeout")
+
+    class StaticCompiler:
+        def compile_policy_packet(self, request, selection_packet, context):
+            return GeneratedCompiledPolicyDraft(
+                required_steps=[
+                    GeneratedPolicyConstraint(
+                        statement="Use the retained auth policy.",
+                        citation_ids=["AUTH-1"],
+                    )
+                ]
+            )
+
+        def close(self) -> None:
+            return None
 
     monkeypatch.setattr(
         mcp_module,
@@ -659,6 +678,7 @@ def test_call_tool_logs_failure_class_when_policy_preflight_generator_times_out(
             index_store=StaticIndexStore(),
             reranker=StaticReranker(),
             generator=TimeoutGenerator(),
+            compiler=StaticCompiler(),
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -1,0 +1,308 @@
+"""Tests for the NVIDIA policy compiler adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from openai import RateLimitError
+
+from policynim.errors import ConfigurationError, ProviderError
+from policynim.providers.nvidia import NVIDIAPolicyCompiler
+from policynim.types import (
+    CompileRequest,
+    PolicyMetadata,
+    PolicySelectionPacket,
+    ScoredChunk,
+    SelectedPolicy,
+    SelectedPolicyEvidence,
+)
+
+
+class MockChatCompletions:
+    """Deterministic chat client stub."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=self.content),
+                )
+            ]
+        )
+
+
+class MockOpenAIClient:
+    """OpenAI client stub with the minimum chat surface."""
+
+    def __init__(self, content: str) -> None:
+        self.chat = SimpleNamespace(completions=MockChatCompletions(content))
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeRateLimitError(RateLimitError):
+    """Minimal rate-limit error subclass for provider classification tests."""
+
+    def __init__(self) -> None:
+        Exception.__init__(self, "too many requests")
+        self.status_code = 429
+
+
+class RaisingChatCompletions:
+    """Chat completions stub that always raises the supplied exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def create(self, **kwargs):  # noqa: ANN003
+        raise self._exc
+
+
+class RaisingOpenAIClient:
+    """OpenAI client stub that always fails during chat completion."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.chat = SimpleNamespace(completions=RaisingChatCompletions(exc))
+
+
+def test_policy_compiler_parses_grounded_constraint_json() -> None:
+    client = MockOpenAIClient(
+        """
+        {
+          "required_steps": [
+            {
+              "statement": "Thread request ids through backend log context.",
+              "citation_ids": ["BACKEND-1"]
+            }
+          ],
+          "forbidden_patterns": [
+            {
+              "statement": "Do not log token values.",
+              "citation_ids": ["SECURITY-1"]
+            }
+          ],
+          "architectural_expectations": [],
+          "test_expectations": [],
+          "style_constraints": [],
+          "insufficient_context": false
+        }
+        """
+    )
+    compiler = make_compiler(client)
+
+    result = compiler.compile_policy_packet(
+        CompileRequest(task="fix backend logging bug", top_k=2),
+        make_selection_packet(),
+        make_context(),
+    )
+
+    assert result.required_steps[0].statement == "Thread request ids through backend log context."
+    assert result.required_steps[0].citation_ids == ["BACKEND-1"]
+    assert result.forbidden_patterns[0].citation_ids == ["SECURITY-1"]
+    assert not result.insufficient_context
+
+
+def test_policy_compiler_prompt_includes_allowed_chunk_ids() -> None:
+    client = MockOpenAIClient(
+        '{"required_steps":[{"statement":"Use request ids.","citation_ids":["BACKEND-1"]}]}'
+    )
+    compiler = make_compiler(client)
+
+    compiler.compile_policy_packet(
+        CompileRequest(task="fix backend logging bug", top_k=2),
+        make_selection_packet(),
+        make_context(),
+    )
+
+    messages = client.chat.completions.calls[0]["messages"]
+    prompt_text = "\n".join(str(message["content"]) for message in messages)  # type: ignore[index]
+    assert "BACKEND-1" in prompt_text
+    assert "SECURITY-1" in prompt_text
+    assert "policy_id" in prompt_text
+
+
+def test_policy_compiler_extracts_json_from_reasoning_wrappers() -> None:
+    compiler = make_compiler(
+        MockOpenAIClient(
+            '<think>reasoning</think>{"required_steps":[{"statement":"Use request ids.",'
+            '"citation_ids":["BACKEND-1"]}]}'
+        )
+    )
+
+    result = compiler.compile_policy_packet(
+        CompileRequest(task="task", top_k=1),
+        make_selection_packet(),
+        make_context(),
+    )
+
+    assert result.required_steps[0].citation_ids == ["BACKEND-1"]
+
+
+def test_policy_compiler_rejects_invalid_json_and_preserves_cause() -> None:
+    compiler = make_compiler(MockOpenAIClient("not json"))
+
+    with pytest.raises(ProviderError, match="invalid JSON") as excinfo:
+        compiler.compile_policy_packet(
+            CompileRequest(task="task", top_k=1),
+            make_selection_packet(),
+            make_context(),
+        )
+
+    assert excinfo.value.failure_class == "invalid_response"
+    assert excinfo.value.__cause__ is not None
+
+
+def test_policy_compiler_rejects_invalid_constraint_shape() -> None:
+    compiler = make_compiler(
+        MockOpenAIClient(
+            '{"required_steps":[{"statement":"Use request ids.","citation_ids":"BACKEND-1"}]}'
+        )
+    )
+
+    with pytest.raises(ProviderError, match="malformed JSON") as excinfo:
+        compiler.compile_policy_packet(
+            CompileRequest(task="task", top_k=1),
+            make_selection_packet(),
+            make_context(),
+        )
+
+    assert excinfo.value.failure_class == "invalid_response"
+
+
+def test_policy_compiler_classifies_upstream_rate_limits() -> None:
+    compiler = make_compiler(RaisingOpenAIClient(FakeRateLimitError()))
+
+    with pytest.raises(ProviderError, match="failed after retries") as excinfo:
+        compiler.compile_policy_packet(
+            CompileRequest(task="task", top_k=1),
+            make_selection_packet(),
+            make_context(),
+        )
+
+    assert excinfo.value.failure_class == "rate_limit"
+
+
+def test_policy_compiler_preserves_empty_response_failure_class() -> None:
+    compiler = make_compiler(MockOpenAIClient("   "))
+
+    with pytest.raises(ProviderError, match="empty response") as excinfo:
+        compiler.compile_policy_packet(
+            CompileRequest(task="task", top_k=1),
+            make_selection_packet(),
+            make_context(),
+        )
+
+    assert excinfo.value.failure_class == "invalid_response"
+
+
+def test_policy_compiler_requires_api_key() -> None:
+    with pytest.raises(ConfigurationError, match="NVIDIA_API_KEY"):
+        NVIDIAPolicyCompiler(
+            api_key="   ",
+            model="mock-model",
+            base_url="https://example.invalid/v1",
+            timeout_seconds=1,
+            max_retries=0,
+        )
+
+
+def test_policy_compiler_close_leaves_injected_client_open() -> None:
+    client = MockOpenAIClient('{"required_steps":[]}')
+    compiler = make_compiler(client)
+
+    compiler.close()
+
+    assert client.closed is False
+
+
+def make_compiler(client) -> NVIDIAPolicyCompiler:
+    return NVIDIAPolicyCompiler(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        timeout_seconds=1,
+        max_retries=0,
+        client=client,  # type: ignore[arg-type]
+    )
+
+
+def make_selection_packet() -> PolicySelectionPacket:
+    return PolicySelectionPacket(
+        task="fix backend logging bug",
+        domain=None,
+        top_k=2,
+        task_type="bug_fix",
+        profile_signals=["fix", "bug"],
+        selected_policies=[make_selected_policy(chunk) for chunk in make_context()],
+        insufficient_context=False,
+    )
+
+
+def make_selected_policy(chunk: ScoredChunk) -> SelectedPolicy:
+    return SelectedPolicy(
+        policy_id=chunk.policy.policy_id,
+        title=chunk.policy.title,
+        domain=chunk.policy.domain,
+        reason="Selected for compiler tests.",
+        evidence=[
+            SelectedPolicyEvidence(
+                chunk_id=chunk.chunk_id,
+                path=chunk.path,
+                section=chunk.section,
+                lines=chunk.lines,
+                text=chunk.text,
+                score=chunk.score,
+            )
+        ],
+    )
+
+
+def make_context() -> list[ScoredChunk]:
+    return [
+        make_chunk(
+            chunk_id="BACKEND-1",
+            policy_id="BACKEND-LOG-001",
+            title="Backend Logging",
+            domain="backend",
+            text="Use request ids in backend logs.",
+        ),
+        make_chunk(
+            chunk_id="SECURITY-1",
+            policy_id="SECURITY-TOKEN-001",
+            title="Token Handling",
+            domain="security",
+            text="Never log token values.",
+        ),
+    ]
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    policy_id: str,
+    title: str,
+    domain: str,
+    text: str,
+) -> ScoredChunk:
+    return ScoredChunk(
+        chunk_id=chunk_id,
+        path=f"policies/{domain}/policy.md",
+        section="Rules",
+        lines="1-4",
+        text=text,
+        policy=PolicyMetadata(
+            policy_id=policy_id,
+            title=title,
+            doc_type="guidance",
+            domain=domain,
+        ),
+        score=0.99,
+    )

--- a/tests/test_preflight_service.py
+++ b/tests/test_preflight_service.py
@@ -14,7 +14,10 @@ from policynim.services.preflight import (
 )
 from policynim.types import (
     Citation,
+    CompiledPolicyPacket,
     EmbeddedChunk,
+    GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConstraint,
     PolicyChunk,
     PolicyGuidance,
     PolicyMetadata,
@@ -120,13 +123,42 @@ class MockGenerator:
         self._draft = draft
         self.last_request: PreflightRequest | None = None
         self.last_context: list[ScoredChunk] = []
+        self.last_compiled_packet: CompiledPolicyPacket | None = None
         self.closed = False
 
     def generate_preflight(
-        self, request: PreflightRequest, context: Sequence[ScoredChunk]
+        self,
+        request: PreflightRequest,
+        context: Sequence[ScoredChunk],
+        *,
+        compiled_packet: CompiledPolicyPacket | None = None,
     ) -> GeneratedPreflightDraft:
         self.last_request = request
         self.last_context = list(context)
+        self.last_compiled_packet = compiled_packet
+        return self._draft
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MockPolicyCompiler:
+    """Returns a deterministic compiler draft for preflight tests."""
+
+    def __init__(self, draft: GeneratedCompiledPolicyDraft | None = None) -> None:
+        self._draft = draft or GeneratedCompiledPolicyDraft(
+            required_steps=[
+                GeneratedPolicyConstraint(
+                    statement="Apply Logging to this task.",
+                    citation_ids=["BACKEND-1"],
+                )
+            ]
+        )
+        self.calls = 0
+        self.closed = False
+
+    def compile_policy_packet(self, request, selection_packet, context):
+        self.calls += 1
         return self._draft
 
     def close(self) -> None:
@@ -179,6 +211,7 @@ def test_preflight_service_returns_grounded_result_and_maps_citations() -> None:
         index_store=store,
         reranker=reranker,
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="refresh token cleanup", top_k=2))
@@ -187,6 +220,7 @@ def test_preflight_service_returns_grounded_result_and_maps_citations() -> None:
     assert reranker.last_top_k == 15
     assert generator.last_request is not None
     assert generator.last_request.top_k == 2
+    assert generator.last_compiled_packet is not None
     assert result.summary == "Use request ids and avoid token leakage."
     assert result.applicable_policies == [
         PolicyGuidance(
@@ -221,6 +255,80 @@ def test_preflight_service_returns_grounded_result_and_maps_citations() -> None:
         ),
     ]
     assert not result.insufficient_context
+
+
+def test_preflight_service_merges_compiled_constraints_into_result() -> None:
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.99,
+            )
+        ]
+    )
+    draft = GeneratedPreflightDraft(
+        summary="Use request ids in logs.",
+        applicable_policies=[
+            DraftPolicyGuidance(
+                policy_id="BACKEND-LOG-001",
+                title="Logging",
+                rationale="Use the retained backend logging policy.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+        implementation_guidance=["Keep existing logging behavior."],
+        review_flags=["Review redaction behavior."],
+        tests_required=["Keep existing tests green."],
+        citation_ids=["BACKEND-1"],
+    )
+    generator = MockGenerator(draft)
+    service = PreflightService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        reranker=MockReranker(order=["BACKEND-1"]),
+        generator=generator,
+        compiler=MockPolicyCompiler(),
+    )
+
+    result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
+
+    assert generator.last_compiled_packet is not None
+    assert generator.last_compiled_packet.required_steps
+    assert result.plan_steps == ["Apply Logging to this task."]
+    assert result.implementation_guidance == ["Keep existing logging behavior."]
+    assert result.review_flags == ["Review redaction behavior."]
+    assert result.tests_required == ["Keep existing tests green."]
+
+
+def test_preflight_service_fails_closed_when_compiler_has_insufficient_context() -> None:
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.99,
+            )
+        ]
+    )
+    compiler = MockPolicyCompiler(GeneratedCompiledPolicyDraft(insufficient_context=True))
+    generator = MockGenerator(GeneratedPreflightDraft(summary="Should not be generated."))
+    service = PreflightService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        reranker=MockReranker(order=["BACKEND-1"]),
+        generator=generator,
+        compiler=compiler,
+    )
+
+    result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
+
+    assert compiler.calls == 1
+    assert generator.last_request is None
+    assert result.insufficient_context
+    assert result.plan_steps == []
 
 
 def test_preflight_service_caps_retained_chunks_per_policy() -> None:
@@ -277,6 +385,7 @@ def test_preflight_service_caps_retained_chunks_per_policy() -> None:
         index_store=store,
         reranker=reranker,
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="backend guidance", top_k=4))
@@ -316,6 +425,7 @@ def test_preflight_service_marks_insufficient_context_for_unknown_chunk_ids() ->
         index_store=store,
         reranker=MockReranker(),
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
@@ -356,6 +466,7 @@ def test_preflight_service_marks_insufficient_context_when_generator_cites_nothi
         index_store=store,
         reranker=MockReranker(),
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
@@ -407,6 +518,7 @@ def test_preflight_service_deduplicates_citation_ids_and_preserves_first_seen_or
         index_store=store,
         reranker=MockReranker(order=["BACKEND-1", "SECURITY-1"]),
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="refresh token cleanup", top_k=2))
@@ -447,6 +559,7 @@ def test_preflight_service_invalidates_response_when_policy_citations_disagree_w
         index_store=store,
         reranker=MockReranker(),
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
@@ -486,6 +599,7 @@ def test_preflight_service_uses_policy_citation_ids_when_draft_level_list_is_emp
         index_store=store,
         reranker=MockReranker(),
         generator=generator,
+        compiler=MockPolicyCompiler(),
     )
 
     result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
@@ -501,6 +615,7 @@ def test_preflight_service_requires_existing_index() -> None:
         index_store=store,
         reranker=MockReranker(),
         generator=MockGenerator(GeneratedPreflightDraft(summary="unused")),
+        compiler=MockPolicyCompiler(),
     )
 
     with pytest.raises(MissingIndexError):
@@ -510,6 +625,7 @@ def test_preflight_service_requires_existing_index() -> None:
 def test_preflight_service_close_closes_owned_components() -> None:
     reranker = MockReranker()
     generator = MockGenerator(GeneratedPreflightDraft(summary="unused"))
+    compiler = MockPolicyCompiler()
     service = PreflightService(
         embedder=MockEmbedder(),
         index_store=MockIndexStore(
@@ -517,12 +633,14 @@ def test_preflight_service_close_closes_owned_components() -> None:
         ),
         reranker=reranker,
         generator=generator,
+        compiler=compiler,
     )
 
     service.close()
 
     assert reranker.closed is True
     assert generator.closed is True
+    assert compiler.closed is True
 
 
 def make_chunk(

--- a/tests/test_service_factories.py
+++ b/tests/test_service_factories.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import policynim.services.compiler as compiler_module
 import policynim.services.eval as eval_module
 import policynim.services.ingest as ingest_module
 import policynim.services.preflight as preflight_module
@@ -55,6 +56,7 @@ import policynim.services.eval
 import policynim.services.search
 import policynim.services.preflight
 import policynim.services.router
+import policynim.services.compiler
 import policynim.services.runtime_decision
 import policynim.services.runtime_evidence_report
 import policynim.services.runtime_execution
@@ -139,16 +141,41 @@ def test_create_policy_router_service_builds_default_components(
     assert service._index_store.table_name == settings.lancedb_table
 
 
-def test_create_preflight_service_builds_default_components(
+def test_create_policy_compiler_service_builds_default_components(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     mock_router = object()
+    mock_compiler = object()
+    monkeypatch.setattr(
+        compiler_module,
+        "create_policy_router_service",
+        lambda settings: mock_router,
+    )
+    monkeypatch.setattr(
+        compiler_module,
+        "_create_default_policy_compiler",
+        lambda settings: mock_compiler,
+    )
+
+    settings = Settings(lancedb_uri=tmp_path / "compiler-index")
+
+    service = compiler_module.create_policy_compiler_service(settings)
+
+    assert service._router is mock_router
+    assert service._compiler is mock_compiler
+
+
+def test_create_preflight_service_builds_default_components(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    mock_compiler_service = object()
     mock_generator = object()
     monkeypatch.setattr(
         preflight_module,
-        "create_policy_router_service",
-        lambda settings: mock_router,
+        "create_policy_compiler_service",
+        lambda settings: mock_compiler_service,
     )
     monkeypatch.setattr(
         preflight_module,
@@ -160,7 +187,7 @@ def test_create_preflight_service_builds_default_components(
 
     service = preflight_module.create_preflight_service(settings)
 
-    assert service._router is mock_router
+    assert service._compiler_service is mock_compiler_service
     assert service._generator is mock_generator
 
 


### PR DESCRIPTION
## Summary
- add typed policy compiler contracts and PolicyCompilerService for citation-backed CompiledPolicyPacket output
- add NVIDIA policy compiler adapter and JSON-first `policynim compile` CLI surface
- integrate compiled constraints into preflight plan steps, guidance, review flags, tests, eval wiring, docs, and MCP payload coverage

## Verification
- `uv run pytest -q tests/test_compiler_service.py tests/test_nvidia_policy_compiler.py tests/test_preflight_service.py tests/test_cli.py tests/test_mcp.py tests/test_eval_service.py tests/test_service_factories.py`
- `uv run ruff check`
- `uvx pyright src tests`
- `uv run pytest -q`
- `uv run policynim compile --help`