### PR TITLE
Add Build 3 policy conformance eval backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - Policy compilation into citation-backed planning and generation constraints.
 - Grounded preflight synthesis with compiled plan steps, citation validation, and
   fail-closed fallback.
+- Eval backend selection with optional policy-conformance scoring for compiled
+  plans and preflight outputs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
 - JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,16 +144,20 @@ Evaluation flow:
 1. load the bundled eval suite
 2. run cases against `search` and `preflight`
 3. score results with deterministic checks
-4. compare rerank-enabled and rerank-disabled runs
-5. persist JSON artifacts and HTML reports
-6. optionally start the local Evidently UI
+4. optionally add policy-conformance scoring for preflight cases with
+   `--backend nemo`
+5. compare rerank-enabled and rerank-disabled runs
+6. persist JSON artifacts and HTML reports
+7. optionally start the local Evidently UI
 
 Important evaluation rules:
 
 - offline mode is the default contributor path
 - live mode is opt-in and requires `NVIDIA_API_KEY`
 - live mode uses an isolated temporary LanceDB path
-- scoring is code-based, not LLM-as-judge
+- the default backend is code-scored and does not use LLM-as-judge behavior
+- the `nemo` backend adds deterministic conformance checks plus final-adherence
+  judgment for preflight cases
 - expected chunk recall, policy recall, and insufficient-context accuracy are the
   core tracked metrics
 
@@ -219,8 +223,8 @@ Important evaluation rules:
   sanitized action, and persists immutable evidence events.
 - `RuntimeEvidenceReportService` reads persisted runtime evidence rows and
   returns a typed session summary for the CLI `evidence report` flow.
-- `EvalService` handles gold-case execution, scoring, comparison, and report
-  persistence.
+- `EvalService` handles gold-case execution, backend-aware scoring, conformance
+  scoring, comparison, and report persistence.
 - `IndexDumpService` handles terminal-friendly inspection of stored chunks.
 - `RuntimeHealthService` handles hosted HTTP readiness checks for the local index.
 - `BetaAuthService` handles hosted beta GitHub login, API-key issuance, and
@@ -260,7 +264,7 @@ Important evaluation rules:
 - `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim compile --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim preflight --task ...`
