### PR TITLE
Add policy evidence traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - Opt-in preflight evidence traces that link chunks, selected policies, compiled
   constraints, generated guidance, and conformance checks.
 - Eval backend selection with optional policy-conformance scoring for compiled
-  plans and preflight outputs, with traces embedded in eval result artifacts.
+  plans and preflight outputs, with compact traces embedded in eval result
+  artifacts.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
 - JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - Policy compilation into citation-backed planning and generation constraints.
 - Grounded preflight synthesis with compiled plan steps, citation validation, and
   fail-closed fallback.
+- Opt-in preflight evidence traces that link chunks, selected policies, compiled
+  constraints, generated guidance, and conformance checks.
 - Eval backend selection with optional policy-conformance scoring for compiled
-  plans and preflight outputs.
+  plans and preflight outputs, with traces embedded in eval result artifacts.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
 - JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
@@ -102,6 +104,7 @@ uv run policynim search --query "refresh token cleanup background job" --top-k 5
 uv run policynim route --task "Implement a refresh-token cleanup background job" --top-k 5
 uv run policynim compile --task "Implement a refresh-token cleanup background job" --top-k 5
 uv run policynim preflight --task "Implement a refresh-token cleanup background job" --top-k 5
+uv run policynim preflight --task "Implement a refresh-token cleanup background job" --top-k 5 --trace
 ```
 
 Use [docs/contributor-guide.md](docs/contributor-guide.md) for environment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,11 @@ Preflight flow:
 6. materialize public citations and policy guidance
 7. return a JSON-first `PreflightResult`
 
+When the CLI passes `--trace`, `PreflightService.preflight_with_trace()` exposes
+the same compiled packet and retained context to `PolicyEvidenceTraceService`.
+The trace service builds a `PolicyEvidenceTrace` from already-materialized data;
+it does not re-run retrieval, compilation, generation, or conformance.
+
 Fail-closed rules are central here:
 
 - missing configuration remains an explicit error
@@ -147,7 +152,7 @@ Evaluation flow:
 4. optionally add policy-conformance scoring for preflight cases with
    `--backend nemo`
 5. compare rerank-enabled and rerank-disabled runs
-6. persist JSON artifacts and HTML reports
+6. persist JSON artifacts and HTML reports, including preflight evidence traces
 7. optionally start the local Evidently UI
 
 Important evaluation rules:
@@ -158,6 +163,8 @@ Important evaluation rules:
 - the default backend is code-scored and does not use LLM-as-judge behavior
 - the `nemo` backend adds deterministic conformance checks plus final-adherence
   judgment for preflight cases
+- preflight eval cases include `PolicyEvidenceTrace`; search cases keep
+  `evidence_trace=null`
 - expected chunk recall, policy recall, and insufficient-context accuracy are the
   core tracked metrics
 
@@ -301,6 +308,8 @@ Shared interface guarantees:
   in Build 2.
 - CLI `preflight` and MCP `policy_preflight` use the same `PreflightResult`
   shape.
+- CLI `preflight --trace` returns `PreflightEvidenceTraceResult`; there is no
+  MCP trace tool.
 - CLI `runtime decide` and `runtime execute` use the same `RuntimeActionRequest`
   input shape.
 - CLI `evidence report` returns a typed session summary over the SQLite runtime

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,9 @@ Preflight flow:
 When the CLI passes `--trace`, `PreflightService.preflight_with_trace()` exposes
 the same compiled packet and retained context to `PolicyEvidenceTraceService`.
 The trace service builds a `PolicyEvidenceTrace` from already-materialized data;
-it does not re-run retrieval, compilation, generation, or conformance.
+it does not re-run retrieval, compilation, generation, or conformance. The
+interactive CLI trace includes retained chunk text; eval uses the same trace
+contract in compact mode and omits retained chunk text from persisted artifacts.
 
 Fail-closed rules are central here:
 
@@ -152,7 +154,8 @@ Evaluation flow:
 4. optionally add policy-conformance scoring for preflight cases with
    `--backend nemo`
 5. compare rerank-enabled and rerank-disabled runs
-6. persist JSON artifacts and HTML reports, including preflight evidence traces
+6. persist JSON artifacts and HTML reports, including compact preflight evidence
+   traces
 7. optionally start the local Evidently UI
 
 Important evaluation rules:
@@ -163,7 +166,7 @@ Important evaluation rules:
 - the default backend is code-scored and does not use LLM-as-judge behavior
 - the `nemo` backend adds deterministic conformance checks plus final-adherence
   judgment for preflight cases
-- preflight eval cases include `PolicyEvidenceTrace`; search cases keep
+- preflight eval cases include compact `PolicyEvidenceTrace`; search cases keep
   `evidence_trace=null`
 - expected chunk recall, policy recall, and insufficient-context accuracy are the
   core tracked metrics

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -72,6 +72,9 @@ constraints, not setup mistakes.
 - This happens when the grounded answer does not survive citation validation or the
   retained evidence is too weak for a trustworthy result.
 - The system intentionally prefers no grounded answer over a fabricated one.
+- `preflight --trace` can show which chunks, selected policies, and compiled
+  constraints were retained before the fail-closed result, but it does not retry
+  or regenerate the answer.
 
 ### Evaluation Is Gold-Case Driven
 
@@ -82,6 +85,8 @@ constraints, not setup mistakes.
 - The `nemo` eval backend adds policy-conformance checks for preflight cases, but
   it remains a narrow conformance signal rather than a broad benchmark of prose
   quality or policy nuance.
+- Eval JSON artifacts include evidence traces for preflight cases only. They are
+  not a persistent tracing backend, database, or generic workflow replay system.
 
 ### No Separate Review Or Approval Layer
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -73,8 +73,8 @@ constraints, not setup mistakes.
   retained evidence is too weak for a trustworthy result.
 - The system intentionally prefers no grounded answer over a fabricated one.
 - `preflight --trace` can show which chunks, selected policies, and compiled
-  constraints were retained before the fail-closed result, but it does not retry
-  or regenerate the answer.
+  constraints were retained before the fail-closed result, including retained
+  chunk text, but it does not retry or regenerate the answer.
 
 ### Evaluation Is Gold-Case Driven
 
@@ -86,7 +86,8 @@ constraints, not setup mistakes.
   it remains a narrow conformance signal rather than a broad benchmark of prose
   quality or policy nuance.
 - Eval JSON artifacts include evidence traces for preflight cases only. They are
-  not a persistent tracing backend, database, or generic workflow replay system.
+  compact by default, omit retained chunk text, and are not a persistent tracing
+  backend, database, or generic workflow replay system.
 
 ### No Separate Review Or Approval Layer
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -173,8 +173,8 @@ uv run policynim preflight \
 `preflight --trace` returns a JSON `PreflightEvidenceTraceResult` with the public
 `PreflightResult` plus a `PolicyEvidenceTrace` containing retained chunks,
 selected policies, compiled constraints, generated output links, and trace steps.
-It does not add a new artifact directory or call NVIDIA beyond the normal
-preflight route.
+Interactive preflight traces include retained chunk text. They do not add a new
+artifact directory or call NVIDIA beyond the normal preflight route.
 
 ### 7. Run Evaluations
 
@@ -188,7 +188,8 @@ Default behavior:
 - uses the `default` eval backend unless `--backend nemo` is provided
 - executes rerank-enabled and rerank-disabled runs
 - writes JSON artifacts and HTML reports under `data/evals/workspace`
-- embeds `PolicyEvidenceTrace` records in preflight eval case JSON artifacts
+- embeds compact `PolicyEvidenceTrace` records in preflight eval case JSON
+  artifacts
 - starts the local Evidently UI on `http://localhost:8001`
 
 Useful variants:
