### PR TITLE
Rename test doubles to mock terminology

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -58,8 +58,8 @@ constraints, not setup mistakes.
 - CI does not exercise live NVIDIA embeddings, reranking, grounded generation, or
   end-to-end MCP flows against hosted services.
 - CI does not require NeMo Evaluator SDK or NeMo Agent Toolkit packages; optional
-  package paths use fake/import-injected tests.
-- CI does not require NeMo Guardrails; output-rail tests use fakes and verify the
+  package paths use mock-backed import-injected tests.
+- CI does not require NeMo Guardrails; output-rail tests use mocks and verify the
   default factory does not import the optional package.
 - Live-provider and Railway-hosted verification remain manual or opt-in local workflows.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,8 +30,8 @@ Current automated coverage includes:
 - Phoenix eval reporting, headless UI skipping, workspace-local
   Phoenix startup, deterministic span publishing, and synchronous code
   annotations
-- Optional NeMo Evaluator and NeMo Agent Toolkit adapter gating with fake
-  import-injected package modules; default CI does not import live optional
+- Optional NeMo Evaluator and NeMo Agent Toolkit adapter gating with
+  mock-backed import-injected package modules; default CI does not import live optional
   NVIDIA eval packages
 - Optional NVIDIA Eval Launcher dependency resolution through
   `uv sync --extra nvidia-eval --extra nvidia-eval-launcher --group test --group dev`

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -23,7 +23,7 @@ from policynim.types import (
 )
 
 
-class FakeIngestService:
+class MockIngestService:
     """Capture the isolated live eval index path."""
 
     def __init__(self, settings: Settings, seen_paths: list[Path]) -> None:
@@ -35,7 +35,7 @@ class FakeIngestService:
         return None
 
 
-class FakeSearchService:
+class MockSearchService:
     """Static search service used for live-eval isolation tests."""
 
     def search(self, request) -> SearchResult:
@@ -66,7 +66,7 @@ class FakeSearchService:
         return None
 
 
-class FakePreflightService:
+class MockPreflightService:
     """Static preflight service used for live-eval isolation tests."""
 
     def preflight(self, request) -> PreflightResult:
@@ -101,7 +101,7 @@ class FakePreflightService:
         return None
 
 
-class FakeProcess:
+class MockProcess:
     """Subprocess stub with controllable lifecycle."""
 
     def __init__(self, returncodes: list[int | None] | None = None) -> None:
