### PR TITLE
Clean up weekly audit findings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ Compiler flow:
 5. materialize public citations and source policy IDs
 6. return a JSON-first `CompiledPolicyPacket`
 
-Build 2 compilation adds no new environment variable or artifact directory. It
+Policy compilation adds no new environment variable or artifact directory. It
 reuses the existing NVIDIA chat model setting and fails closed when generated
 constraints are malformed, unsupported, or uncited.
 
@@ -209,8 +209,8 @@ Important evaluation rules:
 ### Repo Root
 
 - `Dockerfile` builds the hosted image and bakes the LanceDB index into it.
-- `railway.toml` pins the Day 3 Railway deploy contract to Dockerfile build plus
-  `/healthz` health checks.
+- `railway.toml` pins the hosted Railway deploy contract to Dockerfile build
+  plus `/healthz` health checks.
 
 ### `src/policynim/settings.py`
 
@@ -343,8 +343,7 @@ Shared interface guarantees:
 
 - CLI `search` and MCP `policy_search` use the same `SearchResult` shape.
 - CLI `route` returns a `PolicySelectionPacket`; there is no MCP route tool.
-- CLI `compile` returns a `CompiledPolicyPacket`; there is no MCP compile tool
-  in Build 2.
+- CLI `compile` returns a `CompiledPolicyPacket`; there is no MCP compile tool.
 - CLI `preflight` and MCP `policy_preflight` use the same `PreflightResult`
   shape.
 - CLI `preflight --trace` returns `PreflightEvidenceTraceResult`; there is no

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -113,8 +113,8 @@ compatible launcher stack version; default CI does not sync this extra.
 
 ## Optional NVIDIA Guardrails Package
 
-The default development install does not include NeMo Guardrails. Build 6 adds an
-internal output-rail wrapper for generated preflight drafts, but it does not add a
+The default development install does not include NeMo Guardrails. PolicyNIM has
+an internal output-rail wrapper for generated preflight drafts, but it does not add a
 CLI flag, MCP tool, eval backend, or default factory switch. Install the package
 only when directly constructing the internal Guardrails-backed generator:
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -32,9 +32,8 @@ constraints, not setup mistakes.
 - Hosted startup now validates the configured local index before serving traffic
   and attempts one rebuild with the runtime `NVIDIA_API_KEY` when the baked index
   is missing or empty.
-- Hosted observability is still request-log level only. Day 3 adds structured
-  JSON logs for auth rejects and MCP tool calls, but there is no tracing or
-  metrics pipeline yet.
+- Hosted observability is structured JSON request logging for auth rejects and
+  MCP tool calls only. There is no tracing or metrics pipeline yet.
 
 ### NVIDIA Dependency For Live Retrieval, Conformance, And Regeneration
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -133,7 +133,7 @@ preflight. It returns a JSON `CompiledPolicyPacket` with:
 - citations
 - `insufficient_context`
 
-Build 2 compilation reuses the existing NVIDIA chat model setting and adds no
+Policy compilation reuses the existing NVIDIA chat model setting and adds no
 new environment variable or artifact directory.
 
 ### 6. Run Grounded Preflight
@@ -369,7 +369,7 @@ That compiled artifact powers the runtime decision and execution services:
 - `POLICYNIM_RUNTIME_SHELL_TIMEOUT_SECONDS` sets the default shell timeout for
   runtime execution
 