@@ -209,7 +210,9 @@ offline mode it uses deterministic local fixtures; in live mode it reuses the
 configured NVIDIA chat model for final-adherence judgment.
 
 Search eval cases keep `evidence_trace=null`; preflight eval cases include the
-trace used for conformance and debugging.
+trace used for conformance and debugging. Eval traces keep chunk IDs, paths,
+sections, line spans, scores, selected policies, constraints, and output links,
+but omit retained chunk text to keep artifacts compact by default.
 
 ### 6. Run The MCP Server
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -161,6 +161,21 @@ returns `insufficient_context=true` instead of bluffing.
 compiled packet to condition plan steps, implementation guidance, review flags,
 and test expectations.
 
+Add `--trace` when you need to inspect the full policy evidence path:
+
+```bash
+uv run policynim preflight \
+  --task "Implement a refresh-token cleanup background job" \
+  --top-k 5 \
+  --trace
+```
+
+`preflight --trace` returns a JSON `PreflightEvidenceTraceResult` with the public
+`PreflightResult` plus a `PolicyEvidenceTrace` containing retained chunks,
+selected policies, compiled constraints, generated output links, and trace steps.
+It does not add a new artifact directory or call NVIDIA beyond the normal
+preflight route.
+
 ### 7. Run Evaluations
 
 ```bash
@@ -173,6 +188,7 @@ Default behavior:
 - uses the `default` eval backend unless `--backend nemo` is provided
 - executes rerank-enabled and rerank-disabled runs
 - writes JSON artifacts and HTML reports under `data/evals/workspace`
+- embeds `PolicyEvidenceTrace` records in preflight eval case JSON artifacts
 - starts the local Evidently UI on `http://localhost:8001`
 
 Useful variants:
@@ -191,6 +207,9 @@ it does not overwrite the normal runtime index.
 `--backend nemo` adds policy-conformance scoring for preflight eval cases. In
 offline mode it uses deterministic local fixtures; in live mode it reuses the
 configured NVIDIA chat model for final-adherence judgment.
+
+Search eval cases keep `evidence_trace=null`; preflight eval cases include the
+trace used for conformance and debugging.
 
 ### 6. Run The MCP Server
 

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -21,6 +21,7 @@ from policynim.services import (
     create_index_dump_service,
     create_ingest_service,
     create_policy_compiler_service,
+    create_policy_evidence_trace_service,
     create_policy_router_service,
     create_preflight_service,
     create_runtime_decision_service,
@@ -34,6 +35,7 @@ from policynim.types import (
     CompileRequest,
     EvalBackend,
     EvalExecutionMode,
+    PreflightEvidenceTraceResult,
     PreflightRequest,
     RouteRequest,
     RuntimeActionRequest,
@@ -205,6 +207,13 @@ def preflight(
             help="Retrieval depth. Allowed range: 1-20.",
         ),
     ] = None,
+    trace: Annotated[
+        bool,
+        typer.Option(
+            "--trace",
+            help="Include a replay-free evidence trace with the preflight result.",
+        ),
+    ] = False,
 ) -> None:
     """Return policy guidance for a coding task."""
     service = None