@@ -289,15 +289,15 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+        lambda active_settings: MockIngestService(active_settings, seen_paths),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
-        lambda active_settings, rerank_enabled: FakeSearchService(),
+        lambda active_settings, rerank_enabled: MockSearchService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_preflight_service",
-        lambda active_settings, rerank_enabled: FakePreflightService(),
+        lambda active_settings, rerank_enabled: MockPreflightService(),
     )
 
     result = EvalService(settings=settings).run(
@@ -321,25 +321,25 @@ def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(
     seen_paths: list[Path] = []
     closed: list[bool] = []
 
-    class FakeConformanceService:
+    class MockConformanceService:
         def close(self) -> None:
             closed.append(True)
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+        lambda active_settings: MockIngestService(active_settings, seen_paths),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
-        lambda active_settings, rerank_enabled: FakeSearchService(),
+        lambda active_settings, rerank_enabled: MockSearchService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_preflight_service",
-        lambda active_settings, rerank_enabled: FakePreflightService(),
+        lambda active_settings, rerank_enabled: MockPreflightService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_conformance_service",
-        lambda active_settings, *, backend: FakeConformanceService(),
+        lambda active_settings, *, backend: MockConformanceService(),
     )
 
     result = EvalService(settings=settings).run(
@@ -356,7 +356,7 @@ def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(
 
 def test_eval_service_start_ui_fails_when_process_exits_early(monkeypatch, tmp_path: Path) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[1])
+    process = MockProcess(returncodes=[1])
     monkeypatch.setattr(
         "policynim.services.eval.subprocess.Popen",
         lambda *args, **kwargs: process,
@@ -372,16 +372,16 @@ def test_eval_service_start_ui_succeeds_when_port_becomes_reachable(
     monkeypatch, tmp_path: Path
 ) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[None, None])
+    process = MockProcess(returncodes=[None, None])
     port_checks = iter([False, True])
     popen_call: dict[str, object] = {}
 
-    def fake_popen(command, **kwargs):
+    def mock_popen(command, **kwargs):
         popen_call["command"] = command
         popen_call["env"] = kwargs["env"]
         return process
 
-    monkeypatch.setattr("policynim.services.eval.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("policynim.services.eval.subprocess.Popen", mock_popen)
     monkeypatch.setattr(
         "policynim.services.eval._is_local_port_reachable",
         lambda port: next(port_checks),
@@ -404,7 +404,7 @@ def test_eval_service_start_ui_terminates_when_port_never_becomes_reachable(
     monkeypatch, tmp_path: Path
 ) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[None, None, None])
+    process = MockProcess(returncodes=[None, None, None])
     monotonic_values = iter([0.0, 1.0, 2.0, 6.0])
     monkeypatch.setattr(
         "policynim.services.eval.subprocess.Popen",
@@ -427,21 +427,21 @@ def test_eval_service_publish_to_ui_logs_deterministic_spans_and_annotations(
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
     result = service.run(mode="offline", compare_rerank=False)
 
-    class FakePhoenixClient:
+    class MockPhoenixClient:
         def __init__(self, *, base_url: str) -> None:
             self.base_url = base_url
-            self.projects = FakePhoenixProjects()
-            self.spans = FakePhoenixSpans()
+            self.projects = MockPhoenixProjects()
+            self.spans = MockPhoenixSpans()
             clients.append(self)
 
-    class FakePhoenixProjects:
+    class MockPhoenixProjects:
         def get(self, *, project_name: str) -> None:
             raise RuntimeError(f"missing project {project_name}")
 
         def create(self, *, name: str) -> dict[str, str]:
             return {"name": name}
 
-    class FakePhoenixSpans:
+    class MockPhoenixSpans:
         def __init__(self) -> None:
             self.logged_spans: list[dict[str, object]] = []
             self.logged_annotations: list[dict[str, object]] = []
@@ -455,10 +455,10 @@ def test_eval_service_publish_to_ui_logs_deterministic_spans_and_annotations(
             self.sync = sync
             self.logged_annotations.extend(span_annotations)
 
-    clients: list[FakePhoenixClient] = []
-    fake_client_module = types.ModuleType("phoenix.client")
-    setattr(fake_client_module, "Client", FakePhoenixClient)
-    monkeypatch.setitem(sys.modules, "phoenix.client", fake_client_module)
+    clients: list[MockPhoenixClient] = []
+    mock_client_module = types.ModuleType("phoenix.client")
+    setattr(mock_client_module, "Client", MockPhoenixClient)
+    monkeypatch.setitem(sys.modules, "phoenix.client", mock_client_module)
 
     service.publish_to_ui(result, port=8123)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -832,11 +832,11 @@ def test_healthz_constructs_service_once_and_runs_check_off_thread(monkeypatch) 
         factory_calls += 1
         return CountingHealthService()
 
-    async def fake_to_thread(func, /, *args, **kwargs):
+    async def mock_to_thread(func, /, *args, **kwargs):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(mcp_module, "create_runtime_health_service", build_service)
-    monkeypatch.setattr(mcp_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(mcp_module.asyncio, "to_thread", mock_to_thread)
 
     app = mcp_module._build_streamable_http_app(Settings())
 

--- a/tests/test_nemo_agent_toolkit_policy_conformance.py
+++ b/tests/test_nemo_agent_toolkit_policy_conformance.py
@@ -22,7 +22,7 @@ def test_nat_adapter_requires_optional_eval_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
-    evaluator = FakeEvaluator()
+    evaluator = MockEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
         NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=evaluator)
@@ -36,14 +36,14 @@ def test_nat_from_settings_checks_optional_package_first(monkeypatch) -> None:
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeEvaluator:
+    def mock_from_settings(settings: Settings) -> MockEvaluator:
         constructed.append(True)
-        return FakeEvaluator()
+        return MockEvaluator()
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
     monkeypatch.setattr(
         "policynim.providers.nvidia_eval.NVIDIAPolicyConformanceEvaluator.from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
@@ -55,12 +55,12 @@ def test_nat_from_settings_checks_optional_package_first(monkeypatch) -> None:
 def test_nat_adapter_accepts_nat_eval_package_and_delegates(monkeypatch) -> None:
     checked: list[str] = []
 
-    def fake_installed_version(distribution_name: str) -> str:
+    def mock_installed_version(distribution_name: str) -> str:
         checked.append(distribution_name)
         return "1.0"
 
-    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", fake_installed_version)
-    evaluator = FakeEvaluator()
+    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", mock_installed_version)
+    evaluator = MockEvaluator()
     adapter = NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=evaluator)
 
     result = adapter.evaluate_policy_conformance(make_request())
@@ -72,7 +72,7 @@ def test_nat_adapter_accepts_nat_eval_package_and_delegates(monkeypatch) -> None
     assert evaluator.closed is True
 
 
-class FakeEvaluator:
+class MockEvaluator:
     """Static NVIDIA judge double."""
 
     def __init__(self) -> None:

--- a/tests/test_nemo_evaluator_policy_conformance.py
+++ b/tests/test_nemo_evaluator_policy_conformance.py
@@ -22,7 +22,7 @@ def test_nemo_evaluator_adapter_requires_optional_packages(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
-    evaluator = FakeEvaluator()
+    evaluator = MockEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
         NeMoEvaluatorPolicyConformanceEvaluator(evaluator=evaluator)
@@ -36,14 +36,14 @@ def test_nemo_evaluator_from_settings_checks_optional_packages_first(monkeypatch
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeEvaluator:
+    def mock_from_settings(settings: Settings) -> MockEvaluator:
         constructed.append(True)
-        return FakeEvaluator()
+        return MockEvaluator()
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
     monkeypatch.setattr(
         "policynim.providers.nvidia_eval.NVIDIAPolicyConformanceEvaluator.from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
@@ -55,12 +55,12 @@ def test_nemo_evaluator_from_settings_checks_optional_packages_first(monkeypatch
 def test_nemo_evaluator_adapter_delegates_to_configured_judge(monkeypatch) -> None:
     checked: list[str] = []
 
-    def fake_installed_version(distribution_name: str) -> str:
+    def mock_installed_version(distribution_name: str) -> str:
         checked.append(distribution_name)
         return "1.0"
 
-    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", fake_installed_version)
-    evaluator = FakeEvaluator()
+    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", mock_installed_version)
+    evaluator = MockEvaluator()
     adapter = NeMoEvaluatorPolicyConformanceEvaluator(evaluator=evaluator)
 
     result = adapter.evaluate_policy_conformance(make_request())
@@ -72,7 +72,7 @@ def test_nemo_evaluator_adapter_delegates_to_configured_judge(monkeypatch) -> No
     assert evaluator.closed is True
 
 
-class FakeEvaluator:
+class MockEvaluator:
     """Static NVIDIA judge double."""
 
     def __init__(self) -> None:

--- a/tests/test_nemo_guardrails_preflight_generator.py
+++ b/tests/test_nemo_guardrails_preflight_generator.py
@@ -67,7 +67,7 @@ def test_guardrails_generator_requires_optional_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr(guardrails_module, "installed_version", missing_distribution)
-    base_generator = FakeGenerator([make_draft()])
+    base_generator = MockGenerator([make_draft()])
 
     with pytest.raises(ConfigurationError, match="nvidia-guardrails") as excinfo:
         NeMoGuardrailsPreflightGenerator(base_generator=base_generator)
@@ -84,15 +84,15 @@ def test_guardrails_from_settings_checks_optional_package_before_base_generator(
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeGenerator:
+    def mock_from_settings(settings: Settings) -> MockGenerator:
         constructed.append(True)
-        return FakeGenerator([make_draft()])
+        return MockGenerator([make_draft()])
 
     monkeypatch.setattr(guardrails_module, "installed_version", missing_distribution)
     monkeypatch.setattr(
         guardrails_module.NVIDIAGenerator,
         "from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="nvidia-guardrails"):
@@ -113,9 +113,9 @@ def test_guardrails_assets_are_packaged_and_model_scoped() -> None:
 
 def test_guardrails_generator_returns_valid_checked_draft() -> None:
     checked_draft = make_draft(summary="Checked preflight.")
-    rails = FakeRails([rail_result(status="passed", content=draft_json(checked_draft))])
+    rails = MockRails([rail_result(status="passed", content=draft_json(checked_draft))])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
         rail_type_output="output",
     )
@@ -129,9 +129,9 @@ def test_guardrails_generator_returns_valid_checked_draft() -> None:
 
 
 def test_guardrails_generator_rejects_missing_required_fields() -> None:
-    rails = FakeRails([rail_result(status="passed", content='{"citation_ids":["BACKEND-1"]}')])
+    rails = MockRails([rail_result(status="passed", content='{"citation_ids":["BACKEND-1"]}')])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -142,9 +142,9 @@ def test_guardrails_generator_rejects_missing_required_fields() -> None:
 
 
 def test_guardrails_generator_rejects_invalid_json() -> None:
-    rails = FakeRails([rail_result(status="passed", content="not json")])
+    rails = MockRails([rail_result(status="passed", content="not json")])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -155,11 +155,11 @@ def test_guardrails_generator_rejects_invalid_json() -> None:
 
 
 def test_guardrails_generator_rejects_unsupported_citations() -> None:
-    rails = FakeRails(
+    rails = MockRails(
         [rail_result(status="modified", content=draft_json(make_draft(citation_ids=["UNKNOWN-1"])))]
     )
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -170,8 +170,8 @@ def test_guardrails_generator_rejects_unsupported_citations() -> None:
 
 
 def test_guardrails_generator_fails_closed_when_rails_block() -> None:
-    rails = FakeRails([rail_result(status="blocked", content=draft_json(make_draft()))])
-    base_generator = FakeGenerator([make_draft()])
+    rails = MockRails([rail_result(status="blocked", content=draft_json(make_draft()))])
+    base_generator = MockGenerator([make_draft()])
     generator = NeMoGuardrailsPreflightGenerator(
         base_generator=base_generator,
         rails=rails,
@@ -187,7 +187,7 @@ def test_guardrails_generator_fails_closed_when_rails_block() -> None:
 def test_guardrails_generator_preserves_rails_exception_chain() -> None:
     raised = RuntimeError("rail runtime failed")
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=RaisingRails(raised),
     )
 
@@ -199,8 +199,8 @@ def test_guardrails_generator_preserves_rails_exception_chain() -> None:
 
 
 def test_guardrails_generator_passes_regeneration_context_unchanged() -> None:
-    base_generator = FakeGenerator([make_draft()])
-    rails = FakeRails([rail_result(status="passed", content=draft_json(make_draft()))])
+    base_generator = MockGenerator([make_draft()])
+    rails = MockRails([rail_result(status="passed", content=draft_json(make_draft()))])
     generator = NeMoGuardrailsPreflightGenerator(
         base_generator=base_generator,
         rails=rails,
@@ -235,7 +235,7 @@ class GenerateCall:
         self.regeneration_context = regeneration_context
 
 
-class FakeGenerator:
+class MockGenerator:
     """Static generator double."""
 
     def __init__(self, drafts: list[GeneratedPreflightDraft]) -> None:
@@ -278,7 +278,7 @@ class RailCall:
         self.rail_types = list(rail_types) if rail_types is not None else None
 
 
-class FakeRails:
+class MockRails:
     """Static Guardrails double."""
 
     def __init__(self, results: list[object]) -> None:

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -9,14 +9,14 @@ from policynim.errors import ConfigurationError, ProviderError
 from policynim.providers.nvidia import NVIDIAEmbedder
 
 
-class FakeAuthenticationError(AuthenticationError):
+class MockAuthenticationError(AuthenticationError):
     """Minimal auth error subclass for provider classification tests."""
 
     def __init__(self) -> None:
         Exception.__init__(self, "bad API key")
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -44,7 +44,7 @@ def test_embedder_classifies_upstream_auth_failures() -> None:
         timeout_seconds=1,
         max_retries=0,
     )
-    embedder._client = RaisingEmbeddingsClient(FakeAuthenticationError())  # type: ignore[assignment]
+    embedder._client = RaisingEmbeddingsClient(MockAuthenticationError())  # type: ignore[assignment]
 
     with pytest.raises(ConfigurationError, match="authentication failed") as excinfo:
         embedder.embed_query("backend logging")
@@ -61,7 +61,7 @@ def test_embedder_classifies_upstream_rate_limits() -> None:
         timeout_seconds=1,
         max_retries=0,
     )
-    embedder._client = RaisingEmbeddingsClient(FakeRateLimitError())  # type: ignore[assignment]
+    embedder._client = RaisingEmbeddingsClient(MockRateLimitError())  # type: ignore[assignment]
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         embedder.embed_query("backend logging")

--- a/tests/test_nvidia_generator.py
+++ b/tests/test_nvidia_generator.py
@@ -37,7 +37,7 @@ class MockOpenAIClient:
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -176,7 +176,7 @@ def test_generator_classifies_upstream_rate_limits() -> None:
         base_url="https://example.invalid/v1",
         timeout_seconds=1,
         max_retries=0,
-        client=RaisingOpenAIClient(FakeRateLimitError()),  # type: ignore[arg-type]
+        client=RaisingOpenAIClient(MockRateLimitError()),  # type: ignore[arg-type]
     )
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -48,7 +48,7 @@ class MockOpenAIClient:
         self.closed = True
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -178,7 +178,7 @@ def test_policy_compiler_rejects_invalid_constraint_shape() -> None:
 
 
 def test_policy_compiler_classifies_upstream_rate_limits() -> None:
-    compiler = make_compiler(RaisingOpenAIClient(FakeRateLimitError()))
+    compiler = make_compiler(RaisingOpenAIClient(MockRateLimitError()))
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         compiler.compile_policy_packet(

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -49,7 +49,7 @@ class MockOpenAIClient:
         self.closed = True
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -173,7 +173,7 @@ def test_policy_conformance_rejects_unsupported_chunk_ids() -> None:
 
 
 def test_policy_conformance_classifies_upstream_rate_limits() -> None:
-    evaluator = make_evaluator(RaisingOpenAIClient(FakeRateLimitError()))
+    evaluator = make_evaluator(RaisingOpenAIClient(MockRateLimitError()))
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         evaluator.evaluate_policy_conformance(make_request())

--- a/tests/test_policy_regeneration_service.py
+++ b/tests/test_policy_regeneration_service.py
@@ -34,14 +34,14 @@ from policynim.types import (
 
 def test_regeneration_compiles_once_and_retries_from_typed_triggers() -> None:
     packet = make_compiled_packet()
-    compiler = FakeCompilerService(packet=packet, context=[make_chunk()])
-    generator = FakeGenerator(
+    compiler = MockCompilerService(packet=packet, context=[make_chunk()])
+    generator = MockGenerator(
         [
             make_draft(summary="Initial preflight."),
             make_draft(summary="Regenerated preflight."),
         ]
     )
-    conformance = FakeConformanceService(
+    conformance = MockConformanceService(
         [
             make_conformance_result(
                 passed=False,
@@ -97,7 +97,7 @@ def test_regeneration_compiles_once_and_retries_from_typed_triggers() -> None:
 
 def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
     packet = make_compiled_packet()
-    base_generator = FakeGenerator(
+    base_generator = MockGenerator(
         [
             make_draft(summary="Initial preflight."),
             make_draft(summary="Regenerated preflight."),
@@ -109,9 +109,9 @@ def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
         rails=rails,
     )
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=packet, context=[make_chunk()]),
+        compiler_service=MockCompilerService(packet=packet, context=[make_chunk()]),
         generator=guardrails_generator,
-        conformance_service=FakeConformanceService(
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -150,9 +150,9 @@ def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
 
 def test_regeneration_can_include_chunk_text_for_debug_traces() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft()]),
-        conformance_service=FakeConformanceService([make_conformance_result(passed=True)]),
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft()]),
+        conformance_service=MockConformanceService([make_conformance_result(passed=True)]),
     )
 
     result = service.regenerate(
@@ -168,9 +168,9 @@ def test_regeneration_can_include_chunk_text_for_debug_traces() -> None:
 
 def test_regeneration_stops_at_max_regenerations() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft(), make_draft(summary="Retry still failing.")]),
-        conformance_service=FakeConformanceService(
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft(), make_draft(summary="Retry still failing.")]),
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -214,9 +214,9 @@ def test_regeneration_stops_at_max_regenerations() -> None:
 
 def test_regeneration_stops_when_failed_metrics_have_no_material_trigger() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft()]),
-        conformance_service=FakeConformanceService(
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft()]),
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -241,12 +241,12 @@ def test_regeneration_stops_when_failed_metrics_have_no_material_trigger() -> No
 
 
 def test_regeneration_treats_insufficient_compiled_context_as_terminal() -> None:
-    compiler = FakeCompilerService(
+    compiler = MockCompilerService(
         packet=make_compiled_packet(insufficient_context=True),
         context=[],
     )
-    generator = FakeGenerator([make_draft()])
-    conformance = FakeConformanceService([make_conformance_result(passed=True)])
+    generator = MockGenerator([make_draft()])
+    conformance = MockConformanceService([make_conformance_result(passed=True)])
     service = PolicyRegenerationService(
         compiler_service=compiler,
         generator=generator,
@@ -263,9 +263,9 @@ def test_regeneration_treats_insufficient_compiled_context_as_terminal() -> None
 
 
 def test_regeneration_fails_closed_for_provider_errors_without_retry() -> None:
-    compiler = FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()])
-    generator = FakeGenerator([make_draft(), make_draft(summary="Should not run.")])
-    conformance = FakeConformanceService([ProviderError("judge failed", failure_class="timeout")])
+    compiler = MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()])
+    generator = MockGenerator([make_draft(), make_draft(summary="Should not run.")])
+    conformance = MockConformanceService([ProviderError("judge failed", failure_class="timeout")])
     service = PolicyRegenerationService(
         compiler_service=compiler,
         generator=generator,
@@ -281,10 +281,10 @@ def test_regeneration_fails_closed_for_provider_errors_without_retry() -> None:
 
 
 def test_regeneration_rejects_citation_drift_as_insufficient_context() -> None:
-    conformance = FakeConformanceService([make_conformance_result(passed=True)])
+    conformance = MockConformanceService([make_conformance_result(passed=True)])
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft(citation_ids=["UNKNOWN-1"])]),
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft(citation_ids=["UNKNOWN-1"])]),
         conformance_service=conformance,
     )
 
@@ -319,7 +319,7 @@ def test_trigger_mapping_preserves_judged_final_adherence_ids() -> None:
     assert triggers[0].chunk_ids == ["BACKEND-1"]
 
 
-class FakeCompilerService:
+class MockCompilerService:
     """Static compiler service double."""
 
     def __init__(self, *, packet: CompiledPolicyPacket, context: list[ScoredChunk]) -> None:
@@ -353,7 +353,7 @@ class GenerateCall:
         self.regeneration_context = regeneration_context
 
 
-class FakeGenerator:
+class MockGenerator:
     """Static generator double."""
 
     def __init__(self, drafts: list[GeneratedPreflightDraft]) -> None:
@@ -384,7 +384,7 @@ class FakeGenerator:
         self.closed = True
 
 
-class FakeConformanceService:
+class MockConformanceService:
     """Static conformance service double."""
 
     def __init__(self, outcomes: list[PolicyConformanceResult | ProviderError]) -> None:


### PR DESCRIPTION
## Summary
- rename test double classes, functions, and variables to Mock/mock terminology
- update related test/docs wording to use mock terminology
- confirm no remaining old terminology outside excluded lock data

## Tests
- uv run pytest tests/test_eval_service.py tests/test_mcp.py tests/test_nemo_agent_toolkit_policy_conformance.py tests/test_nemo_evaluator_policy_conformance.py tests/test_nemo_guardrails_preflight_generator.py tests/test_nvidia_embedder.py tests/test_nvidia_generator.py tests/test_nvidia_policy_compiler.py tests/test_nvidia_policy_conformance.py tests/test_policy_regeneration_service.py
- uv run ruff check
- uv run pytest