-The Day 4 runtime CLI flow is JSON-first and file- or stdin-driven:
+The runtime CLI flow is JSON-first and file- or stdin-driven:
 
 ```bash
 # Decide without side effects.

--- a/src/policynim/contracts.py
+++ b/src/policynim/contracts.py
@@ -1,4 +1,4 @@
-"""Core external seams for later PolicyNIM implementation."""
+"""Core external seams for PolicyNIM services and providers."""
 
 from __future__ import annotations
 

--- a/src/policynim/errors.py
+++ b/src/policynim/errors.py
@@ -41,11 +41,3 @@ class RuntimeCitationLinkError(PolicyNIMError):
 
 class RuntimeEvidencePersistenceError(PolicyNIMError):
     """Raised when runtime execution evidence cannot be persisted durably."""
-
-
-class WeakEvidenceError(PolicyNIMError):
-    """Raised when retrieval evidence is too weak to support synthesis."""
-
-
-class NotImplementedYetError(PolicyNIMError):
-    """Raised for Day 1 command surfaces that are intentionally scaffold-only."""

--- a/src/policynim/providers/nvidia_eval.py
+++ b/src/policynim/providers/nvidia_eval.py
@@ -35,11 +35,15 @@ class NeMoEvaluatorPolicyConformanceEvaluator:
     """Policy conformance adapter gated on NeMo Evaluator SDK packages."""
 
     def __init__(self, *, evaluator: _ClosablePolicyConformanceEvaluator) -> None:
-        _require_optional_distributions(
-            _NEMO_EVALUATOR_DISTRIBUTIONS,
-            install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-            backend=_NEMO_EVALUATOR_BACKEND,
-        )
+        try:
+            _require_optional_distributions(
+                _NEMO_EVALUATOR_DISTRIBUTIONS,
+                install_hint=_NVIDIA_EVAL_INSTALL_HINT,
+                backend=_NEMO_EVALUATOR_BACKEND,
+            )
+        except ConfigurationError:
+            evaluator.close()
+            raise
         self._evaluator = evaluator
 
     @classmethod
@@ -73,11 +77,15 @@ class NeMoAgentToolkitPolicyConformanceEvaluator:
     """Policy conformance adapter gated on NeMo Agent Toolkit eval packages."""
 
     def __init__(self, *, evaluator: _ClosablePolicyConformanceEvaluator) -> None:
-        _require_optional_distributions(
-            _NAT_DISTRIBUTIONS,
-            install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-            backend=_NAT_BACKEND,
-        )
+        try:
+            _require_optional_distributions(
+                _NAT_DISTRIBUTIONS,
+                install_hint=_NVIDIA_EVAL_INSTALL_HINT,
+                backend=_NAT_BACKEND,
+            )
+        except ConfigurationError:
+            evaluator.close()
+            raise
         self._evaluator = evaluator
 
     @classmethod

--- a/src/policynim/providers/nvidia_guardrails.py
+++ b/src/policynim/providers/nvidia_guardrails.py
@@ -58,9 +58,13 @@ class NeMoGuardrailsPreflightGenerator(Generator):
         model: str | None = None,
     ) -> None:
         if rails is None:
-            rails, rail_type_output = _create_default_output_rails(
-                model=model or _DEFAULT_GUARDRAILS_MODEL
-            )
+            try:
+                rails, rail_type_output = _create_default_output_rails(
+                    model=model or _DEFAULT_GUARDRAILS_MODEL
+                )
+            except ConfigurationError:
+                _close_component(base_generator)
+                raise
             owns_rails = True
 
         self._base_generator = base_generator

--- a/src/policynim/settings.py
+++ b/src/policynim/settings.py
@@ -336,7 +336,7 @@ def _build_discovered_dotenv_source(
     settings_cls: type[BaseSettings],
     template: DotEnvSettingsSource,
 ) -> DotEnvSettingsSource:
-    """Replace the static `.env` source with Day 1 discovery precedence."""
+    """Replace the static `.env` source with discovered config precedence."""
     discovery = config_discovery.discover_config_files()
     return _clone_filtered_dotenv_source(
         settings_cls,

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,31 +3,31 @@
 Current automated coverage includes:
 
 - Markdown policy parsing, metadata normalization, and deterministic chunking
-- Additional Day 6 chunking edge cases around blank sections and repeated nested headings
-- Day 3 ingest orchestration with local LanceDB rebuild behavior
-- Day 3 search orchestration with domain filters and missing-index handling
-- Day 2 runtime decision orchestration with compiled runtime rules and evidence-linked citations
-- Day 3 runtime execution orchestration with confirmation handling, redaction, and durable evidence persistence
-- Day 4 runtime evidence session-summary reporting over the SQLite evidence store
+- Additional chunking edge cases around blank sections and repeated nested headings
+- Ingest orchestration with local LanceDB rebuild behavior
+- Search orchestration with domain filters and missing-index handling
+- Runtime decision orchestration with compiled runtime rules and evidence-linked citations
+- Runtime execution orchestration with confirmation handling, redaction, and durable evidence persistence
+- Runtime evidence session-summary reporting over the SQLite evidence store
 - Runtime execution SQLite store schema, ordering, reopen, and concurrency behavior
-- Day 5 runtime hardening for file-write and HTTP execution paths plus confirmation-callback failures
-- Day 5 real SQLite-backed CLI runtime execution plus `evidence report` coverage
-- Day 5 runtime docs parity for command forms, env examples, and policy authoring guidance
-- Day 6 eval orchestration, rerank on/off comparison, and isolated live-eval index handling
-- Day 4 grounded preflight orchestration, citation validation, and fallback behavior
-- Build 1 task-aware routing, task-profile inference, selected-policy grouping,
+- Runtime hardening for file-write and HTTP execution paths plus confirmation-callback failures
+- Real SQLite-backed CLI runtime execution plus `evidence report` coverage
+- Runtime docs parity for command forms, env examples, and policy authoring guidance
+- Eval orchestration, rerank on/off comparison, and isolated live-eval index handling
+- Grounded preflight orchestration, citation validation, and fallback behavior
+- Task-aware routing, task-profile inference, selected-policy grouping,
   and weak-evidence fallback behavior
-- Build 2 policy compilation, compiled constraint citation validation,
+- Policy compilation, compiled constraint citation validation,
   fail-closed handling, and preflight conditioning
-- Build 3 policy conformance scoring, eval backend selection, preflight trace
+- Policy conformance scoring, eval backend selection, preflight trace
   handling, and NVIDIA conformance-response validation
-- Build 4 policy evidence trace materialization, `preflight --trace` CLI output,
+- Policy evidence trace materialization, `preflight --trace` CLI output,
   compact eval artifact trace attachment, and conformance ID preservation
-- Build 5 policy-backed regeneration, compile-once packet identity, typed retry
+- Policy-backed regeneration, compile-once packet identity, typed retry
   triggers, max-regeneration and insufficient-context stops, provider fail-closed
   behavior, citation-drift rejection, `preflight --regenerate`, and
   `eval --regenerate`
-- Build 5 follow-up Phoenix eval reporting, headless UI skipping, workspace-local
+- Phoenix eval reporting, headless UI skipping, workspace-local
   Phoenix startup, deterministic span publishing, and synchronous code
   annotations
 - Optional NeMo Evaluator and NeMo Agent Toolkit adapter gating with fake
@@ -35,10 +35,10 @@ Current automated coverage includes:
   NVIDIA eval packages
 - Optional NVIDIA Eval Launcher dependency resolution through
   `uv sync --extra nvidia-eval --extra nvidia-eval-launcher --group test --group dev`
-- Build 6 internal NeMo Guardrails output-rail wrapper coverage for lazy package
+- Internal NeMo Guardrails output-rail wrapper coverage for lazy package
   gating, packaged assets, malformed rail output, blocked output, citation drift,
   regeneration context pass-through, and default factory isolation
-- Day 6 citation-deduplication and policy-vs-draft citation validation edge cases
+- Citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads
 - CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 3 CLI surface."""
+"""Tests for the CLI surface."""
 
 from __future__ import annotations
 

--- a/tests/test_compiler_service.py
+++ b/tests/test_compiler_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Build 2 policy compiler service."""
+"""Tests for the policy compiler service."""
 
 from __future__ import annotations
 

--- a/tests/test_docs_hosted_onboarding.py
+++ b/tests/test_docs_hosted_onboarding.py
@@ -1,4 +1,4 @@
-"""Docs parity checks for hosted Day 4 onboarding."""
+"""Docs parity checks for hosted onboarding."""
 
 from __future__ import annotations
 

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -79,11 +79,11 @@ def test_policy_template_includes_runtime_rules_authoring_guidance() -> None:
         assert token in text
 
 
-def test_tests_readme_mentions_day5_runtime_and_docs_parity_coverage() -> None:
+def test_tests_readme_mentions_runtime_and_docs_parity_coverage() -> None:
     text = _read_text(TESTS_README)
 
     for token in (
-        "real SQLite-backed CLI runtime execution plus `evidence report` coverage",
-        "runtime docs parity",
+        "Real SQLite-backed CLI runtime execution plus `evidence report` coverage",
+        "Runtime docs parity",
     ):
         assert token in text

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 6 eval service."""
+"""Tests for the eval service."""
 
 from __future__ import annotations
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 2 ingest foundation."""
+"""Tests for the ingest foundation."""
 
 from __future__ import annotations
 

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 3 ingest service."""
+"""Tests for the ingest service."""
 
 from __future__ import annotations
 

--- a/tests/test_nemo_agent_toolkit_policy_conformance.py
+++ b/tests/test_nemo_agent_toolkit_policy_conformance.py
@@ -22,9 +22,12 @@ def test_nat_adapter_requires_optional_eval_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
+    evaluator = FakeEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
-        NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=FakeEvaluator())
+        NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=evaluator)
+
+    assert evaluator.closed is True
 
 
 def test_nat_from_settings_checks_optional_package_first(monkeypatch) -> None:

--- a/tests/test_nemo_evaluator_policy_conformance.py
+++ b/tests/test_nemo_evaluator_policy_conformance.py
@@ -22,9 +22,12 @@ def test_nemo_evaluator_adapter_requires_optional_packages(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
+    evaluator = FakeEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
-        NeMoEvaluatorPolicyConformanceEvaluator(evaluator=FakeEvaluator())
+        NeMoEvaluatorPolicyConformanceEvaluator(evaluator=evaluator)
+
+    assert evaluator.closed is True
 
 
 def test_nemo_evaluator_from_settings_checks_optional_packages_first(monkeypatch) -> None:

--- a/tests/test_nemo_guardrails_preflight_generator.py
+++ b/tests/test_nemo_guardrails_preflight_generator.py
@@ -67,11 +67,13 @@ def test_guardrails_generator_requires_optional_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr(guardrails_module, "installed_version", missing_distribution)
+    base_generator = FakeGenerator([make_draft()])
 
     with pytest.raises(ConfigurationError, match="nvidia-guardrails") as excinfo:
-        NeMoGuardrailsPreflightGenerator(base_generator=FakeGenerator([make_draft()]))
+        NeMoGuardrailsPreflightGenerator(base_generator=base_generator)
 
     assert excinfo.value.failure_class == "missing_optional_dependency"
+    assert base_generator.closed is True
 
 
 def test_guardrails_from_settings_checks_optional_package_before_base_generator(

--- a/tests/test_nvidia_live.py
+++ b/tests/test_nvidia_live.py
@@ -20,7 +20,7 @@ pytestmark = [
 def test_nvidia_embed_query_live() -> None:
     embedder = nvidia_module.NVIDIAEmbedder.from_settings(get_settings())
 
-    vector = embedder.embed_query("PolicyNIM live Day 3 smoke test")
+    vector = embedder.embed_query("PolicyNIM live embedding smoke test")
 
     assert vector
     assert all(isinstance(value, float) for value in vector)

--- a/tests/test_preflight_service.py
+++ b/tests/test_preflight_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 4 grounded preflight service."""
+"""Tests for the grounded preflight service."""
 
 from __future__ import annotations
 

--- a/tests/test_router_service.py
+++ b/tests/test_router_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Build 1 task-aware policy router."""
+"""Tests for the task-aware policy router."""
 
 from __future__ import annotations
 

--- a/tests/test_runtime_decision_service.py
+++ b/tests/test_runtime_decision_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 2 runtime decision service."""
+"""Tests for the runtime decision service."""
 
 from __future__ import annotations
 

--- a/tests/test_runtime_execution_service.py
+++ b/tests/test_runtime_execution_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 3 runtime execution service."""
+"""Tests for the runtime execution service."""
 
 from __future__ import annotations
 

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,4 +1,4 @@
-"""Tests for the Day 4 reranked search service."""
+"""Tests for the reranked search service."""
 
 from __future__ import annotations
 

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -39,8 +39,8 @@ def write_env_file(path: Path, **values: str) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def clear_day1_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clear env variables that would interfere with Day 1 precedence tests."""
+def clear_config_precedence_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear env variables that would interfere with config precedence tests."""
     for key in (
         "POLICYNIM_CONFIG_FILE",
         "POLICYNIM_DEFAULT_TOP_K",
@@ -172,7 +172,7 @@ def test_settings_parses_csv_bearer_tokens(monkeypatch: pytest.MonkeyPatch) -> N
 def test_settings_uses_user_config_and_standalone_defaults_when_no_local_dotenv(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     _, config_root, data_root = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="8")
 
@@ -186,7 +186,7 @@ def test_settings_uses_user_config_and_standalone_defaults_when_no_local_dotenv(
 def test_settings_prefers_explicit_config_file_over_cwd_dotenv_and_user_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
     write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
@@ -202,7 +202,7 @@ def test_settings_prefers_explicit_config_file_over_cwd_dotenv_and_user_config(
 def test_settings_prefers_cwd_dotenv_over_user_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
     write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
@@ -215,7 +215,7 @@ def test_settings_prefers_cwd_dotenv_over_user_config(
 def test_settings_prefers_process_env_over_all_discovered_config_files(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
     write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
@@ -232,7 +232,7 @@ def test_settings_prefers_process_env_over_all_discovered_config_files(
 def test_settings_fails_closed_when_explicit_config_file_is_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     configure_standalone_discovery(monkeypatch, tmp_path)
     missing_config = tmp_path / "missing.env"
     monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(missing_config))
@@ -244,7 +244,7 @@ def test_settings_fails_closed_when_explicit_config_file_is_missing(
 def test_settings_ignores_config_file_from_discovered_user_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     _, config_root, data_root = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(
         config_root / "config.env",
@@ -263,7 +263,7 @@ def test_standalone_setup_missing_when_redirected_config_file_does_not_exist(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     redirected_config = tmp_path / "redirected" / "config.env"
     monkeypatch.setenv("POLICYNIM_CONFIG_FILE", str(redirected_config))
@@ -281,7 +281,7 @@ def test_standalone_setup_missing_ignores_unrelated_cwd_dotenv(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(workspace / ".env", POLICYNIM_DEFAULT_TOP_K="4")
 
@@ -298,7 +298,7 @@ def test_standalone_setup_present_when_cwd_dotenv_has_nvidia_api_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(workspace / ".env", NVIDIA_API_KEY="'nvapi-test-key'")
 
@@ -315,7 +315,7 @@ def test_standalone_setup_missing_when_existing_explicit_config_lacks_api_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     workspace, _, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     explicit_config = tmp_path / "explicit.env"
     write_env_file(explicit_config, POLICYNIM_DEFAULT_TOP_K="4")
@@ -334,7 +334,7 @@ def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     config_root = tmp_path / "Application Support" / "PolicyNIM"
     data_root = tmp_path / "Library" / "Application Support" / "PolicyNIM"
     custom_corpus = tmp_path / "Custom Policies"
@@ -498,7 +498,7 @@ def test_settings_keeps_loopback_host_outside_production_even_with_port(
 def test_settings_ignores_user_config_when_platform_port_is_present(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     _, config_root, _ = configure_standalone_discovery(monkeypatch, tmp_path)
     write_env_file(
         config_root / "config.env",
@@ -519,7 +519,7 @@ def test_settings_ignores_user_config_when_platform_port_is_present(
 def test_settings_keeps_checkout_defaults_when_running_from_source_checkout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     checkout_root, config_root, _ = configure_checkout_discovery(monkeypatch, tmp_path)
     write_env_file(config_root / "config.env", POLICYNIM_DEFAULT_TOP_K="3")
     write_env_file(checkout_root / ".env", POLICYNIM_DEFAULT_TOP_K="11")
@@ -534,7 +534,7 @@ def test_settings_keeps_checkout_defaults_when_running_from_source_checkout(
 def test_settings_keeps_hosted_defaults_out_of_standalone_platformdirs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    clear_day1_env(monkeypatch)
+    clear_config_precedence_env(monkeypatch)
     configure_standalone_discovery(monkeypatch, tmp_path)
     monkeypatch.setenv("POLICYNIM_ENV", "production")
     monkeypatch.setenv("PORT", "8123")


### PR DESCRIPTION
## Summary
- remove unused PolicyNIM error classes found during the dead-code audit
- update stale milestone-era docs, docstrings, and test coverage labels to current product wording
- keep config precedence naming and test docs aligned with current behavior

## Verification
- uv run --group dev ruff check
- uv run --group test python -m pytest -q -m 'not live and not docker_live'
- uv run policynim --help