@@ -212,7 +221,16 @@ def preflight(
         settings = _load_setup_dependent_settings()
         resolved_top_k = top_k if top_k is not None else settings.default_top_k
         service = create_preflight_service(settings)
-        result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
+        request = PreflightRequest(task=task, domain=domain, top_k=resolved_top_k)
+        if trace:
+            trace_result = service.preflight_with_trace(request)
+            evidence_trace = create_policy_evidence_trace_service().build(trace_result)
+            result = PreflightEvidenceTraceResult(
+                result=trace_result.result,
+                evidence_trace=evidence_trace,
+            )
+        else:
+            result = service.preflight(request)
     except ValidationError as exc:
         _exit_with_error(_format_validation_error("Preflight request", exc))
     except PolicyNIMError as exc:

--- a/src/policynim/services/__init__.py
+++ b/src/policynim/services/__init__.py
@@ -5,6 +5,10 @@ from policynim.services.compiler import PolicyCompilerService, create_policy_com
 from policynim.services.conformance import PolicyConformanceService
 from policynim.services.dump import IndexDumpService, create_index_dump_service
 from policynim.services.eval import EvalService, create_eval_service
+from policynim.services.evidence_trace import (
+    PolicyEvidenceTraceService,
+    create_policy_evidence_trace_service,
+)
 from policynim.services.health import (
     RuntimeHealthService,
     create_runtime_health_service,
@@ -35,6 +39,7 @@ __all__ = [
     "PreflightService",
     "PolicyCompilerService",
     "PolicyConformanceService",
+    "PolicyEvidenceTraceService",
     "PolicyRouterService",
     "RuntimeDecisionService",
     "RuntimeEvidenceReportService",
@@ -42,6 +47,7 @@ __all__ = [
     "RuntimeHealthService",
     "SearchService",
     "create_beta_auth_service",
+    "create_policy_evidence_trace_service",
     "create_policy_compiler_service",
     "create_eval_service",
     "create_runtime_decision_service",

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -80,6 +80,10 @@ class PolicyConformanceService:
                 if evaluator_draft is not None
                 else None
             ),
+            constraint_ids=(
+                list(evaluator_draft.constraint_ids) if evaluator_draft is not None else []
+            ),
+            chunk_ids=list(evaluator_draft.chunk_ids) if evaluator_draft is not None else [],
             failure_reasons=failure_reasons,
         )
 

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -385,6 +385,7 @@ def _score_suite_cases(
         evidence_trace = trace_service.build(
             trace_result,
             conformance_result=conformance_result,
+            include_chunk_text=False,
         )
         results.append(
             _score_preflight_case(

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -20,12 +20,14 @@ from policynim.contracts import Generator, IndexStore, Reranker
 from policynim.errors import PolicyNIMError
 from policynim.runtime_paths import resolve_eval_suite_path, resolve_runtime_path
 from policynim.services.conformance import PolicyConformanceService
+from policynim.services.evidence_trace import create_policy_evidence_trace_service
 from policynim.services.ingest import create_ingest_service
 from policynim.services.preflight import PreflightService
 from policynim.services.search import SearchService
 from policynim.settings import Settings, get_settings
 from policynim.storage import LanceDBIndexStore
 from policynim.types import (
+    CompiledPolicyConstraint,
     CompiledPolicyPacket,
     CompileRequest,
     EvalAggregateMetrics,
@@ -46,6 +48,7 @@ from policynim.types import (
     PolicyChunk,
     PolicyConformanceRequest,
     PolicyConformanceResult,
+    PolicyEvidenceTrace,
     PolicyMetadata,
     PolicySelectionPacket,
     PreflightRequest,
@@ -356,6 +359,7 @@ def _score_suite_cases(
     rerank_enabled: bool,
 ) -> list[EvalCaseResult]:
     results: list[EvalCaseResult] = []
+    trace_service = create_policy_evidence_trace_service()
     for case in cases:
         if case.kind == "search":
             result = search_service.search(
@@ -366,26 +370,28 @@ def _score_suite_cases(
 
         request = PreflightRequest(task=case.input, domain=case.domain, top_k=case.top_k)
         conformance_result: PolicyConformanceResult | None = None
-        if conformance_service is None:
-            result = preflight_service.preflight(request)
-        else:
-            trace_result = preflight_service.preflight_with_trace(request)
-            result = trace_result.result
-            if not result.insufficient_context:
-                conformance_result = conformance_service.evaluate(
-                    PolicyConformanceRequest(
-                        task=request.task,
-                        result=result,
-                        compiled_packet=trace_result.compiled_packet,
-                        trace_steps=trace_result.trace_steps,
-                    ),
-                    backend=backend,
-                )
+        trace_result = preflight_service.preflight_with_trace(request)
+        result = trace_result.result
+        if conformance_service is not None and not result.insufficient_context:
+            conformance_result = conformance_service.evaluate(
+                PolicyConformanceRequest(
+                    task=request.task,
+                    result=result,
+                    compiled_packet=trace_result.compiled_packet,
+                    trace_steps=trace_result.trace_steps,
+                ),
+                backend=backend,
+            )
+        evidence_trace = trace_service.build(
+            trace_result,
+            conformance_result=conformance_result,
+        )
         results.append(
             _score_preflight_case(
                 case,
                 result=result,
                 conformance_result=conformance_result,
+                evidence_trace=evidence_trace,
                 rerank_enabled=rerank_enabled,
             )
         )
@@ -442,6 +448,7 @@ def _score_preflight_case(
     *,
     result: PreflightResult,
     conformance_result: PolicyConformanceResult | None = None,
+    evidence_trace: PolicyEvidenceTrace | None = None,
     rerank_enabled: bool,
 ) -> EvalCaseResult:
     actual_policy_ids = [policy.policy_id for policy in result.applicable_policies]
@@ -487,6 +494,7 @@ def _score_preflight_case(
         matched_policy_ids=matched_policy_ids,
         actual_summary=result.summary,
         conformance_result=conformance_result,
+        evidence_trace=evidence_trace,
         metrics=EvalCaseMetrics(
             expected_chunk_recall=_recall(len(matched_chunk_ids), len(case.expected_chunk_ids)),
             expected_policy_recall=_recall(len(matched_policy_ids), len(case.expected_policy_ids)),
@@ -728,6 +736,17 @@ def _build_evidently_report(
                 " | ".join(result.conformance_result.failure_reasons)
                 if result.conformance_result is not None
                 else ""
+            ),
+            "evidence_trace_chunk_count": (
+                len(result.evidence_trace.chunks) if result.evidence_trace is not None else 0
+            ),
+            "evidence_trace_constraint_count": (
+                len(result.evidence_trace.constraints) if result.evidence_trace is not None else 0
+            ),
+            "evidence_trace_conformance_check_count": (
+                len(result.evidence_trace.conformance_checks)
+                if result.evidence_trace is not None
+                else 0
             ),
             "actual_summary": result.actual_summary or "",
             "overall_pass_rate": metrics.overall_pass_rate,
@@ -1064,13 +1083,30 @@ class _OfflinePolicyConformanceEvaluator:
                 if trajectory_score is not None
                 else None
             ),
-            constraint_ids=[],
+            constraint_ids=_offline_policy_conformance_constraint_ids(request.compiled_packet),
             chunk_ids=[citation.chunk_id for citation in request.result.citations],
             failure_reasons=[],
         )
 
     def close(self) -> None:
         return None
+
+
+def _offline_policy_conformance_constraint_ids(
+    compiled_packet: CompiledPolicyPacket,
+) -> list[str]:
+    categories: tuple[tuple[str, Sequence[CompiledPolicyConstraint]], ...] = (
+        ("required_steps", compiled_packet.required_steps),
+        ("forbidden_patterns", compiled_packet.forbidden_patterns),
+        ("architectural_expectations", compiled_packet.architectural_expectations),
+        ("test_expectations", compiled_packet.test_expectations),
+        ("style_constraints", compiled_packet.style_constraints),
+    )
+    return [
+        f"{category_name}:{index}"
+        for category_name, constraints in categories
+        for index, _constraint in enumerate(constraints)
+    ]
 
 
 def _cleanup_job_draft(context_by_id: dict[str, ScoredChunk]) -> GeneratedPreflightDraft:

--- a/src/policynim/services/evidence_trace.py
+++ b/src/policynim/services/evidence_trace.py
@@ -30,6 +30,7 @@ class PolicyEvidenceTraceService:
         trace_result: PreflightTraceResult,
         *,
         conformance_result: PolicyConformanceResult | None = None,
+        include_chunk_text: bool = True,
     ) -> PolicyEvidenceTrace:
         """Materialize a policy evidence trace without re-running the pipeline."""
         compiled_packet = trace_result.compiled_packet
@@ -43,7 +44,10 @@ class PolicyEvidenceTraceService:
             profile_signals=list(compiled_packet.profile_signals),
             insufficient_context=trace_result.result.insufficient_context,
             compiled_insufficient_context=compiled_packet.insufficient_context,
-            chunks=_trace_chunks(trace_result.retained_context),
+            chunks=_trace_chunks(
+                trace_result.retained_context,
+                include_chunk_text=include_chunk_text,
+            ),
             selected_policies=_trace_policies(compiled_packet),
             constraints=constraints,
             output_links=_trace_output_links(trace_result.result, constraints),
@@ -57,7 +61,11 @@ def create_policy_evidence_trace_service() -> PolicyEvidenceTraceService:
     return PolicyEvidenceTraceService()
 
 
-def _trace_chunks(chunks: Sequence[ScoredChunk]) -> list[PolicyEvidenceTraceChunk]:
+def _trace_chunks(
+    chunks: Sequence[ScoredChunk],
+    *,
+    include_chunk_text: bool,
+) -> list[PolicyEvidenceTraceChunk]:
     seen_chunk_ids: set[str] = set()
     trace_chunks: list[PolicyEvidenceTraceChunk] = []
     for chunk in chunks:
@@ -73,7 +81,7 @@ def _trace_chunks(chunks: Sequence[ScoredChunk]) -> list[PolicyEvidenceTraceChun
                 path=chunk.path,
                 section=chunk.section,
                 lines=chunk.lines,
-                text=chunk.text,
+                text=chunk.text if include_chunk_text else None,
                 score=chunk.score,
             )
         )

--- a/src/policynim/services/evidence_trace.py
+++ b/src/policynim/services/evidence_trace.py
@@ -1,0 +1,328 @@
+"""Evidence trace materialization for policy-conditioned preflight runs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from policynim.types import (
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    PolicyConformanceResult,
+    PolicyEvidenceTrace,
+    PolicyEvidenceTraceChunk,
+    PolicyEvidenceTraceConformanceCheck,
+    PolicyEvidenceTraceConstraint,
+    PolicyEvidenceTraceConstraintCategory,
+    PolicyEvidenceTraceOutputField,
+    PolicyEvidenceTraceOutputLink,
+    PolicyEvidenceTracePolicy,
+    PreflightResult,
+    PreflightTraceResult,
+    ScoredChunk,
+)
+
+
+class PolicyEvidenceTraceService:
+    """Build replay-free trace records from existing preflight and eval data."""
+
+    def build(
+        self,
+        trace_result: PreflightTraceResult,
+        *,
+        conformance_result: PolicyConformanceResult | None = None,
+    ) -> PolicyEvidenceTrace:
+        """Materialize a policy evidence trace without re-running the pipeline."""
+        compiled_packet = trace_result.compiled_packet
+        constraints = _trace_constraints(compiled_packet)
+        return PolicyEvidenceTrace(
+            task=trace_result.result.task,
+            domain=trace_result.result.domain,
+            top_k=compiled_packet.top_k,
+            task_type=compiled_packet.task_type,
+            explicit_task_type=compiled_packet.explicit_task_type,
+            profile_signals=list(compiled_packet.profile_signals),
+            insufficient_context=trace_result.result.insufficient_context,
+            compiled_insufficient_context=compiled_packet.insufficient_context,
+            chunks=_trace_chunks(trace_result.retained_context),
+            selected_policies=_trace_policies(compiled_packet),
+            constraints=constraints,
+            output_links=_trace_output_links(trace_result.result, constraints),
+            trace_steps=list(trace_result.trace_steps),
+            conformance_checks=_trace_conformance_checks(conformance_result, constraints),
+        )
+
+
+def create_policy_evidence_trace_service() -> PolicyEvidenceTraceService:
+    """Build the default policy evidence trace service."""
+    return PolicyEvidenceTraceService()
+
+
+def _trace_chunks(chunks: Sequence[ScoredChunk]) -> list[PolicyEvidenceTraceChunk]:
+    seen_chunk_ids: set[str] = set()
+    trace_chunks: list[PolicyEvidenceTraceChunk] = []
+    for chunk in chunks:
+        if chunk.chunk_id in seen_chunk_ids:
+            continue
+        seen_chunk_ids.add(chunk.chunk_id)
+        trace_chunks.append(
+            PolicyEvidenceTraceChunk(
+                chunk_id=chunk.chunk_id,
+                policy_id=chunk.policy.policy_id,
+                policy_title=chunk.policy.title,
+                domain=chunk.policy.domain,
+                path=chunk.path,
+                section=chunk.section,
+                lines=chunk.lines,
+                text=chunk.text,
+                score=chunk.score,
+            )
+        )
+    return trace_chunks
+
+
+def _trace_policies(compiled_packet: CompiledPolicyPacket) -> list[PolicyEvidenceTracePolicy]:
+    return [
+        PolicyEvidenceTracePolicy(
+            policy_id=policy.policy_id,
+            title=policy.title,
+            reason=policy.reason,
+            supporting_chunk_ids=_ordered_unique(
+                [evidence.chunk_id for evidence in policy.evidence]
+            ),
+        )
+        for policy in compiled_packet.selected_policies
+    ]
+
+
+def _trace_constraints(
+    compiled_packet: CompiledPolicyPacket,
+) -> list[PolicyEvidenceTraceConstraint]:
+    constraints: list[PolicyEvidenceTraceConstraint] = []
+    categories: tuple[
+        tuple[PolicyEvidenceTraceConstraintCategory, Sequence[CompiledPolicyConstraint]],
+        ...,
+    ] = (
+        ("required_steps", compiled_packet.required_steps),
+        ("forbidden_patterns", compiled_packet.forbidden_patterns),
+        ("architectural_expectations", compiled_packet.architectural_expectations),
+        ("test_expectations", compiled_packet.test_expectations),
+        ("style_constraints", compiled_packet.style_constraints),
+    )
+    for category, category_constraints in categories:
+        for index, constraint in enumerate(category_constraints):
+            constraints.append(
+                PolicyEvidenceTraceConstraint(
+                    constraint_id=f"{category}:{index}",
+                    category=category,
+                    statement=constraint.statement,
+                    citation_ids=list(constraint.citation_ids),
+                    source_policy_ids=list(constraint.source_policy_ids),
+                )
+            )
+    return constraints
+
+
+def _trace_output_links(
+    result: PreflightResult,
+    constraints: Sequence[PolicyEvidenceTraceConstraint],
+) -> list[PolicyEvidenceTraceOutputLink]:
+    constraints_by_text = _constraints_by_output_text(constraints)
+    links: list[PolicyEvidenceTraceOutputLink] = []
+    links.extend(_trace_text_outputs("plan_steps", result.plan_steps, constraints_by_text))
+    links.extend(
+        _trace_text_outputs(
+            "implementation_guidance",
+            result.implementation_guidance,
+            constraints_by_text,
+        )
+    )
+    links.extend(_trace_text_outputs("review_flags", result.review_flags, constraints_by_text))
+    links.extend(_trace_text_outputs("tests_required", result.tests_required, constraints_by_text))
+    constraints_by_chunk_id = _constraints_by_chunk_id(constraints)
+    for index, citation in enumerate(result.citations):
+        linked_constraints = constraints_by_chunk_id.get(citation.chunk_id, [])
+        links.append(
+            PolicyEvidenceTraceOutputLink(
+                field="citations",
+                index=index,
+                text=citation.chunk_id,
+                constraint_ids=[constraint.constraint_id for constraint in linked_constraints],
+                chunk_ids=[citation.chunk_id],
+            )
+        )
+    return links
+
+
+def _trace_text_outputs(
+    field: PolicyEvidenceTraceOutputField,
+    values: Sequence[str],
+    constraints_by_text: dict[str, list[PolicyEvidenceTraceConstraint]],
+) -> list[PolicyEvidenceTraceOutputLink]:
+    links: list[PolicyEvidenceTraceOutputLink] = []
+    for index, text in enumerate(values):
+        linked_constraints = constraints_by_text.get(text, [])
+        links.append(
+            PolicyEvidenceTraceOutputLink(
+                field=field,
+                index=index,
+                text=text,
+                constraint_ids=[constraint.constraint_id for constraint in linked_constraints],
+                chunk_ids=_ordered_unique(
+                    [
+                        chunk_id
+                        for constraint in linked_constraints
+                        for chunk_id in constraint.citation_ids
+                    ]
+                ),
+            )
+        )
+    return links
+
+
+def _trace_conformance_checks(
+    conformance_result: PolicyConformanceResult | None,
+    constraints: Sequence[PolicyEvidenceTraceConstraint],
+) -> list[PolicyEvidenceTraceConformanceCheck]:
+    if conformance_result is None:
+        return []
+
+    constraints_by_category = _constraints_by_category(constraints)
+    all_constraint_ids = [constraint.constraint_id for constraint in constraints]
+    all_chunk_ids = _ordered_unique(
+        [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
+    )
+    checks: list[PolicyEvidenceTraceConformanceCheck] = []
+    for metric in conformance_result.metrics:
+        constraint_ids = _metric_constraint_ids(
+            metric.name,
+            constraints_by_category,
+            all_constraint_ids,
+        )
+        chunk_ids = _metric_chunk_ids(metric.name, constraints_by_category, all_chunk_ids)
+        if metric.name in {"final_adherence", "trajectory_adherence"}:
+            constraint_ids = list(conformance_result.constraint_ids)
+            chunk_ids = list(conformance_result.chunk_ids)
+        checks.append(
+            PolicyEvidenceTraceConformanceCheck(
+                backend=conformance_result.backend,
+                name=metric.name,
+                passed=metric.passed,
+                score=metric.score,
+                failure_reasons=list(metric.failure_reasons),
+                constraint_ids=constraint_ids,
+                chunk_ids=chunk_ids,
+            )
+        )
+    return checks
+
+
+def _constraints_by_output_text(
+    constraints: Sequence[PolicyEvidenceTraceConstraint],
+) -> dict[str, list[PolicyEvidenceTraceConstraint]]:
+    constraints_by_text: dict[str, list[PolicyEvidenceTraceConstraint]] = {}
+    for constraint in constraints:
+        constraints_by_text.setdefault(constraint.statement, []).append(constraint)
+        if constraint.category == "forbidden_patterns":
+            constraints_by_text.setdefault(f"Avoid: {constraint.statement}", []).append(constraint)
+    return constraints_by_text
+
+
+def _constraints_by_chunk_id(
+    constraints: Sequence[PolicyEvidenceTraceConstraint],
+) -> dict[str, list[PolicyEvidenceTraceConstraint]]:
+    constraints_by_chunk_id: dict[str, list[PolicyEvidenceTraceConstraint]] = {}
+    for constraint in constraints:
+        for citation_id in constraint.citation_ids:
+            constraints_by_chunk_id.setdefault(citation_id, []).append(constraint)
+    return constraints_by_chunk_id
+
+
+def _constraints_by_category(
+    constraints: Sequence[PolicyEvidenceTraceConstraint],
+) -> dict[PolicyEvidenceTraceConstraintCategory, list[PolicyEvidenceTraceConstraint]]:
+    constraints_by_category: dict[
+        PolicyEvidenceTraceConstraintCategory, list[PolicyEvidenceTraceConstraint]
+    ] = {
+        "required_steps": [],
+        "forbidden_patterns": [],
+        "architectural_expectations": [],
+        "test_expectations": [],
+        "style_constraints": [],
+    }
+    for constraint in constraints:
+        constraints_by_category[constraint.category].append(constraint)
+    return constraints_by_category
+
+
+def _metric_constraint_ids(
+    metric_name: str,
+    constraints_by_category: dict[
+        PolicyEvidenceTraceConstraintCategory, list[PolicyEvidenceTraceConstraint]
+    ],
+    all_constraint_ids: Sequence[str],
+) -> list[str]:
+    if metric_name == "plan_completeness":
+        return [
+            constraint.constraint_id for constraint in constraints_by_category["required_steps"]
+        ]
+    if metric_name == "guidance_coverage":
+        return [
+            constraint.constraint_id
+            for constraint in (
+                *constraints_by_category["architectural_expectations"],
+                *constraints_by_category["style_constraints"],
+            )
+        ]
+    if metric_name == "test_coverage":
+        return [
+            constraint.constraint_id for constraint in constraints_by_category["test_expectations"]
+        ]
+    if metric_name == "forbidden_pattern_handling":
+        return [
+            constraint.constraint_id for constraint in constraints_by_category["forbidden_patterns"]
+        ]
+    if metric_name == "citation_support":
+        return list(all_constraint_ids)
+    return []
+
+
+def _metric_chunk_ids(
+    metric_name: str,
+    constraints_by_category: dict[
+        PolicyEvidenceTraceConstraintCategory, list[PolicyEvidenceTraceConstraint]
+    ],
+    all_chunk_ids: Sequence[str],
+) -> list[str]:
+    if metric_name == "citation_support":
+        return list(all_chunk_ids)
+
+    if metric_name == "guidance_coverage":
+        constraints = [
+            *constraints_by_category["architectural_expectations"],
+            *constraints_by_category["style_constraints"],
+        ]
+    elif metric_name == "plan_completeness":
+        constraints = constraints_by_category["required_steps"]
+    elif metric_name == "test_coverage":
+        constraints = constraints_by_category["test_expectations"]
+    elif metric_name == "forbidden_pattern_handling":
+        constraints = constraints_by_category["forbidden_patterns"]
+    else:
+        constraints = []
+    return _ordered_unique(
+        [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
+    )
+
+
+def _ordered_unique(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+__all__ = ["PolicyEvidenceTraceService", "create_policy_evidence_trace_service"]

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -833,7 +833,7 @@ class PolicyEvidenceTraceChunk(StrictModel):
     path: str
     section: str
     lines: str
-    text: str
+    text: str | None = None
     score: float | None = None
 
 

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -784,6 +784,8 @@ class PolicyConformanceResult(StrictModel):
     final_adherence_rationale: str | None = None
     trajectory_adherence_score: float | None = Field(default=None, ge=0.0, le=1.0)
     trajectory_adherence_rationale: str | None = None
+    constraint_ids: list[str] = Field(default_factory=list)
+    chunk_ids: list[str] = Field(default_factory=list)
     failure_reasons: list[str] = Field(default_factory=list)
 
 
@@ -803,6 +805,103 @@ class PreflightTraceResult(StrictModel):
     compiled_packet: CompiledPolicyPacket
     retained_context: list[ScoredChunk] = Field(default_factory=list)
     trace_steps: list[PolicyConformanceTraceStep] = Field(default_factory=list)
+
+
+PolicyEvidenceTraceConstraintCategory = Literal[
+    "required_steps",
+    "forbidden_patterns",
+    "architectural_expectations",
+    "test_expectations",
+    "style_constraints",
+]
+PolicyEvidenceTraceOutputField = Literal[
+    "plan_steps",
+    "implementation_guidance",
+    "review_flags",
+    "tests_required",
+    "citations",
+]
+
+
+class PolicyEvidenceTraceChunk(StrictModel):
+    """One retained policy chunk available to the traced preflight run."""
+
+    chunk_id: str
+    policy_id: str
+    policy_title: str
+    domain: str
+    path: str
+    section: str
+    lines: str
+    text: str
+    score: float | None = None
+
+
+class PolicyEvidenceTracePolicy(StrictModel):
+    """One selected policy and the chunk IDs supporting its selection."""
+
+    policy_id: str
+    title: str
+    reason: str
+    supporting_chunk_ids: list[str] = Field(default_factory=list)
+
+
+class PolicyEvidenceTraceConstraint(StrictModel):
+    """One compiled constraint linked to policy and chunk evidence."""
+
+    constraint_id: str
+    category: PolicyEvidenceTraceConstraintCategory
+    statement: str
+    citation_ids: list[str] = Field(default_factory=list)
+    source_policy_ids: list[str] = Field(default_factory=list)
+
+
+class PolicyEvidenceTraceOutputLink(StrictModel):
+    """One generated output field linked back to constraints and chunks."""
+
+    field: PolicyEvidenceTraceOutputField
+    index: int = Field(ge=0)
+    text: str
+    constraint_ids: list[str] = Field(default_factory=list)
+    chunk_ids: list[str] = Field(default_factory=list)
+
+
+class PolicyEvidenceTraceConformanceCheck(StrictModel):
+    """One conformance check linked back to judged constraints and chunks."""
+
+    backend: EvalBackend
+    name: str
+    passed: bool
+    score: float = Field(ge=0.0, le=1.0)
+    failure_reasons: list[str] = Field(default_factory=list)
+    constraint_ids: list[str] = Field(default_factory=list)
+    chunk_ids: list[str] = Field(default_factory=list)
+
+
+class PolicyEvidenceTrace(StrictModel):
+    """Replay-free evidence trace for one policy-conditioned preflight run."""
+
+    task: str
+    domain: str | None = None
+    top_k: int
+    task_type: TaskType
+    explicit_task_type: TaskType | None = None
+    profile_signals: list[str] = Field(default_factory=list)
+    insufficient_context: bool = False
+    compiled_insufficient_context: bool = False
+    chunks: list[PolicyEvidenceTraceChunk] = Field(default_factory=list)
+    selected_policies: list[PolicyEvidenceTracePolicy] = Field(default_factory=list)
+    constraints: list[PolicyEvidenceTraceConstraint] = Field(default_factory=list)
+    output_links: list[PolicyEvidenceTraceOutputLink] = Field(default_factory=list)
+    trace_steps: list[PolicyConformanceTraceStep] = Field(default_factory=list)
+    conformance_checks: list[PolicyEvidenceTraceConformanceCheck] = Field(default_factory=list)
+
+
+class PreflightEvidenceTraceResult(StrictModel):
+    """CLI result containing public preflight output and evidence trace."""
+
+    result: PreflightResult
+    evidence_trace: PolicyEvidenceTrace
 
 
 class EvalCase(StrictModel):
@@ -856,6 +955,7 @@ class EvalCaseResult(StrictModel):
     matched_policy_ids: list[str] = Field(default_factory=list)
     actual_summary: str | None = None
     conformance_result: PolicyConformanceResult | None = None
+    evidence_trace: PolicyEvidenceTrace | None = None
     metrics: EvalCaseMetrics
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ Current automated coverage includes:
 - Build 3 policy conformance scoring, eval backend selection, preflight trace
   handling, and NVIDIA conformance-response validation
 - Build 4 policy evidence trace materialization, `preflight --trace` CLI output,
-  eval artifact trace attachment, and conformance ID preservation
+  compact eval artifact trace attachment, and conformance ID preservation
 - Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,8 @@ Current automated coverage includes:
   fail-closed handling, and preflight conditioning
 - Build 3 policy conformance scoring, eval backend selection, preflight trace
   handling, and NVIDIA conformance-response validation
+- Build 4 policy evidence trace materialization, `preflight --trace` CLI output,
+  eval artifact trace attachment, and conformance ID preservation
 - Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,11 +35,14 @@ from policynim.types import (
     EvalRunResult,
     IngestResult,
     PolicyChunk,
+    PolicyConformanceTraceStep,
     PolicyGuidance,
     PolicyMetadata,
     PolicySelectionPacket,
+    PreflightEvidenceTraceResult,
     PreflightRequest,
     PreflightResult,
+    PreflightTraceResult,
     RouteRequest,
     RouteResult,
     RuntimeDecision,
@@ -278,8 +281,11 @@ class MockPreflightService:
 
     def __init__(self) -> None:
         self.closed = False
+        self.preflight_calls = 0
+        self.trace_calls = 0
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
+        self.preflight_calls += 1
         return PreflightResult(
             task=request.task,
             domain=request.domain,
@@ -310,6 +316,79 @@ class MockPreflightService:
                 )
             ],
             insufficient_context=False,
+        )
+
+    def preflight_with_trace(self, request: PreflightRequest) -> PreflightTraceResult:
+        self.trace_calls += 1
+        result = self.preflight(request)
+        chunk = ScoredChunk(
+            chunk_id="AUTH-1",
+            path="policies/security/auth-review.md",
+            section="Cleanup",
+            lines="10-16",
+            text="Retain revocation checks before deleting stale refresh tokens.",
+            policy=PolicyMetadata(
+                policy_id="AUTH-001",
+                title="Auth Reviews",
+                doc_type="guidance",
+                domain="security",
+            ),
+            score=0.98,
+        )
+        return PreflightTraceResult(
+            result=result,
+            compiled_packet=CompiledPolicyPacket(
+                task=request.task,
+                domain=request.domain,
+                top_k=request.top_k,
+                task_type="feature_work",
+                selected_policies=[
+                    SelectedPolicy(
+                        policy_id="AUTH-001",
+                        title="Auth Reviews",
+                        domain="security",
+                        reason="Selected for token cleanup guidance.",
+                        evidence=[
+                            SelectedPolicyEvidence(
+                                chunk_id="AUTH-1",
+                                path="policies/security/auth-review.md",
+                                section="Cleanup",
+                                lines="10-16",
+                                text=(
+                                    "Retain revocation checks before deleting stale refresh tokens."
+                                ),
+                                score=0.98,
+                            )
+                        ],
+                    )
+                ],
+                required_steps=[
+                    CompiledPolicyConstraint(
+                        statement="Retain revocation checks before deleting stale refresh tokens.",
+                        citation_ids=["AUTH-1"],
+                        source_policy_ids=["AUTH-001"],
+                    )
+                ],
+                citations=[
+                    Citation(
+                        policy_id="AUTH-001",
+                        title="Auth Reviews",
+                        path="policies/security/auth-review.md",
+                        section="Cleanup",
+                        lines="10-16",
+                        chunk_id="AUTH-1",
+                    )
+                ],
+            ),
+            retained_context=[chunk],
+            trace_steps=[
+                PolicyConformanceTraceStep(
+                    step_id="compile",
+                    kind="policy_compilation",
+                    summary="Compiled policy packet for generation.",
+                    citation_ids=["AUTH-1"],
+                )
+            ],
         )
 
     def close(self) -> None:
@@ -959,6 +1038,43 @@ def test_preflight_command_prints_json(monkeypatch) -> None:
     assert payload.task == "refresh token cleanup"
     assert payload.domain == "security"
     assert payload.citations[0].chunk_id == "AUTH-1"
+    assert service.preflight_calls == 1
+    assert service.trace_calls == 0
+    assert service.closed is True
+
+
+def test_preflight_trace_command_prints_trace_wrapper(monkeypatch) -> None:
+    service = MockPreflightService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_preflight_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "preflight",
+            "--task",
+            "refresh token cleanup",
+            "--domain",
+            "security",
+            "--top-k",
+            "3",
+            "--trace",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = PreflightEvidenceTraceResult.model_validate(json.loads(result.stdout))
+    assert payload.result.task == "refresh token cleanup"
+    assert payload.evidence_trace.task == "refresh token cleanup"
+    assert payload.evidence_trace.chunks[0].chunk_id == "AUTH-1"
+    assert payload.evidence_trace.selected_policies[0].supporting_chunk_ids == ["AUTH-1"]
+    assert payload.evidence_trace.constraints[0].constraint_id == "required_steps:0"
+    assert payload.evidence_trace.output_links[0].chunk_ids == ["AUTH-1"]
+    assert payload.evidence_trace.trace_steps[0].step_id == "compile"
+    assert service.preflight_calls == 1
+    assert service.trace_calls == 1
     assert service.closed is True
 
 
@@ -1200,6 +1316,7 @@ def test_preflight_help_mentions_current_top_k_behavior() -> None:
     assert result.exit_code == 0
     assert "Retrieval depth." in result.stdout
     assert "1-20." in result.stdout
+    assert "--trace" in result.stdout
     assert "Reserved retrieval depth" not in result.stdout
 
 
@@ -1347,6 +1464,23 @@ def test_preflight_command_closes_service_when_it_errors(monkeypatch) -> None:
     )
 
     result = runner.invoke(app, ["preflight", "--task", "refresh token cleanup"])
+
+    assert result.exit_code == 1
+    assert service.closed is True
+
+
+def test_preflight_trace_command_closes_service_when_it_errors(monkeypatch) -> None:
+    class FailingTracePreflightService(MockPreflightService):
+        def preflight_with_trace(self, request: PreflightRequest) -> PreflightTraceResult:
+            raise MissingIndexError("Run `policynim ingest` first.")
+
+    service = FailingTracePreflightService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_preflight_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, ["preflight", "--task", "refresh token cleanup", "--trace"])
 
     assert result.exit_code == 1
     assert service.closed is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1312,12 +1312,13 @@ def test_dump_index_help_mentions_less_for_paging() -> None:
 
 def test_preflight_help_mentions_current_top_k_behavior() -> None:
     result = runner.invoke(app, ["preflight", "--help"])
+    help_text = unstyle(result.stdout)
 
     assert result.exit_code == 0
-    assert "Retrieval depth." in result.stdout
-    assert "1-20." in result.stdout
-    assert "--trace" in result.stdout
-    assert "Reserved retrieval depth" not in result.stdout
+    assert "Retrieval depth." in help_text
+    assert "1-20." in help_text
+    assert "--trace" in help_text
+    assert "Reserved retrieval depth" not in help_text
 
 
 def test_search_command_surfaces_configuration_errors(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1069,6 +1069,10 @@ def test_preflight_trace_command_prints_trace_wrapper(monkeypatch) -> None:
     assert payload.result.task == "refresh token cleanup"
     assert payload.evidence_trace.task == "refresh token cleanup"
     assert payload.evidence_trace.chunks[0].chunk_id == "AUTH-1"
+    assert (
+        payload.evidence_trace.chunks[0].text
+        == "Retain revocation checks before deleting stale refresh tokens."
+    )
     assert payload.evidence_trace.selected_policies[0].supporting_chunk_ids == ["AUTH-1"]
     assert payload.evidence_trace.constraints[0].constraint_id == "required_steps:0"
     assert payload.evidence_trace.output_links[0].chunk_ids == ["AUTH-1"]

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -12,6 +12,7 @@ from policynim.services.eval import EvalService
 from policynim.settings import Settings
 from policynim.types import (
     CompiledPolicyPacket,
+    EvalModeRunResult,
     PolicyMetadata,
     PreflightResult,
     PreflightTraceResult,
@@ -148,11 +149,31 @@ def test_eval_service_offline_run_persists_two_rerank_modes(monkeypatch, tmp_pat
         for run in result.runs
         for case_result in run.case_results
     )
+    assert all(
+        case_result.evidence_trace is None
+        for run in result.runs
+        for case_result in run.case_results
+        if case_result.kind == "search"
+    )
+    assert any(
+        case_result.evidence_trace is not None
+        for run in result.runs
+        for case_result in run.case_results
+        if case_result.kind == "preflight"
+    )
     assert result.comparison is not None
     assert "preflight-refresh-token-cleanup" in result.comparison.improved_case_ids
     assert "search-refresh-token-cleanup" in result.comparison.improved_case_ids
     assert all(Path(run.result_json_path).is_file() for run in result.runs)
     assert all(Path(run.report_html_path).is_file() for run in result.runs)
+    persisted = EvalModeRunResult.model_validate(
+        json.loads(Path(result.runs[0].result_json_path).read_text(encoding="utf-8"))
+    )
+    assert any(
+        case.evidence_trace is not None
+        for case in persisted.case_results
+        if case.kind == "preflight"
+    )
     assert len(run_names) == 2
 
 
@@ -229,7 +250,16 @@ def test_eval_service_nemo_backend_adds_preflight_conformance_results(
     search_cases = [case for case in run.case_results if case.kind == "search"]
     preflight_cases = [case for case in run.case_results if case.kind == "preflight"]
     assert all(case.conformance_result is None for case in search_cases)
+    assert all(case.evidence_trace is None for case in search_cases)
     assert any(case.conformance_result is not None for case in preflight_cases)
+    assert all(case.evidence_trace is not None for case in preflight_cases)
+    conformance_trace = next(
+        case.evidence_trace
+        for case in preflight_cases
+        if case.evidence_trace is not None and case.evidence_trace.conformance_checks
+    )
+    assert conformance_trace.conformance_checks[-1].constraint_ids
+    assert conformance_trace.conformance_checks[-1].chunk_ids
     assert run.metrics.conformance_case_count == 2
     assert run.metrics.conformance_passed_count == 2
     assert run.metrics.conformance_score == 1.0

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -174,6 +174,13 @@ def test_eval_service_offline_run_persists_two_rerank_modes(monkeypatch, tmp_pat
         for case in persisted.case_results
         if case.kind == "preflight"
     )
+    persisted_preflight_trace = next(
+        case.evidence_trace
+        for case in persisted.case_results
+        if case.kind == "preflight" and case.evidence_trace is not None
+    )
+    assert persisted_preflight_trace.chunks
+    assert persisted_preflight_trace.chunks[0].text is None
     assert len(run_names) == 2
 
 

--- a/tests/test_policy_conformance_service.py
+++ b/tests/test_policy_conformance_service.py
@@ -83,6 +83,24 @@ def test_conformance_service_skips_trajectory_metric_when_evaluator_omits_it() -
     assert "trajectory_adherence" not in {metric.name for metric in result.metrics}
 
 
+def test_conformance_service_preserves_judged_constraint_and_chunk_ids() -> None:
+    service = PolicyConformanceService(
+        evaluator=MockConformanceEvaluator(
+            GeneratedPolicyConformanceDraft(
+                final_adherence_score=0.95,
+                final_adherence_rationale="Final output follows the constraints.",
+                constraint_ids=["required_steps:0"],
+                chunk_ids=["BACKEND-1"],
+            )
+        )
+    )
+
+    result = service.evaluate(make_request(), backend="nemo")
+
+    assert result.constraint_ids == ["required_steps:0"]
+    assert result.chunk_ids == ["BACKEND-1"]
+
+
 def test_conformance_service_fails_closed_for_insufficient_compiled_packet() -> None:
     service = PolicyConformanceService(evaluator=None)
     request = make_request(

--- a/tests/test_policy_evidence_trace_service.py
+++ b/tests/test_policy_evidence_trace_service.py
@@ -1,0 +1,273 @@
+"""Tests for policy evidence trace materialization."""
+
+from __future__ import annotations
+
+from policynim.services.evidence_trace import PolicyEvidenceTraceService
+from policynim.types import (
+    Citation,
+    CompiledPolicyConstraint,
+    CompiledPolicyPacket,
+    PolicyConformanceMetric,
+    PolicyConformanceResult,
+    PolicyConformanceTraceStep,
+    PolicyGuidance,
+    PolicyMetadata,
+    PreflightResult,
+    PreflightTraceResult,
+    ScoredChunk,
+    SelectedPolicy,
+    SelectedPolicyEvidence,
+)
+
+
+def test_evidence_trace_links_chunks_constraints_outputs_and_conformance() -> None:
+    service = PolicyEvidenceTraceService()
+
+    trace = service.build(make_trace_result(), conformance_result=make_conformance_result())
+
+    assert trace.task == "fix backend logging"
+    assert trace.top_k == 2
+    assert trace.task_type == "bug_fix"
+    assert trace.profile_signals == ["bug"]
+    assert [chunk.chunk_id for chunk in trace.chunks] == ["BACKEND-1", "SECURITY-1"]
+    assert trace.chunks[0].policy_id == "BACKEND-LOG-001"
+    assert trace.chunks[0].path == "policies/backend/logging.md"
+    assert trace.chunks[0].text == "Use request ids in backend logs."
+    assert trace.selected_policies[0].supporting_chunk_ids == ["BACKEND-1"]
+    assert [constraint.constraint_id for constraint in trace.constraints] == [
+        "required_steps:0",
+        "forbidden_patterns:0",
+        "architectural_expectations:0",
+        "test_expectations:0",
+        "style_constraints:0",
+    ]
+    assert trace.output_links[0].field == "plan_steps"
+    assert trace.output_links[0].constraint_ids == ["required_steps:0"]
+    assert trace.output_links[1].field == "implementation_guidance"
+    assert trace.output_links[1].constraint_ids == ["architectural_expectations:0"]
+    assert trace.output_links[3].field == "review_flags"
+    assert trace.output_links[3].constraint_ids == ["forbidden_patterns:0"]
+    assert trace.output_links[-1].field == "citations"
+    assert trace.output_links[-1].chunk_ids == ["SECURITY-1"]
+    assert trace.trace_steps[0].step_id == "compile"
+    assert trace.conformance_checks[-1].name == "final_adherence"
+    assert trace.conformance_checks[-1].constraint_ids == ["required_steps:0"]
+    assert trace.conformance_checks[-1].chunk_ids == ["BACKEND-1"]
+
+
+def test_evidence_trace_preserves_insufficient_context_without_output_links() -> None:
+    service = PolicyEvidenceTraceService()
+    result = PreflightResult(
+        task="unclear task",
+        summary="PolicyNIM could not find enough grounded policy evidence for this task.",
+        insufficient_context=True,
+    )
+    trace_result = PreflightTraceResult(
+        result=result,
+        compiled_packet=CompiledPolicyPacket(
+            task="unclear task",
+            top_k=2,
+            task_type="unknown",
+            insufficient_context=True,
+        ),
+        retained_context=[],
+        trace_steps=[],
+    )
+
+    trace = service.build(trace_result)
+
+    assert trace.task == "unclear task"
+    assert trace.insufficient_context is True
+    assert trace.compiled_insufficient_context is True
+    assert trace.chunks == []
+    assert trace.constraints == []
+    assert trace.output_links == []
+    assert trace.conformance_checks == []
+
+
+def make_trace_result() -> PreflightTraceResult:
+    return PreflightTraceResult(
+        result=make_result(),
+        compiled_packet=make_compiled_packet(),
+        retained_context=[
+            make_chunk(
+                chunk_id="BACKEND-1",
+                policy_id="BACKEND-LOG-001",
+                title="Backend Logging",
+                domain="backend",
+                path="policies/backend/logging.md",
+                text="Use request ids in backend logs.",
+                score=0.98,
+            ),
+            make_chunk(
+                chunk_id="SECURITY-1",
+                policy_id="SECURITY-TOKEN-001",
+                title="Token Handling",
+                domain="security",
+                path="policies/security/token.md",
+                text="Never log token values.",
+                score=0.95,
+            ),
+        ],
+        trace_steps=[
+            PolicyConformanceTraceStep(
+                step_id="compile",
+                kind="policy_compilation",
+                summary="Compiled policy constraints.",
+                citation_ids=["BACKEND-1", "SECURITY-1"],
+            )
+        ],
+    )
+
+
+def make_compiled_packet() -> CompiledPolicyPacket:
+    return CompiledPolicyPacket(
+        task="fix backend logging",
+        top_k=2,
+        task_type="bug_fix",
+        profile_signals=["bug"],
+        selected_policies=[
+            SelectedPolicy(
+                policy_id="BACKEND-LOG-001",
+                title="Backend Logging",
+                domain="backend",
+                reason="Selected for logging guidance.",
+                evidence=[
+                    SelectedPolicyEvidence(
+                        chunk_id="BACKEND-1",
+                        path="policies/backend/logging.md",
+                        section="Rules",
+                        lines="1-4",
+                        text="Use request ids in backend logs.",
+                        score=0.98,
+                    )
+                ],
+            )
+        ],
+        required_steps=[
+            CompiledPolicyConstraint(
+                statement="Thread request ids through log context.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        forbidden_patterns=[
+            CompiledPolicyConstraint(
+                statement="Never log token values.",
+                citation_ids=["SECURITY-1"],
+                source_policy_ids=["SECURITY-TOKEN-001"],
+            )
+        ],
+        architectural_expectations=[
+            CompiledPolicyConstraint(
+                statement="Keep logging changes in the backend service layer.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        test_expectations=[
+            CompiledPolicyConstraint(
+                statement="Add a regression test for token redaction.",
+                citation_ids=["SECURITY-1"],
+                source_policy_ids=["SECURITY-TOKEN-001"],
+            )
+        ],
+        style_constraints=[
+            CompiledPolicyConstraint(
+                statement="Use explicit request-id naming.",
+                citation_ids=["BACKEND-1"],
+                source_policy_ids=["BACKEND-LOG-001"],
+            )
+        ],
+        citations=[
+            make_citation("BACKEND-1", "BACKEND-LOG-001", "Backend Logging"),
+            make_citation("SECURITY-1", "SECURITY-TOKEN-001", "Token Handling"),
+        ],
+    )
+
+
+def make_result() -> PreflightResult:
+    return PreflightResult(
+        task="fix backend logging",
+        summary="Use request ids and keep tokens out of logs.",
+        applicable_policies=[
+            PolicyGuidance(
+                policy_id="BACKEND-LOG-001",
+                title="Backend Logging",
+                rationale="Request ids keep logs traceable.",
+                citation_ids=["BACKEND-1"],
+            )
+        ],
+        plan_steps=["Thread request ids through log context."],
+        implementation_guidance=[
+            "Keep logging changes in the backend service layer.",
+            "Use explicit request-id naming.",
+        ],
+        review_flags=["Avoid: Never log token values."],
+        tests_required=["Add a regression test for token redaction."],
+        citations=[
+            make_citation("BACKEND-1", "BACKEND-LOG-001", "Backend Logging"),
+            make_citation("SECURITY-1", "SECURITY-TOKEN-001", "Token Handling"),
+        ],
+    )
+
+
+def make_conformance_result() -> PolicyConformanceResult:
+    return PolicyConformanceResult(
+        backend="nemo",
+        passed=True,
+        overall_score=1.0,
+        metrics=[
+            PolicyConformanceMetric(
+                name="plan_completeness",
+                score=1.0,
+                passed=True,
+            ),
+            PolicyConformanceMetric(
+                name="final_adherence",
+                score=1.0,
+                passed=True,
+            ),
+        ],
+        final_adherence_score=1.0,
+        final_adherence_rationale="Output follows the compiled constraints.",
+        constraint_ids=["required_steps:0"],
+        chunk_ids=["BACKEND-1"],
+    )
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    policy_id: str,
+    title: str,
+    domain: str,
+    path: str,
+    text: str,
+    score: float,
+) -> ScoredChunk:
+    return ScoredChunk(
+        chunk_id=chunk_id,
+        path=path,
+        section="Rules",
+        lines="1-4",
+        text=text,
+        policy=PolicyMetadata(
+            policy_id=policy_id,
+            title=title,
+            doc_type="guidance",
+            domain=domain,
+        ),
+        score=score,
+    )
+
+
+def make_citation(chunk_id: str, policy_id: str, title: str) -> Citation:
+    return Citation(
+        policy_id=policy_id,
+        title=title,
+        path=f"policies/{policy_id}.md",
+        section="Rules",
+        lines="1-4",
+        chunk_id=chunk_id,
+    )

--- a/tests/test_policy_evidence_trace_service.py
+++ b/tests/test_policy_evidence_trace_service.py
@@ -55,6 +55,18 @@ def test_evidence_trace_links_chunks_constraints_outputs_and_conformance() -> No
     assert trace.conformance_checks[-1].chunk_ids == ["BACKEND-1"]
 
 
+def test_evidence_trace_can_strip_chunk_text_for_compact_artifacts() -> None:
+    service = PolicyEvidenceTraceService()
+
+    trace = service.build(make_trace_result(), include_chunk_text=False)
+
+    assert [chunk.chunk_id for chunk in trace.chunks] == ["BACKEND-1", "SECURITY-1"]
+    assert trace.chunks[0].path == "policies/backend/logging.md"
+    assert trace.chunks[0].lines == "1-4"
+    assert trace.chunks[0].text is None
+    assert trace.output_links[0].chunk_ids == ["BACKEND-1"]
+
+
 def test_evidence_trace_preserves_insufficient_context_without_output_links() -> None:
     service = PolicyEvidenceTraceService()
     result = PreflightResult(


### PR DESCRIPTION
## Summary
- add typed PolicyEvidenceTrace contracts and a trace materializer over existing preflight trace data
- add opt-in `policynim preflight --trace` output without changing default preflight or MCP contracts
- embed evidence traces in eval preflight case artifacts and preserve conformance judge constraint/chunk IDs
- update docs and focused coverage for trace CLI, eval artifacts, and conformance linkage

## Verification
- `uv run pytest -q tests/test_policy_evidence_trace_service.py tests/test_preflight_service.py tests/test_eval_service.py tests/test_cli.py tests/test_nvidia_policy_conformance.py tests/test_policy_conformance_service.py tests/test_service_factories.py`
- `uv run pytest -q`
- `uv run ruff check`
- `uvx pyright src tests`

## Notes
- Hidden `.plan/` files are intentionally excluded from this PR.