-- `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
+- `policynim eval --mode offline|live [--backend default|nemo] [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
 - `policynim runtime decide --input <path|->`
 - `policynim runtime execute --input <path|->`
@@ -320,6 +324,7 @@ NVIDIA-hosted APIs are used for:
 - reranking retrieved candidates
 - policy compilation for planning and generation constraints
 - grounded generation for preflight
+- live `eval --backend nemo` final-adherence judging
 
 These steps require `NVIDIA_API_KEY`.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -36,9 +36,10 @@ constraints, not setup mistakes.
   JSON logs for auth rejects and MCP tool calls, but there is no tracing or
   metrics pipeline yet.
 
-### NVIDIA Dependency For Live Retrieval
+### NVIDIA Dependency For Live Retrieval And Live Conformance
 
-- `ingest`, `search`, `preflight`, and live eval mode depend on NVIDIA-hosted APIs.
+- `ingest`, `search`, `route`, `compile`, `preflight`, live eval mode, and live
+  `eval --backend nemo` depend on NVIDIA-hosted APIs.
 - There is no offline fallback model path for those live retrieval workflows.
 - Runtime failures related to missing credentials or provider access remain
   explicit operator errors.
@@ -76,8 +77,11 @@ constraints, not setup mistakes.
 
 - The built-in eval suite is deterministic and small.
 - It is useful for regression detection, not for benchmarking broad model quality.
-- Eval scoring checks recall and insufficient-context behavior; it does not attempt
-  to judge prose quality or policy nuance beyond those coded expectations.
+- The default eval backend checks recall and insufficient-context behavior without
+  LLM-as-judge scoring.
+- The `nemo` eval backend adds policy-conformance checks for preflight cases, but
+  it remains a narrow conformance signal rather than a broad benchmark of prose
+  quality or policy nuance.
 
 ### No Separate Review Or Approval Layer
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -13,7 +13,7 @@ reference that used to live in the root README.
 - `policynim route --task "..."`
 - `policynim compile --task "..."`
 - `policynim preflight --task "..."`
-- `policynim eval --mode offline|live [--headless] [--no-compare-rerank]`
+- `policynim eval --mode offline|live [--backend default|nemo] [--headless] [--no-compare-rerank]`
 - `policynim mcp --transport stdio|streamable-http`
 - `policynim runtime decide --input <path|->`
 - `policynim runtime execute --input <path|->`
@@ -170,6 +170,7 @@ uv run policynim eval
 Default behavior:
 
 - runs the bundled eval suite in `offline` mode
+- uses the `default` eval backend unless `--backend nemo` is provided
 - executes rerank-enabled and rerank-disabled runs
 - writes JSON artifacts and HTML reports under `data/evals/workspace`
 - starts the local Evidently UI on `http://localhost:8001`
@@ -179,11 +180,17 @@ Useful variants:
 ```bash
 uv run policynim eval --headless
 uv run policynim eval --no-compare-rerank
+uv run policynim eval --backend nemo --headless
 uv run policynim eval --mode live
+uv run policynim eval --mode live --backend nemo --headless
 ```
 
 `--mode live` requires `NVIDIA_API_KEY` and uses an isolated temporary index so
 it does not overwrite the normal runtime index.
+
+`--backend nemo` adds policy-conformance scoring for preflight eval cases. In
+offline mode it uses deterministic local fixtures; in live mode it reuses the
+configured NVIDIA chat model for final-adherence judgment.
 
 ### 6. Run The MCP Server
 
@@ -359,6 +366,7 @@ PolicyNIM keeps the retrieval stack explicit:
 6. compile selected policy evidence into constraint packets
 7. generate grounded guidance from routed evidence and compiled constraints
 8. validate every citation against retrieved chunks before returning results
+9. optionally score policy conformance during `eval --backend nemo`
 
 The system is designed to fail closed:
 
@@ -429,5 +437,5 @@ uv run policynim ingest
 
 ### Missing NVIDIA Credentials
 
-`ingest`, `search`, `route`, `compile`, `preflight`, and live eval mode require
-`NVIDIA_API_KEY`. Offline eval mode does not.
+`ingest`, `search`, `route`, `compile`, `preflight`, live eval mode, and live
+`eval --backend nemo` require `NVIDIA_API_KEY`. Offline eval mode does not.

--- a/src/policynim/contracts.py
+++ b/src/policynim/contracts.py
@@ -12,8 +12,10 @@ from policynim.types import (
     CompileRequest,
     EmbeddedChunk,
     GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConformanceDraft,
     GeneratedPreflightDraft,
     PolicyChunk,
+    PolicyConformanceRequest,
     PolicySelectionPacket,
     PreflightRequest,
     RuntimeActionRequest,
@@ -73,6 +75,17 @@ class PolicyCompiler(Protocol):
         context: Sequence[ScoredChunk],
     ) -> GeneratedCompiledPolicyDraft:
         """Compile grounded policy evidence into a draft constraint packet."""
+        ...
+
+
+class PolicyConformanceEvaluator(Protocol):
+    """Judges policy conformance for a traced preflight result."""
+
+    def evaluate_policy_conformance(
+        self,
+        request: PolicyConformanceRequest,
+    ) -> GeneratedPolicyConformanceDraft:
+        """Evaluate final and optional trajectory adherence."""
         ...
 
 

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -32,6 +32,7 @@ from policynim.settings import Settings, get_settings
 from policynim.types import (
     MAX_TOP_K,
     CompileRequest,
+    EvalBackend,
     EvalExecutionMode,
     PreflightRequest,
     RouteRequest,
@@ -454,6 +455,13 @@ def eval(
         EvalExecutionMode,
         typer.Option("--mode", help="Eval execution mode. Supported values: offline, live."),
     ] = "offline",
+    backend: Annotated[
+        EvalBackend,
+        typer.Option(
+            "--backend",
+            help="Eval backend. Supported values: default, nemo.",
+        ),
+    ] = "default",
     no_compare_rerank: Annotated[
         bool,
         typer.Option(
@@ -474,7 +482,7 @@ def eval(
     try:
         settings = _load_setup_dependent_settings()
         service = create_eval_service(settings)
-        result = service.run(mode=mode, compare_rerank=not no_compare_rerank)
+        result = service.run(mode=mode, backend=backend, compare_rerank=not no_compare_rerank)
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:

--- a/src/policynim/providers/__init__.py
+++ b/src/policynim/providers/__init__.py
@@ -4,12 +4,14 @@ from policynim.providers.nvidia import (
     NVIDIAEmbedder,
     NVIDIAGenerator,
     NVIDIAPolicyCompiler,
+    NVIDIAPolicyConformanceEvaluator,
     NVIDIAReranker,
 )
 
 __all__ = [
     "NVIDIAEmbedder",
     "NVIDIAGenerator",
+    "NVIDIAPolicyConformanceEvaluator",
     "NVIDIAPolicyCompiler",
     "NVIDIAReranker",
 ]

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -25,10 +25,13 @@ from policynim.contracts import Embedder, Generator, Reranker
 from policynim.errors import ConfigurationError, ProviderError
 from policynim.settings import Settings
 from policynim.types import (
+    CompiledPolicyConstraint,
     CompiledPolicyPacket,
     CompileRequest,
     GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConformanceDraft,
     GeneratedPreflightDraft,
+    PolicyConformanceRequest,
     PolicySelectionPacket,
     PreflightRequest,
     ScoredChunk,
@@ -436,6 +439,67 @@ class NVIDIAPolicyCompiler:
             _close_client(self._client)
 
 
+class NVIDIAPolicyConformanceEvaluator:
+    """Judges policy conformance through NVIDIA chat completions."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int,
+        client: OpenAI | Any | None = None,
+    ) -> None:
+        api_key = api_key.strip()
+        if not api_key:
+            raise ConfigurationError(
+                "NVIDIA_API_KEY is required for policy conformance evaluation."
+            )
+
+        self._model = model
+        self._max_retries = max_retries
+        self._owns_client = client is None
+        self._client = client or OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout_seconds,
+            max_retries=0,
+        )
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> NVIDIAPolicyConformanceEvaluator:
+        """Construct a conformance evaluator from application settings."""
+        return cls(
+            api_key=settings.nvidia_api_key or "",
+            model=settings.nvidia_chat_model,
+            base_url=settings.nvidia_base_url,
+            timeout_seconds=settings.nvidia_timeout_seconds,
+            max_retries=settings.nvidia_max_retries,
+        )
+
+    def evaluate_policy_conformance(
+        self,
+        request: PolicyConformanceRequest,
+    ) -> GeneratedPolicyConformanceDraft:
+        """Judge final and optional trajectory adherence for a preflight trace."""
+        messages = _build_policy_conformance_messages(request)
+        content = _request_chat_completion(
+            self._client,
+            model=self._model,
+            messages=messages,
+            max_retries=self._max_retries,
+            operation="policy conformance evaluation",
+        )
+        return _parse_policy_conformance_draft(content, request)
+
+    def close(self) -> None:
+        """Release the owned OpenAI client when supported by the SDK."""
+        if self._owns_client:
+            _close_client(self._client)
+
+
 def _request_chat_completion(
     client: OpenAI | Any,
     *,
@@ -761,6 +825,76 @@ def _build_policy_compiler_messages(
     ]
 
 
+def _build_policy_conformance_messages(
+    request: PolicyConformanceRequest,
+) -> list[ChatCompletionMessageParam]:
+    system_prompt = (
+        "You are PolicyNIM's policy conformance evaluator.\n"
+        "Return ONLY valid JSON. Do not use markdown fences or commentary.\n"
+        "The JSON must match this shape exactly:\n"
+        "{\n"
+        '  "final_adherence_score": 0.0,\n'
+        '  "final_adherence_rationale": "string",\n'
+        '  "trajectory_adherence_score": null,\n'
+        '  "trajectory_adherence_rationale": null,\n'
+        '  "constraint_ids": ["required_steps:0"],\n'
+        '  "chunk_ids": ["chunk-id"],\n'
+        '  "failure_reasons": ["string"]\n'
+        "}\n"
+        "Rules:\n"
+        "- Score final_adherence_score from 0 to 1 against the supplied compiled "
+        "policy constraints and final preflight result.\n"
+        "- If trace steps are absent or insufficient for trajectory judgment, set "
+        "trajectory_adherence_score and trajectory_adherence_rationale to null.\n"
+        "- Cite only constraint_ids and chunk_ids that appear in the supplied request.\n"
+        "- Do not invent constraints, chunks, files, or policy requirements.\n"
+        "- Add failure_reasons only for material conformance gaps."
+    )
+    user_prompt = f"Policy conformance request:\n{_format_policy_conformance_request(request)}"
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+def _format_policy_conformance_request(request: PolicyConformanceRequest) -> str:
+    return json.dumps(
+        {
+            "task": request.task,
+            "compiled_constraints": _format_policy_conformance_constraints(request.compiled_packet),
+            "allowed_chunk_ids": _allowed_policy_conformance_chunk_ids(request),
+            "final_result": request.result.model_dump(mode="json"),
+            "trace_steps": [step.model_dump(mode="json") for step in request.trace_steps],
+        },
+        indent=2,
+    )
+
+
+def _format_policy_conformance_constraints(
+    compiled_packet: CompiledPolicyPacket,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    categories: tuple[tuple[str, Sequence[CompiledPolicyConstraint]], ...] = (
+        ("required_steps", compiled_packet.required_steps),
+        ("forbidden_patterns", compiled_packet.forbidden_patterns),
+        ("architectural_expectations", compiled_packet.architectural_expectations),
+        ("test_expectations", compiled_packet.test_expectations),
+        ("style_constraints", compiled_packet.style_constraints),
+    )
+    for category_name, constraints in categories:
+        for index, constraint in enumerate(constraints):
+            rows.append(
+                {
+                    "constraint_id": f"{category_name}:{index}",
+                    "category": category_name,
+                    "statement": constraint.statement,
+                    "citation_ids": list(constraint.citation_ids),
+                    "source_policy_ids": list(constraint.source_policy_ids),
+                }
+            )
+    return rows
+
+
 def _format_compiled_policy_packet(compiled_packet: CompiledPolicyPacket) -> str:
     if compiled_packet.insufficient_context:
         return "(compiled policy packet has insufficient context)"
@@ -822,6 +956,97 @@ def _parse_compiled_policy_draft(content: str) -> GeneratedCompiledPolicyDraft:
             "NVIDIA policy compilation returned malformed JSON.",
             failure_class="invalid_response",
         ) from exc
+
+
+def _parse_policy_conformance_draft(
+    content: str,
+    request: PolicyConformanceRequest,
+) -> GeneratedPolicyConformanceDraft:
+    json_object = _parse_json_object_response(
+        content,
+        operation="policy conformance evaluation",
+    )
+    try:
+        draft = GeneratedPolicyConformanceDraft.model_validate(json_object)
+    except ValidationError as exc:
+        raise ProviderError(
+            "NVIDIA policy conformance evaluation returned malformed JSON.",
+            failure_class="invalid_response",
+        ) from exc
+
+    _validate_policy_conformance_draft(draft, request)
+    return draft
+
+
+def _validate_policy_conformance_draft(
+    draft: GeneratedPolicyConformanceDraft,
+    request: PolicyConformanceRequest,
+) -> None:
+    allowed_constraint_ids = set(_allowed_policy_conformance_constraint_ids(request))
+    unsupported_constraint_ids = [
+        constraint_id
+        for constraint_id in draft.constraint_ids
+        if constraint_id not in allowed_constraint_ids
+    ]
+    if unsupported_constraint_ids:
+        raise ProviderError(
+            "NVIDIA policy conformance evaluation returned unsupported constraint ids: "
+            f"{', '.join(unsupported_constraint_ids)}.",
+            failure_class="invalid_response",
+        )
+
+    allowed_chunk_ids = set(_allowed_policy_conformance_chunk_ids(request))
+    unsupported_chunk_ids = [
+        chunk_id for chunk_id in draft.chunk_ids if chunk_id not in allowed_chunk_ids
+    ]
+    if unsupported_chunk_ids:
+        raise ProviderError(
+            "NVIDIA policy conformance evaluation returned unsupported chunk ids: "
+            f"{', '.join(unsupported_chunk_ids)}.",
+            failure_class="invalid_response",
+        )
+
+
+def _allowed_policy_conformance_constraint_ids(
+    request: PolicyConformanceRequest,
+) -> list[str]:
+    return [
+        str(row["constraint_id"])
+        for row in _format_policy_conformance_constraints(request.compiled_packet)
+    ]
+
+
+def _allowed_policy_conformance_chunk_ids(
+    request: PolicyConformanceRequest,
+) -> list[str]:
+    constraint_chunk_ids = [
+        citation_id
+        for constraints in (
+            request.compiled_packet.required_steps,
+            request.compiled_packet.forbidden_patterns,
+            request.compiled_packet.architectural_expectations,
+            request.compiled_packet.test_expectations,
+            request.compiled_packet.style_constraints,
+        )
+        for constraint in constraints
+        for citation_id in constraint.citation_ids
+    ]
+    result_chunk_ids = [citation.chunk_id for citation in request.result.citations]
+    trace_chunk_ids = [
+        citation_id for step in request.trace_steps for citation_id in step.citation_ids
+    ]
+    return _ordered_unique([*constraint_chunk_ids, *result_chunk_ids, *trace_chunk_ids])
+
+
+def _ordered_unique(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
 
 
 def _parse_json_object_response(content: str, *, operation: str) -> dict[str, Any]:

--- a/src/policynim/services/__init__.py
+++ b/src/policynim/services/__init__.py
@@ -2,6 +2,7 @@
 
 from policynim.services.beta_auth import BetaAuthService, create_beta_auth_service
 from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
+from policynim.services.conformance import PolicyConformanceService
 from policynim.services.dump import IndexDumpService, create_index_dump_service
 from policynim.services.eval import EvalService, create_eval_service
 from policynim.services.health import (
@@ -33,6 +34,7 @@ __all__ = [
     "IngestService",
     "PreflightService",
     "PolicyCompilerService",
+    "PolicyConformanceService",
     "PolicyRouterService",
     "RuntimeDecisionService",
     "RuntimeEvidenceReportService",

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -227,22 +227,18 @@ def _citation_support_metric(
             failure_reasons=["preflight result has no citations"],
         )
 
-    matched = [chunk_id for chunk_id in expected_chunk_ids if chunk_id in set(actual_chunk_ids)]
-    unsupported = [
-        chunk_id for chunk_id in actual_chunk_ids if chunk_id not in set(expected_chunk_ids)
-    ]
+    actual_chunk_id_set = set(actual_chunk_ids)
+    matched = [chunk_id for chunk_id in expected_chunk_ids if chunk_id in actual_chunk_id_set]
     score = len(matched) / len(expected_chunk_ids)
     failure_reasons = []
     if score < 1.0:
         missing = [chunk_id for chunk_id in expected_chunk_ids if chunk_id not in set(matched)]
         failure_reasons.append(f"missing compiled citation ids: {', '.join(missing)}")
-    if unsupported:
-        failure_reasons.append(f"result cited unsupported chunk ids: {', '.join(unsupported)}")
 
     return PolicyConformanceMetric(
         name="citation_support",
-        score=0.0 if unsupported else score,
-        passed=score == 1.0 and not unsupported,
+        score=score,
+        passed=score == 1.0,
         failure_reasons=failure_reasons,
     )
 

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -1,0 +1,323 @@
+"""Policy conformance scoring for traced preflight results."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from types import TracebackType
+
+from policynim.contracts import PolicyConformanceEvaluator
+from policynim.types import (
+    CompiledPolicyConstraint,
+    EvalBackend,
+    GeneratedPolicyConformanceDraft,
+    PolicyConformanceMetric,
+    PolicyConformanceRequest,
+    PolicyConformanceResult,
+)
+
+_FINAL_ADHERENCE_THRESHOLD = 0.75
+_TRAJECTORY_ADHERENCE_THRESHOLD = 0.75
+
+
+class PolicyConformanceService:
+    """Score policy conformance for one traced preflight result."""
+
+    def __init__(self, *, evaluator: PolicyConformanceEvaluator | None = None) -> None:
+        self._evaluator = evaluator
+
+    def __enter__(self) -> PolicyConformanceService:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release owned evaluator resources."""
+        _close_component(self._evaluator)
+
+    def evaluate(
+        self,
+        request: PolicyConformanceRequest,
+        *,
+        backend: EvalBackend,
+    ) -> PolicyConformanceResult:
+        """Score deterministic conformance and optional evaluator judgment."""
+        deterministic_metrics = _deterministic_metrics(request)
+        evaluator_draft = (
+            self._evaluator.evaluate_policy_conformance(request)
+            if self._evaluator is not None
+            else None
+        )
+        metrics = list(deterministic_metrics)
+        if evaluator_draft is not None:
+            metrics.extend(_judge_metrics(evaluator_draft))
+
+        passed = all(metric.passed for metric in metrics)
+        overall_score = _average([metric.score for metric in metrics])
+        failure_reasons = [reason for metric in metrics for reason in metric.failure_reasons]
+        return PolicyConformanceResult(
+            backend=backend,
+            passed=passed,
+            overall_score=overall_score,
+            metrics=metrics,
+            final_adherence_score=(
+                evaluator_draft.final_adherence_score if evaluator_draft is not None else None
+            ),
+            final_adherence_rationale=(
+                evaluator_draft.final_adherence_rationale if evaluator_draft is not None else None
+            ),
+            trajectory_adherence_score=(
+                evaluator_draft.trajectory_adherence_score if evaluator_draft is not None else None
+            ),
+            trajectory_adherence_rationale=(
+                evaluator_draft.trajectory_adherence_rationale
+                if evaluator_draft is not None
+                else None
+            ),
+            failure_reasons=failure_reasons,
+        )
+
+
+def _deterministic_metrics(
+    request: PolicyConformanceRequest,
+) -> list[PolicyConformanceMetric]:
+    compiled_packet = request.compiled_packet
+    if compiled_packet.insufficient_context:
+        return [
+            PolicyConformanceMetric(
+                name="compiled_context",
+                score=0.0,
+                passed=False,
+                failure_reasons=["compiled policy packet has insufficient context"],
+            )
+        ]
+
+    return [
+        _constraint_presence_metric(
+            name="plan_completeness",
+            constraints=compiled_packet.required_steps,
+            texts=request.result.plan_steps,
+            missing_label="required steps missing from plan_steps",
+        ),
+        _constraint_presence_metric(
+            name="guidance_coverage",
+            constraints=[
+                *compiled_packet.architectural_expectations,
+                *compiled_packet.style_constraints,
+            ],
+            texts=request.result.implementation_guidance,
+            missing_label="architecture or style constraints missing from implementation guidance",
+        ),
+        _constraint_presence_metric(
+            name="test_coverage",
+            constraints=compiled_packet.test_expectations,
+            texts=request.result.tests_required,
+            missing_label="test expectations missing from tests_required",
+        ),
+        _forbidden_pattern_metric(
+            constraints=compiled_packet.forbidden_patterns,
+            review_flags=request.result.review_flags,
+            positive_texts=[
+                *request.result.plan_steps,
+                *request.result.implementation_guidance,
+                *request.result.tests_required,
+            ],
+        ),
+        _citation_support_metric(request),
+    ]
+
+
+def _constraint_presence_metric(
+    *,
+    name: str,
+    constraints: Sequence[CompiledPolicyConstraint],
+    texts: Sequence[str],
+    missing_label: str,
+) -> PolicyConformanceMetric:
+    if not constraints:
+        return PolicyConformanceMetric(name=name, score=1.0, passed=True)
+
+    matched = [
+        constraint for constraint in constraints if _contains_statement(constraint.statement, texts)
+    ]
+    score = len(matched) / len(constraints)
+    failure_reasons = []
+    if score < 1.0:
+        missing = [constraint.statement for constraint in constraints if constraint not in matched]
+        failure_reasons.append(f"{missing_label}: {', '.join(missing)}")
+    return PolicyConformanceMetric(
+        name=name,
+        score=score,
+        passed=score == 1.0,
+        failure_reasons=failure_reasons,
+    )
+
+
+def _forbidden_pattern_metric(
+    *,
+    constraints: Sequence[CompiledPolicyConstraint],
+    review_flags: Sequence[str],
+    positive_texts: Sequence[str],
+) -> PolicyConformanceMetric:
+    if not constraints:
+        return PolicyConformanceMetric(name="forbidden_pattern_handling", score=1.0, passed=True)
+
+    handled = 0
+    failure_reasons: list[str] = []
+    for constraint in constraints:
+        in_review_flags = _contains_statement(constraint.statement, review_flags)
+        in_positive_text = _contains_statement(constraint.statement, positive_texts)
+        if in_review_flags and not in_positive_text:
+            handled += 1
+            continue
+        if not in_review_flags:
+            failure_reasons.append(
+                f"forbidden pattern missing from review_flags: {constraint.statement}"
+            )
+        if in_positive_text:
+            failure_reasons.append(
+                f"forbidden pattern appears as positive guidance: {constraint.statement}"
+            )
+
+    score = handled / len(constraints)
+    return PolicyConformanceMetric(
+        name="forbidden_pattern_handling",
+        score=score,
+        passed=score == 1.0,
+        failure_reasons=failure_reasons,
+    )
+
+
+def _citation_support_metric(
+    request: PolicyConformanceRequest,
+) -> PolicyConformanceMetric:
+    expected_chunk_ids = _ordered_unique(
+        [
+            citation_id
+            for constraints in (
+                request.compiled_packet.required_steps,
+                request.compiled_packet.forbidden_patterns,
+                request.compiled_packet.architectural_expectations,
+                request.compiled_packet.test_expectations,
+                request.compiled_packet.style_constraints,
+            )
+            for constraint in constraints
+            for citation_id in constraint.citation_ids
+        ]
+    )
+    actual_chunk_ids = _ordered_unique([citation.chunk_id for citation in request.result.citations])
+    if not expected_chunk_ids:
+        return PolicyConformanceMetric(
+            name="citation_support",
+            score=0.0,
+            passed=False,
+            failure_reasons=["compiled packet has no constraint citations"],
+        )
+    if not actual_chunk_ids:
+        return PolicyConformanceMetric(
+            name="citation_support",
+            score=0.0,
+            passed=False,
+            failure_reasons=["preflight result has no citations"],
+        )
+
+    matched = [chunk_id for chunk_id in expected_chunk_ids if chunk_id in set(actual_chunk_ids)]
+    unsupported = [
+        chunk_id for chunk_id in actual_chunk_ids if chunk_id not in set(expected_chunk_ids)
+    ]
+    score = len(matched) / len(expected_chunk_ids)
+    failure_reasons = []
+    if score < 1.0:
+        missing = [chunk_id for chunk_id in expected_chunk_ids if chunk_id not in set(matched)]
+        failure_reasons.append(f"missing compiled citation ids: {', '.join(missing)}")
+    if unsupported:
+        failure_reasons.append(f"result cited unsupported chunk ids: {', '.join(unsupported)}")
+
+    return PolicyConformanceMetric(
+        name="citation_support",
+        score=0.0 if unsupported else score,
+        passed=score == 1.0 and not unsupported,
+        failure_reasons=failure_reasons,
+    )
+
+
+def _judge_metrics(
+    draft: GeneratedPolicyConformanceDraft,
+) -> list[PolicyConformanceMetric]:
+    final_failure_reasons = list(draft.failure_reasons)
+    final_passed = draft.final_adherence_score >= _FINAL_ADHERENCE_THRESHOLD
+    if not final_passed and not final_failure_reasons:
+        final_failure_reasons.append(
+            f"final adherence score below threshold: {draft.final_adherence_score:.2f}"
+        )
+
+    metrics = [
+        PolicyConformanceMetric(
+            name="final_adherence",
+            score=draft.final_adherence_score,
+            passed=final_passed and not draft.failure_reasons,
+            failure_reasons=final_failure_reasons,
+        )
+    ]
+    if draft.trajectory_adherence_score is not None:
+        trajectory_passed = draft.trajectory_adherence_score >= _TRAJECTORY_ADHERENCE_THRESHOLD
+        trajectory_failure_reasons = []
+        if not trajectory_passed:
+            trajectory_failure_reasons.append(
+                "trajectory adherence score below threshold: "
+                f"{draft.trajectory_adherence_score:.2f}"
+            )
+        metrics.append(
+            PolicyConformanceMetric(
+                name="trajectory_adherence",
+                score=draft.trajectory_adherence_score,
+                passed=trajectory_passed,
+                failure_reasons=trajectory_failure_reasons,
+            )
+        )
+    return metrics
+
+
+def _contains_statement(statement: str, texts: Sequence[str]) -> bool:
+    normalized_statement = _normalize_for_matching(statement)
+    if not normalized_statement:
+        return False
+    return any(normalized_statement in _normalize_for_matching(text) for text in texts)
+
+
+def _normalize_for_matching(value: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", value.lower())).strip()
+
+
+def _ordered_unique(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _average(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()
+
+
+__all__ = [
+    "PolicyConformanceService",
+]

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -19,6 +19,7 @@ import pandas as pd
 from policynim.contracts import Generator, IndexStore, Reranker
 from policynim.errors import PolicyNIMError
 from policynim.runtime_paths import resolve_eval_suite_path, resolve_runtime_path
+from policynim.services.conformance import PolicyConformanceService
 from policynim.services.ingest import create_ingest_service
 from policynim.services.preflight import PreflightService
 from policynim.services.search import SearchService
@@ -28,6 +29,7 @@ from policynim.types import (
     CompiledPolicyPacket,
     CompileRequest,
     EvalAggregateMetrics,
+    EvalBackend,
     EvalCase,
     EvalCaseMetrics,
     EvalCaseResult,
@@ -37,10 +39,13 @@ from policynim.types import (
     EvalRunResult,
     EvalSuite,
     GeneratedCompiledPolicyDraft,
+    GeneratedPolicyConformanceDraft,
     GeneratedPolicyConstraint,
     GeneratedPolicyGuidance,
     GeneratedPreflightDraft,
     PolicyChunk,
+    PolicyConformanceRequest,
+    PolicyConformanceResult,
     PolicyMetadata,
     PolicySelectionPacket,
     PreflightRequest,
@@ -84,6 +89,7 @@ class EvalService:
         self,
         *,
         mode: EvalExecutionMode = "offline",
+        backend: EvalBackend = "default",
         compare_rerank: bool = True,
     ) -> EvalRunResult:
         """Run the requested eval suite and persist the resulting reports."""
@@ -96,6 +102,7 @@ class EvalService:
             case_results = self._run_suite_cases(
                 suite,
                 mode=mode,
+                backend=backend,
                 rerank_enabled=rerank_enabled,
             )
             mode_results.append(
@@ -103,6 +110,7 @@ class EvalService:
                     suite=suite,
                     suite_path=suite_path,
                     mode=mode,
+                    backend=backend,
                     rerank_enabled=rerank_enabled,
                     case_results=case_results,
                 )
@@ -115,6 +123,7 @@ class EvalService:
         )
         return EvalRunResult(
             mode=mode,
+            backend=backend,
             suite_name=suite.name,
             suite_path=suite_path.as_posix(),
             workspace_path=self._workspace_path.as_posix(),
@@ -171,16 +180,26 @@ class EvalService:
         suite: EvalSuite,
         *,
         mode: EvalExecutionMode,
+        backend: EvalBackend,
         rerank_enabled: bool,
     ) -> list[EvalCaseResult]:
         if mode == "offline":
-            return self._run_offline_suite(suite, rerank_enabled=rerank_enabled)
-        return self._run_live_suite(suite, rerank_enabled=rerank_enabled)
+            return self._run_offline_suite(
+                suite,
+                backend=backend,
+                rerank_enabled=rerank_enabled,
+            )
+        return self._run_live_suite(
+            suite,
+            backend=backend,
+            rerank_enabled=rerank_enabled,
+        )
 
     def _run_offline_suite(
         self,
         suite: EvalSuite,
         *,
+        backend: EvalBackend,
         rerank_enabled: bool,
     ) -> list[EvalCaseResult]:
         store = _OfflineIndexStore(_OFFLINE_QUERY_CANDIDATES)
@@ -197,21 +216,30 @@ class EvalService:
             generator=_OfflineGenerator(),
             compiler=_OfflinePolicyCompiler(),
         )
+        conformance_service = (
+            PolicyConformanceService(evaluator=_OfflinePolicyConformanceEvaluator())
+            if backend == "nemo"
+            else None
+        )
         try:
             return _score_suite_cases(
                 suite.cases,
                 search_service=search_service,
                 preflight_service=preflight_service,
+                conformance_service=conformance_service,
+                backend=backend,
                 rerank_enabled=rerank_enabled,
             )
         finally:
             search_service.close()
             preflight_service.close()
+            _close_component(conformance_service)
 
     def _run_live_suite(
         self,
         suite: EvalSuite,
         *,
+        backend: EvalBackend,
         rerank_enabled: bool,
     ) -> list[EvalCaseResult]:
         with TemporaryDirectory(prefix="policynim-eval-") as temp_dir:
@@ -229,16 +257,22 @@ class EvalService:
                 temp_settings,
                 rerank_enabled=rerank_enabled,
             )
+            conformance_service = (
+                _create_live_conformance_service(temp_settings) if backend == "nemo" else None
+            )
             try:
                 return _score_suite_cases(
                     suite.cases,
                     search_service=search_service,
                     preflight_service=preflight_service,
+                    conformance_service=conformance_service,
+                    backend=backend,
                     rerank_enabled=rerank_enabled,
                 )
             finally:
                 search_service.close()
                 preflight_service.close()
+                _close_component(conformance_service)
 
     def _persist_mode_run(
         self,
@@ -246,6 +280,7 @@ class EvalService:
         suite: EvalSuite,
         suite_path: Path,
         mode: EvalExecutionMode,
+        backend: EvalBackend,
         rerank_enabled: bool,
         case_results: list[EvalCaseResult],
     ) -> EvalModeRunResult:
@@ -260,14 +295,16 @@ class EvalService:
         reports_dir.mkdir(parents=True, exist_ok=True)
 
         result_payload = EvalModeRunResult(
+            backend=backend,
             rerank_enabled=rerank_enabled,
             metrics=metrics,
             result_json_path="",
             report_html_path="",
             case_results=case_results,
         )
-        result_json_path = results_dir / f"{timestamp}-{suite_slug}-{mode_slug}.json"
-        report_html_path = reports_dir / f"{timestamp}-{suite_slug}-{mode_slug}.html"
+        backend_slug = f"{mode_slug}-{backend}"
+        result_json_path = results_dir / f"{timestamp}-{suite_slug}-{backend_slug}.json"
+        report_html_path = reports_dir / f"{timestamp}-{suite_slug}-{backend_slug}.html"
         result_json_path.write_text(
             result_payload.model_copy(
                 update={
@@ -282,6 +319,7 @@ class EvalService:
             suite=suite,
             suite_path=suite_path,
             mode=mode,
+            backend=backend,
             rerank_enabled=rerank_enabled,
             case_results=case_results,
             metrics=metrics,
@@ -290,10 +328,11 @@ class EvalService:
         _add_report_to_workspace(
             self._workspace_path,
             report,
-            run_name=f"{suite.name} | {mode} | {mode_slug}",
+            run_name=f"{suite.name} | {mode} | {backend} | {mode_slug}",
         )
 
         return EvalModeRunResult(
+            backend=backend,
             rerank_enabled=rerank_enabled,
             metrics=metrics,
             result_json_path=result_json_path.as_posix(),
@@ -312,6 +351,8 @@ def _score_suite_cases(
     *,
     search_service: SearchService,
     preflight_service: PreflightService,
+    conformance_service: PolicyConformanceService | None,
+    backend: EvalBackend,
     rerank_enabled: bool,
 ) -> list[EvalCaseResult]:
     results: list[EvalCaseResult] = []
@@ -323,10 +364,31 @@ def _score_suite_cases(
             results.append(_score_search_case(case, result=result, rerank_enabled=rerank_enabled))
             continue
 
-        result = preflight_service.preflight(
-            PreflightRequest(task=case.input, domain=case.domain, top_k=case.top_k)
+        request = PreflightRequest(task=case.input, domain=case.domain, top_k=case.top_k)
+        conformance_result: PolicyConformanceResult | None = None
+        if conformance_service is None:
+            result = preflight_service.preflight(request)
+        else:
+            trace_result = preflight_service.preflight_with_trace(request)
+            result = trace_result.result
+            if not result.insufficient_context:
+                conformance_result = conformance_service.evaluate(
+                    PolicyConformanceRequest(
+                        task=request.task,
+                        result=result,
+                        compiled_packet=trace_result.compiled_packet,
+                        trace_steps=trace_result.trace_steps,
+                    ),
+                    backend=backend,
+                )
+        results.append(
+            _score_preflight_case(
+                case,
+                result=result,
+                conformance_result=conformance_result,
+                rerank_enabled=rerank_enabled,
+            )
         )
-        results.append(_score_preflight_case(case, result=result, rerank_enabled=rerank_enabled))
     return results
 
 
@@ -379,6 +441,7 @@ def _score_preflight_case(
     case: EvalCase,
     *,
     result: PreflightResult,
+    conformance_result: PolicyConformanceResult | None = None,
     rerank_enabled: bool,
 ) -> EvalCaseResult:
     actual_policy_ids = [policy.policy_id for policy in result.applicable_policies]
@@ -396,6 +459,15 @@ def _score_preflight_case(
         matched_ids=matched_policy_ids,
         label="policy_id",
     )
+    if conformance_result is not None and not conformance_result.passed:
+        failure_reasons.append(
+            "policy conformance failed: "
+            + (
+                "; ".join(conformance_result.failure_reasons)
+                if conformance_result.failure_reasons
+                else "score below threshold"
+            )
+        )
     return EvalCaseResult(
         case_id=case.case_id,
         kind=case.kind,
@@ -414,11 +486,18 @@ def _score_preflight_case(
         actual_policy_ids=actual_policy_ids,
         matched_policy_ids=matched_policy_ids,
         actual_summary=result.summary,
+        conformance_result=conformance_result,
         metrics=EvalCaseMetrics(
             expected_chunk_recall=_recall(len(matched_chunk_ids), len(case.expected_chunk_ids)),
             expected_policy_recall=_recall(len(matched_policy_ids), len(case.expected_policy_ids)),
             insufficient_context_correct=(
                 case.expected_insufficient_context == result.insufficient_context
+            ),
+            conformance_score=(
+                conformance_result.overall_score if conformance_result is not None else None
+            ),
+            conformance_passed=(
+                conformance_result.passed if conformance_result is not None else None
             ),
         ),
     )
@@ -447,8 +526,16 @@ def _build_failure_reasons(
 def _aggregate_metrics(case_results: Sequence[EvalCaseResult]) -> EvalAggregateMetrics:
     search_results = [result for result in case_results if result.kind == "search"]
     preflight_results = [result for result in case_results if result.kind == "preflight"]
+    conformance_results = [
+        result for result in preflight_results if result.conformance_result is not None
+    ]
     total_results = list(case_results)
     passed_count = sum(result.passed for result in total_results)
+    conformance_passed_count = sum(
+        result.conformance_result.passed
+        for result in conformance_results
+        if result.conformance_result is not None
+    )
     return EvalAggregateMetrics(
         case_count=len(total_results),
         passed_count=passed_count,
@@ -475,6 +562,16 @@ def _aggregate_metrics(case_results: Sequence[EvalCaseResult]) -> EvalAggregateM
             [
                 1.0 if result.metrics.insufficient_context_correct else 0.0
                 for result in total_results
+            ]
+        ),
+        conformance_case_count=len(conformance_results),
+        conformance_passed_count=conformance_passed_count,
+        conformance_pass_rate=_ratio(conformance_passed_count, len(conformance_results)),
+        conformance_score=_average(
+            [
+                result.conformance_result.overall_score
+                for result in conformance_results
+                if result.conformance_result is not None
             ]
         ),
     )
@@ -588,6 +685,7 @@ def _build_evidently_report(
     suite: EvalSuite,
     suite_path: Path,
     mode: EvalExecutionMode,
+    backend: EvalBackend,
     rerank_enabled: bool,
     case_results: Sequence[EvalCaseResult],
     metrics: EvalAggregateMetrics,
@@ -600,6 +698,7 @@ def _build_evidently_report(
             "suite_name": suite.name,
             "suite_path": suite_path.as_posix(),
             "mode": mode,
+            "backend": backend,
             "rerank_enabled": rerank_enabled,
             "case_id": result.case_id,
             "kind": result.kind,
@@ -617,10 +716,25 @@ def _build_evidently_report(
             "expected_chunk_recall": result.metrics.expected_chunk_recall,
             "expected_policy_recall": result.metrics.expected_policy_recall,
             "insufficient_context_correct": result.metrics.insufficient_context_correct,
+            "conformance_passed": (
+                result.conformance_result.passed if result.conformance_result is not None else None
+            ),
+            "conformance_score": (
+                result.conformance_result.overall_score
+                if result.conformance_result is not None
+                else None
+            ),
+            "conformance_failure_reasons": (
+                " | ".join(result.conformance_result.failure_reasons)
+                if result.conformance_result is not None
+                else ""
+            ),
             "actual_summary": result.actual_summary or "",
             "overall_pass_rate": metrics.overall_pass_rate,
             "expected_policy_recall_run": metrics.expected_policy_recall,
             "expected_chunk_recall_run": metrics.expected_chunk_recall,
+            "conformance_pass_rate_run": metrics.conformance_pass_rate,
+            "conformance_score_run": metrics.conformance_score,
         }
         for result in case_results
     ]
@@ -718,6 +832,20 @@ def _create_live_preflight_service(
         generator=NVIDIAGenerator.from_settings(settings),
         compiler=NVIDIAPolicyCompiler.from_settings(settings),
     )
+
+
+def _create_live_conformance_service(settings: Settings) -> PolicyConformanceService:
+    from policynim.providers import NVIDIAPolicyConformanceEvaluator
+
+    return PolicyConformanceService(
+        evaluator=NVIDIAPolicyConformanceEvaluator.from_settings(settings),
+    )
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()
 
 
 class _PassThroughReranker(Reranker):
@@ -913,6 +1041,32 @@ class _OfflinePolicyCompiler:
             forbidden_patterns=forbidden_patterns,
             test_expectations=test_expectations,
             insufficient_context=not (required_steps or forbidden_patterns or test_expectations),
+        )
+
+    def close(self) -> None:
+        return None
+
+
+class _OfflinePolicyConformanceEvaluator:
+    """Produce deterministic conformance judgments for offline evals."""
+
+    def evaluate_policy_conformance(
+        self,
+        request: PolicyConformanceRequest,
+    ) -> GeneratedPolicyConformanceDraft:
+        trajectory_score = 1.0 if request.trace_steps else None
+        return GeneratedPolicyConformanceDraft(
+            final_adherence_score=1.0,
+            final_adherence_rationale="Offline preflight output follows compiled policy evidence.",
+            trajectory_adherence_score=trajectory_score,
+            trajectory_adherence_rationale=(
+                "Offline trace steps preserve compile and generation flow."
+                if trajectory_score is not None
+                else None
+            ),
+            constraint_ids=[],
+            chunk_ids=[citation.chunk_id for citation in request.result.citations],
+            failure_reasons=[],
         )
 
     def close(self) -> None:

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -17,9 +17,11 @@ from policynim.types import (
     CompileRequest,
     GeneratedPolicyGuidance,
     GeneratedPreflightDraft,
+    PolicyConformanceTraceStep,
     PolicyGuidance,
     PreflightRequest,
     PreflightResult,
+    PreflightTraceResult,
     ScoredChunk,
 )
 
@@ -88,12 +90,33 @@ class PreflightService:
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
+        return self.preflight_with_trace(request).result
+
+    def preflight_with_trace(self, request: PreflightRequest) -> PreflightTraceResult:
+        """Run preflight and retain internal data needed for eval scoring."""
         compile_result = self._compiler_service.compile(
             CompileRequest(task=request.task, domain=request.domain, top_k=request.top_k)
         )
         compiled_packet = compile_result.packet
+        trace_steps = [
+            _trace_step(
+                step_id="compile",
+                kind="policy_compilation",
+                summary=(
+                    "Compiled policy packet had insufficient context."
+                    if compiled_packet.insufficient_context
+                    else "Compiled policy packet for generation."
+                ),
+                citation_ids=[citation.chunk_id for citation in compiled_packet.citations],
+            )
+        ]
         if compiled_packet.insufficient_context or not compile_result.retained_context:
-            return _insufficient_context_result(request)
+            return PreflightTraceResult(
+                result=_insufficient_context_result(request),
+                compiled_packet=compiled_packet,
+                retained_context=compile_result.retained_context,
+                trace_steps=trace_steps,
+            )
 
         retained_context = compile_result.retained_context
         generated = self._generator.generate_preflight(
@@ -103,10 +126,28 @@ class PreflightService:
         )
         draft = _coerce_generated_draft(generated)
         draft = _apply_compiled_packet_to_draft(draft, compiled_packet)
+        trace_steps.append(
+            _trace_step(
+                step_id="generate",
+                kind="grounded_generation",
+                summary=draft.summary or "Generated preflight draft.",
+                citation_ids=draft.citation_ids,
+            )
+        )
         validated = _validate_and_materialize_result(request, retained_context, draft)
         if validated is None:
-            return _insufficient_context_result(request)
-        return validated
+            return PreflightTraceResult(
+                result=_insufficient_context_result(request),
+                compiled_packet=compiled_packet,
+                retained_context=retained_context,
+                trace_steps=trace_steps,
+            )
+        return PreflightTraceResult(
+            result=validated,
+            compiled_packet=compiled_packet,
+            retained_context=retained_context,
+            trace_steps=trace_steps,
+        )
 
 
 def create_preflight_service(settings: Settings | None = None) -> PreflightService:
@@ -302,6 +343,21 @@ def _constraint_statements(
     constraints: Sequence[CompiledPolicyConstraint],
 ) -> list[str]:
     return [constraint.statement for constraint in constraints]
+
+
+def _trace_step(
+    *,
+    step_id: str,
+    kind: str,
+    summary: str,
+    citation_ids: Sequence[str],
+) -> PolicyConformanceTraceStep:
+    return PolicyConformanceTraceStep(
+        step_id=step_id,
+        kind=kind,
+        summary=summary.strip() or kind,
+        citation_ids=_ordered_unique(list(citation_ids)),
+    )
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -90,28 +90,42 @@ class PreflightService:
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
-        return self.preflight_with_trace(request).result
+        output = self._run_preflight(request, with_trace=False)
+        assert isinstance(output, PreflightResult)
+        return output
 
     def preflight_with_trace(self, request: PreflightRequest) -> PreflightTraceResult:
         """Run preflight and retain internal data needed for eval scoring."""
+        output = self._run_preflight(request, with_trace=True)
+        assert isinstance(output, PreflightTraceResult)
+        return output
+
+    def _run_preflight(
+        self,
+        request: PreflightRequest,
+        *,
+        with_trace: bool,
+    ) -> PreflightResult | PreflightTraceResult:
         compile_result = self._compiler_service.compile(
             CompileRequest(task=request.task, domain=request.domain, top_k=request.top_k)
         )
         compiled_packet = compile_result.packet
-        trace_steps = [
-            _trace_step(
-                step_id="compile",
-                kind="policy_compilation",
-                summary=(
-                    "Compiled policy packet had insufficient context."
-                    if compiled_packet.insufficient_context
-                    else "Compiled policy packet for generation."
-                ),
-                citation_ids=[citation.chunk_id for citation in compiled_packet.citations],
+        trace_steps: list[PolicyConformanceTraceStep] | None = [] if with_trace else None
+        if trace_steps is not None:
+            trace_steps.append(
+                _trace_step(
+                    step_id="compile",
+                    kind="policy_compilation",
+                    summary=(
+                        "Compiled policy packet had insufficient context."
+                        if compiled_packet.insufficient_context
+                        else "Compiled policy packet for generation."
+                    ),
+                    citation_ids=[citation.chunk_id for citation in compiled_packet.citations],
+                )
             )
-        ]
         if compiled_packet.insufficient_context or not compile_result.retained_context:
-            return PreflightTraceResult(
+            return _preflight_output(
                 result=_insufficient_context_result(request),
                 compiled_packet=compiled_packet,
                 retained_context=compile_result.retained_context,
@@ -126,28 +140,46 @@ class PreflightService:
         )
         draft = _coerce_generated_draft(generated)
         draft = _apply_compiled_packet_to_draft(draft, compiled_packet)
-        trace_steps.append(
-            _trace_step(
-                step_id="generate",
-                kind="grounded_generation",
-                summary=draft.summary or "Generated preflight draft.",
-                citation_ids=draft.citation_ids,
+        if trace_steps is not None:
+            trace_steps.append(
+                _trace_step(
+                    step_id="generate",
+                    kind="grounded_generation",
+                    summary=draft.summary or "Generated preflight draft.",
+                    citation_ids=draft.citation_ids,
+                )
             )
-        )
         validated = _validate_and_materialize_result(request, retained_context, draft)
         if validated is None:
-            return PreflightTraceResult(
+            return _preflight_output(
                 result=_insufficient_context_result(request),
                 compiled_packet=compiled_packet,
                 retained_context=retained_context,
                 trace_steps=trace_steps,
             )
-        return PreflightTraceResult(
+        return _preflight_output(
             result=validated,
             compiled_packet=compiled_packet,
             retained_context=retained_context,
             trace_steps=trace_steps,
         )
+
+
+def _preflight_output(
+    *,
+    result: PreflightResult,
+    compiled_packet: CompiledPolicyPacket,
+    retained_context: list[ScoredChunk],
+    trace_steps: list[PolicyConformanceTraceStep] | None,
+) -> PreflightResult | PreflightTraceResult:
+    if trace_steps is None:
+        return result
+    return PreflightTraceResult(
+        result=result,
+        compiled_packet=compiled_packet,
+        retained_context=retained_context,
+        trace_steps=trace_steps,
+    )
 
 
 def create_preflight_service(settings: Settings | None = None) -> PreflightService:

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -738,8 +738,71 @@ class PreflightResult(StrictModel):
     insufficient_context: bool = False
 
 
+EvalBackend = Literal["default", "nemo"]
 EvalKind = Literal["search", "preflight"]
 EvalExecutionMode = Literal["offline", "live"]
+
+
+class PolicyConformanceMetric(StrictModel):
+    """One policy-conformance metric for a preflight result."""
+
+    name: str = Field(min_length=1)
+    score: float = Field(ge=0.0, le=1.0)
+    passed: bool
+    failure_reasons: list[str] = Field(default_factory=list)
+
+
+class PolicyConformanceTraceStep(StrictModel):
+    """One optional intermediate step available for trajectory-aware judging."""
+
+    step_id: str = Field(min_length=1)
+    kind: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    citation_ids: list[str] = Field(default_factory=list)
+
+
+class GeneratedPolicyConformanceDraft(StrictModel):
+    """Untrusted conformance judgment returned by an external evaluator."""
+
+    final_adherence_score: float = Field(ge=0.0, le=1.0)
+    final_adherence_rationale: str = ""
+    trajectory_adherence_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    trajectory_adherence_rationale: str | None = None
+    constraint_ids: list[str] = Field(default_factory=list)
+    chunk_ids: list[str] = Field(default_factory=list)
+    failure_reasons: list[str] = Field(default_factory=list)
+
+
+class PolicyConformanceResult(StrictModel):
+    """Typed policy-conformance result for one preflight eval case."""
+
+    backend: EvalBackend
+    passed: bool
+    overall_score: float = Field(ge=0.0, le=1.0)
+    metrics: list[PolicyConformanceMetric] = Field(default_factory=list)
+    final_adherence_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    final_adherence_rationale: str | None = None
+    trajectory_adherence_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    trajectory_adherence_rationale: str | None = None
+    failure_reasons: list[str] = Field(default_factory=list)
+
+
+class PolicyConformanceRequest(StrictModel):
+    """Conformance request assembled from a preflight trace."""
+
+    task: str
+    result: PreflightResult
+    compiled_packet: CompiledPolicyPacket
+    trace_steps: list[PolicyConformanceTraceStep] = Field(default_factory=list)
+
+
+class PreflightTraceResult(StrictModel):
+    """Internal preflight result plus trace data for eval scoring."""
+
+    result: PreflightResult
+    compiled_packet: CompiledPolicyPacket
+    retained_context: list[ScoredChunk] = Field(default_factory=list)
+    trace_steps: list[PolicyConformanceTraceStep] = Field(default_factory=list)
 
 
 class EvalCase(StrictModel):
@@ -768,6 +831,8 @@ class EvalCaseMetrics(StrictModel):
     expected_chunk_recall: float = Field(default=0.0, ge=0.0, le=1.0)
     expected_policy_recall: float = Field(default=0.0, ge=0.0, le=1.0)
     insufficient_context_correct: bool = False
+    conformance_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    conformance_passed: bool | None = None
 
 
 class EvalCaseResult(StrictModel):
@@ -790,6 +855,7 @@ class EvalCaseResult(StrictModel):
     actual_policy_ids: list[str] = Field(default_factory=list)
     matched_policy_ids: list[str] = Field(default_factory=list)
     actual_summary: str | None = None
+    conformance_result: PolicyConformanceResult | None = None
     metrics: EvalCaseMetrics
 
 
@@ -808,11 +874,16 @@ class EvalAggregateMetrics(StrictModel):
     expected_chunk_recall: float = Field(default=0.0, ge=0.0, le=1.0)
     expected_policy_recall: float = Field(default=0.0, ge=0.0, le=1.0)
     insufficient_context_accuracy: float = Field(default=0.0, ge=0.0, le=1.0)
+    conformance_case_count: int = Field(default=0, ge=0)
+    conformance_passed_count: int = Field(default=0, ge=0)
+    conformance_pass_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    conformance_score: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
 class EvalModeRunResult(StrictModel):
     """All eval results for one rerank mode."""
 
+    backend: EvalBackend = "default"
     rerank_enabled: bool
     metrics: EvalAggregateMetrics
     result_json_path: str
@@ -836,6 +907,7 @@ class EvalRunResult(StrictModel):
     """Top-level eval command result."""
 
     mode: EvalExecutionMode
+    backend: EvalBackend = "default"
     suite_name: str
     suite_path: str
     workspace_path: str

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,12 +19,15 @@ Current automated coverage includes:
   and weak-evidence fallback behavior
 - Build 2 policy compilation, compiled constraint citation validation,
   fail-closed handling, and preflight conditioning
+- Build 3 policy conformance scoring, eval backend selection, preflight trace
+  handling, and NVIDIA conformance-response validation
 - Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads
 - CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
   `compile`, and JSON-first `preflight`
 - CLI output for `eval`
+- CLI output for `eval --backend default|nemo`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`
 - CLI output for `beta-admin` hosted operator commands
 - MCP tool parity for `policy_preflight` and `policy_search`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ from policynim.types import (
     CompileRequest,
     CompileResult,
     EvalAggregateMetrics,
+    EvalBackend,
     EvalCaseMetrics,
     EvalCaseResult,
     EvalComparisonDelta,
@@ -415,10 +416,17 @@ class MockEvalService:
         self.launch_port: int | None = None
         self.started_ui = False
 
-    def run(self, *, mode, compare_rerank) -> EvalRunResult:
+    def run(
+        self,
+        *,
+        mode,
+        backend: EvalBackend = "default",
+        compare_rerank,
+    ) -> EvalRunResult:
         passed_count = 2 if self.passed else 1
         return EvalRunResult(
             mode=mode,
+            backend=backend,
             suite_name="day-6-default",
             suite_path="evals/default_cases.json",
             workspace_path="data/evals/workspace",
@@ -850,6 +858,30 @@ def test_eval_command_prints_json(monkeypatch) -> None:
     assert payload.mode == "offline"
     assert payload.runs[0].metrics.case_count == 2
     assert "--cases" not in runner.invoke(app, ["eval", "--help"]).stdout
+
+
+def test_eval_command_accepts_nemo_backend(monkeypatch) -> None:
+    service = MockEvalService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_eval_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "--mode", "offline", "--backend", "nemo", "--headless"],
+    )
+
+    assert result.exit_code == 0
+    payload = EvalRunResult.model_validate(json.loads(result.stdout))
+    assert payload.backend == "nemo"
+
+
+def test_eval_command_rejects_invalid_backend() -> None:
+    result = runner.invoke(app, ["eval", "--backend", "not-a-backend", "--headless"])
+
+    assert result.exit_code != 0
+    assert "not-a-backend" in result.output
 
 
 def test_eval_command_starts_ui_by_default(monkeypatch) -> None:

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -11,8 +11,10 @@ from policynim.errors import PolicyNIMError
 from policynim.services.eval import EvalService
 from policynim.settings import Settings
 from policynim.types import (
+    CompiledPolicyPacket,
     PolicyMetadata,
     PreflightResult,
+    PreflightTraceResult,
     ScoredChunk,
     SearchResult,
 )
@@ -88,6 +90,21 @@ class FakePreflightService:
             insufficient_context=True,
         )
 
+    def preflight_with_trace(self, request) -> PreflightTraceResult:
+        result = self.preflight(request)
+        return PreflightTraceResult(
+            result=result,
+            compiled_packet=CompiledPolicyPacket(
+                task=request.task,
+                domain=request.domain,
+                top_k=request.top_k,
+                task_type="unknown",
+                insufficient_context=True,
+            ),
+            retained_context=[],
+            trace_steps=[],
+        )
+
     def close(self) -> None:
         return None
 
@@ -124,7 +141,13 @@ def test_eval_service_offline_run_persists_two_rerank_modes(monkeypatch, tmp_pat
     result = EvalService(settings=settings).run(mode="offline")
 
     assert result.mode == "offline"
+    assert result.backend == "default"
     assert len(result.runs) == 2
+    assert all(
+        case_result.conformance_result is None
+        for run in result.runs
+        for case_result in run.case_results
+    )
     assert result.comparison is not None
     assert "preflight-refresh-token-cleanup" in result.comparison.improved_case_ids
     assert "search-refresh-token-cleanup" in result.comparison.improved_case_ids
@@ -181,6 +204,37 @@ def test_eval_service_uses_original_suite_name_and_safe_artifact_slug(
     assert "\\" not in Path(result.runs[0].result_json_path).name
 
 
+def test_eval_service_nemo_backend_adds_preflight_conformance_results(
+    monkeypatch, tmp_path: Path
+) -> None:
+    settings = Settings(eval_workspace_dir=tmp_path / "workspace")
+    monkeypatch.setattr(
+        "policynim.services.eval._build_evidently_report",
+        lambda **kwargs: FakeReport(),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._add_report_to_workspace",
+        lambda workspace_path, report, run_name: None,
+    )
+
+    result = EvalService(settings=settings).run(
+        mode="offline",
+        backend="nemo",
+        compare_rerank=False,
+    )
+
+    assert result.backend == "nemo"
+    assert len(result.runs) == 1
+    run = result.runs[0]
+    search_cases = [case for case in run.case_results if case.kind == "search"]
+    preflight_cases = [case for case in run.case_results if case.kind == "preflight"]
+    assert all(case.conformance_result is None for case in search_cases)
+    assert any(case.conformance_result is not None for case in preflight_cases)
+    assert run.metrics.conformance_case_count == 2
+    assert run.metrics.conformance_passed_count == 2
+    assert run.metrics.conformance_score == 1.0
+
+
 def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: Path) -> None:
     settings = Settings(
         lancedb_uri=tmp_path / "caller-index",
@@ -218,6 +272,57 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
     assert seen_paths
     assert seen_paths[0] != settings.lancedb_uri
     assert settings.lancedb_uri == tmp_path / "caller-index"
+
+
+def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(
+    monkeypatch, tmp_path: Path
+) -> None:
+    settings = Settings(
+        lancedb_uri=tmp_path / "caller-index",
+        eval_workspace_dir=tmp_path / "workspace",
+    )
+    seen_paths: list[Path] = []
+    closed: list[bool] = []
+
+    class FakeConformanceService:
+        def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(
+        "policynim.services.eval.create_ingest_service",
+        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._create_live_search_service",
+        lambda active_settings, rerank_enabled: FakeSearchService(),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._create_live_preflight_service",
+        lambda active_settings, rerank_enabled: FakePreflightService(),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._create_live_conformance_service",
+        lambda active_settings: FakeConformanceService(),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._build_evidently_report",
+        lambda **kwargs: FakeReport(),
+    )
+    monkeypatch.setattr(
+        "policynim.services.eval._add_report_to_workspace",
+        lambda workspace_path, report, run_name: None,
+    )
+
+    result = EvalService(settings=settings).run(
+        mode="live",
+        backend="nemo",
+        compare_rerank=False,
+    )
+
+    assert result.backend == "nemo"
+    assert seen_paths
+    assert seen_paths[0] != settings.lancedb_uri
+    assert closed == [True]
 
 
 def test_eval_service_start_ui_fails_when_process_exits_early(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -1,0 +1,264 @@
+"""Tests for the NVIDIA policy conformance evaluator adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from openai import RateLimitError
+
+from policynim.errors import ConfigurationError, ProviderError
+from policynim.providers.nvidia import NVIDIAPolicyConformanceEvaluator
+from policynim.types import (
+    Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    PolicyConformanceRequest,
+    PolicyConformanceTraceStep,
+    PolicyGuidance,
+    PreflightResult,
+)
+
+
+class MockChatCompletions:
+    """Deterministic chat client stub."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs):  # noqa: ANN003
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=self.content),
+                )
+            ]
+        )
+
+
+class MockOpenAIClient:
+    """OpenAI client stub with the minimum chat surface."""
+
+    def __init__(self, content: str) -> None:
+        self.chat = SimpleNamespace(completions=MockChatCompletions(content))
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeRateLimitError(RateLimitError):
+    """Minimal rate-limit error subclass for provider classification tests."""
+
+    def __init__(self) -> None:
+        Exception.__init__(self, "too many requests")
+        self.status_code = 429
+
+
+class RaisingChatCompletions:
+    """Chat completions stub that always raises the supplied exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def create(self, **kwargs):  # noqa: ANN003
+        raise self._exc
+
+
+class RaisingOpenAIClient:
+    """OpenAI client stub that always fails during chat completion."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.chat = SimpleNamespace(completions=RaisingChatCompletions(exc))
+
+
+def test_policy_conformance_evaluator_parses_grounded_json() -> None:
+    client = MockOpenAIClient(
+        """
+        {
+          "final_adherence_score": 0.93,
+          "final_adherence_rationale": "The output follows the compiled constraints.",
+          "trajectory_adherence_score": 0.88,
+          "trajectory_adherence_rationale": "The trace preserved compile and generation steps.",
+          "constraint_ids": ["required_steps:0"],
+          "chunk_ids": ["BACKEND-1"],
+          "failure_reasons": []
+        }
+        """
+    )
+    evaluator = make_evaluator(client)
+
+    result = evaluator.evaluate_policy_conformance(make_request())
+
+    assert result.final_adherence_score == 0.93
+    assert result.trajectory_adherence_score == 0.88
+    assert result.constraint_ids == ["required_steps:0"]
+    assert result.chunk_ids == ["BACKEND-1"]
+
+
+def test_policy_conformance_prompt_includes_allowed_ids() -> None:
+    client = MockOpenAIClient(
+        '{"final_adherence_score":1,"constraint_ids":["required_steps:0"],"chunk_ids":["BACKEND-1"]}'
+    )
+    evaluator = make_evaluator(client)
+
+    evaluator.evaluate_policy_conformance(make_request())
+
+    messages = client.chat.completions.calls[0]["messages"]
+    prompt_text = "\n".join(str(message["content"]) for message in messages)  # type: ignore[index]
+    assert "required_steps:0" in prompt_text
+    assert "BACKEND-1" in prompt_text
+    assert "Thread request ids through log context." in prompt_text
+
+
+def test_policy_conformance_extracts_json_from_reasoning_wrappers() -> None:
+    evaluator = make_evaluator(
+        MockOpenAIClient(
+            '<think>reasoning</think>{"final_adherence_score":1,'
+            '"constraint_ids":["required_steps:0"],"chunk_ids":["BACKEND-1"]}'
+        )
+    )
+
+    result = evaluator.evaluate_policy_conformance(make_request())
+
+    assert result.final_adherence_score == 1.0
+
+
+def test_policy_conformance_rejects_invalid_json_and_preserves_cause() -> None:
+    evaluator = make_evaluator(MockOpenAIClient("not json"))
+
+    with pytest.raises(ProviderError, match="invalid JSON") as excinfo:
+        evaluator.evaluate_policy_conformance(make_request())
+
+    assert excinfo.value.failure_class == "invalid_response"
+    assert excinfo.value.__cause__ is not None
+
+
+def test_policy_conformance_rejects_invalid_draft_shape() -> None:
+    evaluator = make_evaluator(MockOpenAIClient('{"final_adherence_score":"high"}'))
+
+    with pytest.raises(ProviderError, match="malformed JSON") as excinfo:
+        evaluator.evaluate_policy_conformance(make_request())
+
+    assert excinfo.value.failure_class == "invalid_response"
+
+
+def test_policy_conformance_rejects_unsupported_constraint_ids() -> None:
+    evaluator = make_evaluator(
+        MockOpenAIClient(
+            '{"final_adherence_score":1,"constraint_ids":["unknown:0"],"chunk_ids":["BACKEND-1"]}'
+        )
+    )
+
+    with pytest.raises(ProviderError, match="unsupported constraint ids") as excinfo:
+        evaluator.evaluate_policy_conformance(make_request())
+
+    assert excinfo.value.failure_class == "invalid_response"
+
+
+def test_policy_conformance_rejects_unsupported_chunk_ids() -> None:
+    evaluator = make_evaluator(
+        MockOpenAIClient(
+            '{"final_adherence_score":1,"constraint_ids":["required_steps:0"],'
+            '"chunk_ids":["UNKNOWN"]}'
+        )
+    )
+
+    with pytest.raises(ProviderError, match="unsupported chunk ids") as excinfo:
+        evaluator.evaluate_policy_conformance(make_request())
+
+    assert excinfo.value.failure_class == "invalid_response"
+
+
+def test_policy_conformance_classifies_upstream_rate_limits() -> None:
+    evaluator = make_evaluator(RaisingOpenAIClient(FakeRateLimitError()))
+
+    with pytest.raises(ProviderError, match="failed after retries") as excinfo:
+        evaluator.evaluate_policy_conformance(make_request())
+
+    assert excinfo.value.failure_class == "rate_limit"
+
+
+def test_policy_conformance_requires_api_key() -> None:
+    with pytest.raises(ConfigurationError, match="NVIDIA_API_KEY"):
+        NVIDIAPolicyConformanceEvaluator(
+            api_key="   ",
+            model="mock-model",
+            base_url="https://example.invalid/v1",
+            timeout_seconds=1,
+            max_retries=0,
+        )
+
+
+def test_policy_conformance_close_leaves_injected_client_open() -> None:
+    client = MockOpenAIClient('{"final_adherence_score":1}')
+    evaluator = make_evaluator(client)
+
+    evaluator.close()
+
+    assert client.closed is False
+
+
+def make_evaluator(client) -> NVIDIAPolicyConformanceEvaluator:
+    return NVIDIAPolicyConformanceEvaluator(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        timeout_seconds=1,
+        max_retries=0,
+        client=client,  # type: ignore[arg-type]
+    )
+
+
+def make_request() -> PolicyConformanceRequest:
+    return PolicyConformanceRequest(
+        task="fix backend logging",
+        result=PreflightResult(
+            task="fix backend logging",
+            summary="Use request ids.",
+            applicable_policies=[
+                PolicyGuidance(
+                    policy_id="BACKEND-LOG-001",
+                    title="Backend Logging",
+                    rationale="Request ids keep logs traceable.",
+                    citation_ids=["BACKEND-1"],
+                )
+            ],
+            plan_steps=["Thread request ids through log context."],
+            citations=[make_citation("BACKEND-1")],
+        ),
+        compiled_packet=CompiledPolicyPacket(
+            task="fix backend logging",
+            top_k=1,
+            task_type="bug_fix",
+            required_steps=[
+                CompiledPolicyConstraint(
+                    statement="Thread request ids through log context.",
+                    citation_ids=["BACKEND-1"],
+                    source_policy_ids=["BACKEND-LOG-001"],
+                )
+            ],
+            citations=[make_citation("BACKEND-1")],
+        ),
+        trace_steps=[
+            PolicyConformanceTraceStep(
+                step_id="compile",
+                kind="policy_compilation",
+                summary="Compiled policy constraints.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+    )
+
+
+def make_citation(chunk_id: str) -> Citation:
+    return Citation(
+        policy_id="BACKEND-LOG-001",
+        title="Backend Logging",
+        path="policies/backend/logging.md",
+        section="Rules",
+        lines="1-4",
+        chunk_id=chunk_id,
+    )

--- a/tests/test_policy_conformance_service.py
+++ b/tests/test_policy_conformance_service.py
@@ -1,0 +1,225 @@
+"""Tests for policy conformance scoring."""
+
+from __future__ import annotations
+
+from policynim.services.conformance import PolicyConformanceService
+from policynim.types import (
+    Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    GeneratedPolicyConformanceDraft,
+    PolicyConformanceRequest,
+    PolicyConformanceTraceStep,
+    PolicyGuidance,
+    PreflightResult,
+)
+
+
+class MockConformanceEvaluator:
+    """Static external evaluator double."""
+
+    def __init__(self, draft: GeneratedPolicyConformanceDraft | None = None) -> None:
+        self._draft = draft or GeneratedPolicyConformanceDraft(
+            final_adherence_score=0.95,
+            final_adherence_rationale="Final output follows the constraints.",
+            trajectory_adherence_score=None,
+        )
+        self.closed = False
+
+    def evaluate_policy_conformance(
+        self,
+        request: PolicyConformanceRequest,
+    ) -> GeneratedPolicyConformanceDraft:
+        assert request.task == "fix backend logging"
+        return self._draft
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_conformance_service_scores_compiled_constraints_against_result() -> None:
+    service = PolicyConformanceService(evaluator=MockConformanceEvaluator())
+
+    result = service.evaluate(make_request(), backend="nemo")
+
+    assert result.passed
+    assert result.backend == "nemo"
+    assert result.final_adherence_score == 0.95
+    assert {metric.name: metric.passed for metric in result.metrics} == {
+        "plan_completeness": True,
+        "guidance_coverage": True,
+        "test_coverage": True,
+        "forbidden_pattern_handling": True,
+        "citation_support": True,
+        "final_adherence": True,
+    }
+
+
+def test_conformance_service_reports_missing_required_and_forbidden_pattern_failures() -> None:
+    service = PolicyConformanceService(evaluator=MockConformanceEvaluator())
+    request = make_request(
+        result=make_result(
+            plan_steps=[],
+            implementation_guidance=["Never log token values."],
+            review_flags=[],
+        )
+    )
+
+    result = service.evaluate(request, backend="nemo")
+
+    assert not result.passed
+    assert any("required steps missing" in reason for reason in result.failure_reasons)
+    assert any("missing from review_flags" in reason for reason in result.failure_reasons)
+    assert any("positive guidance" in reason for reason in result.failure_reasons)
+
+
+def test_conformance_service_skips_trajectory_metric_when_evaluator_omits_it() -> None:
+    service = PolicyConformanceService(evaluator=MockConformanceEvaluator())
+
+    result = service.evaluate(make_request(trace_steps=[]), backend="nemo")
+
+    assert result.trajectory_adherence_score is None
+    assert "trajectory_adherence" not in {metric.name for metric in result.metrics}
+
+
+def test_conformance_service_fails_closed_for_insufficient_compiled_packet() -> None:
+    service = PolicyConformanceService(evaluator=None)
+    request = make_request(
+        compiled_packet=make_compiled_packet(insufficient_context=True),
+    )
+
+    result = service.evaluate(request, backend="nemo")
+
+    assert not result.passed
+    assert len(result.metrics) == 1
+    assert result.metrics[0].name == "compiled_context"
+    assert result.metrics[0].score == 0.0
+    assert result.metrics[0].failure_reasons == ["compiled policy packet has insufficient context"]
+
+
+def test_conformance_service_closes_owned_evaluator() -> None:
+    evaluator = MockConformanceEvaluator()
+    service = PolicyConformanceService(evaluator=evaluator)
+
+    service.close()
+
+    assert evaluator.closed is True
+
+
+def make_request(
+    *,
+    result: PreflightResult | None = None,
+    compiled_packet: CompiledPolicyPacket | None = None,
+    trace_steps: list[PolicyConformanceTraceStep] | None = None,
+) -> PolicyConformanceRequest:
+    return PolicyConformanceRequest(
+        task="fix backend logging",
+        result=result or make_result(),
+        compiled_packet=compiled_packet or make_compiled_packet(),
+        trace_steps=trace_steps
+        if trace_steps is not None
+        else [
+            PolicyConformanceTraceStep(
+                step_id="compile",
+                kind="policy_compilation",
+                summary="Compiled policy constraints.",
+                citation_ids=["BACKEND-1", "SECURITY-1"],
+            )
+        ],
+    )
+
+
+def make_compiled_packet(*, insufficient_context: bool = False) -> CompiledPolicyPacket:
+    return CompiledPolicyPacket(
+        task="fix backend logging",
+        top_k=2,
+        task_type="bug_fix",
+        required_steps=[
+            CompiledPolicyConstraint(
+                statement="Thread request ids through log context.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        forbidden_patterns=[
+            CompiledPolicyConstraint(
+                statement="Never log token values.",
+                citation_ids=["SECURITY-1"],
+                source_policy_ids=["SECURITY-TOKEN-001"],
+            )
+        ],
+        architectural_expectations=[
+            CompiledPolicyConstraint(
+                statement="Keep logging changes in the backend service layer.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        test_expectations=[
+            CompiledPolicyConstraint(
+                statement="Add a regression test for token redaction.",
+                citation_ids=["SECURITY-1"],
+                source_policy_ids=["SECURITY-TOKEN-001"],
+            )
+        ],
+        style_constraints=[
+            CompiledPolicyConstraint(
+                statement="Use explicit request-id naming.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        citations=[
+            make_citation("BACKEND-1", "BACKEND-LOG-001"),
+            make_citation("SECURITY-1", "SECURITY-TOKEN-001"),
+        ],
+        insufficient_context=insufficient_context,
+    )
+
+
+def make_result(
+    *,
+    plan_steps: list[str] | None = None,
+    implementation_guidance: list[str] | None = None,
+    review_flags: list[str] | None = None,
+) -> PreflightResult:
+    return PreflightResult(
+        task="fix backend logging",
+        summary="Use request ids and keep tokens out of logs.",
+        applicable_policies=[
+            PolicyGuidance(
+                policy_id="BACKEND-LOG-001",
+                title="Backend Logging",
+                rationale="Request ids keep logs traceable.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+        plan_steps=plan_steps
+        if plan_steps is not None
+        else ["Thread request ids through log context."],
+        implementation_guidance=implementation_guidance
+        if implementation_guidance is not None
+        else [
+            "Keep logging changes in the backend service layer.",
+            "Use explicit request-id naming.",
+        ],
+        review_flags=review_flags
+        if review_flags is not None
+        else ["Avoid: Never log token values."],
+        tests_required=["Add a regression test for token redaction."],
+        citations=[
+            make_citation("BACKEND-1", "BACKEND-LOG-001"),
+            make_citation("SECURITY-1", "SECURITY-TOKEN-001"),
+        ],
+    )
+
+
+def make_citation(chunk_id: str, policy_id: str) -> Citation:
+    return Citation(
+        policy_id=policy_id,
+        title=policy_id,
+        path=f"policies/{policy_id}.md",
+        section="Rules",
+        lines="1-4",
+        chunk_id=chunk_id,
+    )

--- a/tests/test_policy_conformance_service.py
+++ b/tests/test_policy_conformance_service.py
@@ -9,6 +9,7 @@ from policynim.types import (
     CompiledPolicyPacket,
     GeneratedPolicyConformanceDraft,
     PolicyConformanceRequest,
+    PolicyConformanceResult,
     PolicyConformanceTraceStep,
     PolicyGuidance,
     PreflightResult,
@@ -97,6 +98,24 @@ def test_conformance_service_fails_closed_for_insufficient_compiled_packet() -> 
     assert result.metrics[0].failure_reasons == ["compiled policy packet has insufficient context"]
 
 
+def test_conformance_service_allows_extra_result_citations() -> None:
+    service = PolicyConformanceService(evaluator=None)
+    request = make_request(
+        result=make_result(
+            citations=[
+                make_citation("BACKEND-1", "BACKEND-LOG-001"),
+                make_citation("SECURITY-1", "SECURITY-TOKEN-001"),
+                make_citation("CONTEXT-1", "CONTEXT-EXTRA-001"),
+            ]
+        )
+    )
+
+    result = service.evaluate(request, backend="nemo")
+
+    assert result.passed
+    assert _metric_score(result, "citation_support") == 1.0
+
+
 def test_conformance_service_closes_owned_evaluator() -> None:
     evaluator = MockConformanceEvaluator()
     service = PolicyConformanceService(evaluator=evaluator)
@@ -182,6 +201,7 @@ def make_result(
     plan_steps: list[str] | None = None,
     implementation_guidance: list[str] | None = None,
     review_flags: list[str] | None = None,
+    citations: list[Citation] | None = None,
 ) -> PreflightResult:
     return PreflightResult(
         task="fix backend logging",
@@ -207,11 +227,20 @@ def make_result(
         if review_flags is not None
         else ["Avoid: Never log token values."],
         tests_required=["Add a regression test for token redaction."],
-        citations=[
+        citations=citations
+        if citations is not None
+        else [
             make_citation("BACKEND-1", "BACKEND-LOG-001"),
             make_citation("SECURITY-1", "SECURITY-TOKEN-001"),
         ],
     )
+
+
+def _metric_score(result: PolicyConformanceResult, metric_name: str) -> float:
+    for metric in result.metrics:
+        if metric.name == metric_name:
+            return metric.score
+    raise AssertionError(f"missing metric {metric_name}")
 
 
 def make_citation(chunk_id: str, policy_id: str) -> Citation:

--- a/tests/test_preflight_service.py
+++ b/tests/test_preflight_service.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import pytest
 
+import policynim.services.preflight as preflight_module
 from policynim.errors import MissingIndexError
 from policynim.services.preflight import (
     DraftPolicyGuidance,
@@ -342,6 +343,48 @@ def test_preflight_service_trace_exposes_internal_compiled_packet_without_changi
     assert trace_result.compiled_packet.required_steps
     assert [chunk.chunk_id for chunk in trace_result.retained_context] == ["BACKEND-1"]
     assert [step.step_id for step in trace_result.trace_steps] == ["compile", "generate"]
+
+
+def test_preflight_service_preflight_keeps_trace_creation_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_trace_step(**_: object) -> object:
+        raise AssertionError("preflight() should not build trace steps")
+
+    monkeypatch.setattr(preflight_module, "_trace_step", fail_trace_step)
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.99,
+            )
+        ]
+    )
+    draft = GeneratedPreflightDraft(
+        summary="Use request ids in logs.",
+        applicable_policies=[
+            DraftPolicyGuidance(
+                policy_id="BACKEND-LOG-001",
+                title="Logging",
+                rationale="Use the retained backend logging policy.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+        citation_ids=["BACKEND-1"],
+    )
+    service = PreflightService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        reranker=MockReranker(order=["BACKEND-1"]),
+        generator=MockGenerator(draft),
+        compiler=MockPolicyCompiler(),
+    )
+
+    result = service.preflight(PreflightRequest(task="backend guidance", top_k=1))
+
+    assert not result.insufficient_context
 
 
 def test_preflight_service_fails_closed_when_compiler_has_insufficient_context() -> None:

--- a/tests/test_preflight_service.py
+++ b/tests/test_preflight_service.py
@@ -302,6 +302,48 @@ def test_preflight_service_merges_compiled_constraints_into_result() -> None:
     assert result.tests_required == ["Keep existing tests green."]
 
 
+def test_preflight_service_trace_exposes_internal_compiled_packet_without_changing_result() -> None:
+    store = MockIndexStore(
+        [
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                domain="backend",
+                score=0.99,
+            )
+        ]
+    )
+    draft = GeneratedPreflightDraft(
+        summary="Use request ids in logs.",
+        applicable_policies=[
+            DraftPolicyGuidance(
+                policy_id="BACKEND-LOG-001",
+                title="Logging",
+                rationale="Use the retained backend logging policy.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+        citation_ids=["BACKEND-1"],
+    )
+    generator = MockGenerator(draft)
+    service = PreflightService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        reranker=MockReranker(order=["BACKEND-1"]),
+        generator=generator,
+        compiler=MockPolicyCompiler(),
+    )
+
+    trace_result = service.preflight_with_trace(PreflightRequest(task="backend guidance", top_k=1))
+
+    assert trace_result.result == service.preflight(
+        PreflightRequest(task="backend guidance", top_k=1)
+    )
+    assert trace_result.compiled_packet.required_steps
+    assert [chunk.chunk_id for chunk in trace_result.retained_context] == ["BACKEND-1"]
+    assert [step.step_id for step in trace_result.trace_steps] == ["compile", "generate"]
+
+
 def test_preflight_service_fails_closed_when_compiler_has_insufficient_context() -> None:
     store = MockIndexStore(
         [


### PR DESCRIPTION
## Summary
- add eval backend selection with `--backend default|nemo`
- add policy conformance contracts, deterministic scoring, and internal preflight trace support
- add NVIDIA-backed conformance evaluator plus eval artifact/report fields
- update docs and tests for Build 3 conformance evaluation

## Verification
- `uv run pytest -q tests/test_policy_conformance_service.py tests/test_nvidia_policy_conformance.py tests/test_eval_service.py tests/test_cli.py tests/test_preflight_service.py tests/test_service_factories.py` -> 126 passed
- `uv run pytest -q` -> 397 passed, 6 skipped
- `uv run ruff check` -> passed
- `uvx pyright src tests` -> 0 errors
- `git diff --check` -> passed
- `uv run policynim eval --help` -> shows `--backend [default|nemo]`

## Notes
- `.plan/` is ignored by this repository, so the local Build 3 execution-plan artifact is not part of this PR.