### PR TITLE
docs: align workflow summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ contributor quality gates. The launcher path is installable in-project with
 the internal Guardrails output-rail wrapper uses `uv sync --extra nvidia-guardrails`.
 
 If you are using an installed copy instead of a source checkout, run
-`uv run policynim init` once first so PolicyNIM can write the standalone config
-file and data-path defaults before `policynim ingest`.
+`policynim init` once first so PolicyNIM can write the standalone config file
+and data-path defaults before `policynim ingest`. Use `uv run` only when running
+commands from the source checkout's uv-managed project environment.
 
 Use [docs/workflows.md](docs/workflows.md) for the CLI, MCP, runtime, eval, and
 troubleshooting handbook.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ PolicyNIM currently ships with two main user-facing surfaces:
   artifacts and local Phoenix reporting for non-headless runs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
-  `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
+- JSON-first CLI commands for `init`, `ingest`, `dump-index`, `search`, `route`,
+  `compile`, `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
@@ -117,6 +117,10 @@ templates, runtime settings, optional NVIDIA eval and Guardrails extras, and
 contributor quality gates. The launcher path is installable in-project with
 `uv sync --extra nvidia-eval --extra nvidia-eval-launcher --group test --group dev`;
 the internal Guardrails output-rail wrapper uses `uv sync --extra nvidia-guardrails`.
+
+If you are using an installed copy instead of a source checkout, run
+`uv run policynim init` once first so PolicyNIM can write the standalone config
+file and data-path defaults before `policynim ingest`.
 
 Use [docs/workflows.md](docs/workflows.md) for the CLI, MCP, runtime, eval, and
 troubleshooting handbook.

--- a/README.md
+++ b/README.md
@@ -113,18 +113,19 @@ uv run policynim preflight --task "Implement a refresh-token cleanup background 
 ```
 
 Use [docs/contributor-guide.md](docs/contributor-guide.md) for environment
-templates, runtime settings, optional NVIDIA eval and Guardrails extras, and
-contributor quality gates. The launcher path is installable in-project with
-`uv sync --extra nvidia-eval --extra nvidia-eval-launcher --group test --group dev`;
-the internal Guardrails output-rail wrapper uses `uv sync --extra nvidia-guardrails`.
+templates, standalone init, runtime settings, optional NVIDIA eval and
+Guardrails extras, model references, and contributor quality gates. The
+launcher path is installable in-project with `uv sync --extra nvidia-eval
+--extra nvidia-eval-launcher --group test --group dev`; the internal
+Guardrails output-rail wrapper uses `uv sync --extra nvidia-guardrails`.
 
 If you are using an installed copy instead of a source checkout, run
 `policynim init` once first so PolicyNIM can write the standalone config file
 and data-path defaults before `policynim ingest`. Use `uv run` only when running
 commands from the source checkout's uv-managed project environment.
 
-Use [docs/workflows.md](docs/workflows.md) for the CLI, MCP, runtime, eval, and
-troubleshooting handbook.
+Use [docs/workflows.md](docs/workflows.md) for the CLI, standalone init, MCP,
+runtime, eval, hosted HTTP, and troubleshooting handbook.
 
 ## Docs Map
 
@@ -133,9 +134,9 @@ Start here when you want the longer version of a specific path:
 - [docs/index.md](docs/index.md): documentation hub by audience and task
 - [docs/contributor-guide.md](docs/contributor-guide.md): local setup, env vars,
   model references, and quality gates
-- [docs/workflows.md](docs/workflows.md): CLI surfaces,
-  ingest/search/route/compile/preflight, eval, MCP, runtime/evidence, and
-  troubleshooting
+- [docs/workflows.md](docs/workflows.md): CLI surfaces, standalone init,
+  ingest/search/route/compile/preflight, eval, MCP, runtime/evidence,
+  hosted HTTP, and troubleshooting
 - [docs/hosted-beta-operations.md](docs/hosted-beta-operations.md): hosted beta
   quickstart, recovery, container build flow, and Railway deploy notes
 - [docs/architecture.md](docs/architecture.md): package boundaries, runtime flow,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,6 +303,7 @@ Important evaluation rules:
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
 - `policynim dump-index`
 - `policynim search --query ...`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -38,7 +38,7 @@ If you are using an installed copy instead of a source checkout, initialize the
 user-owned config once:
 
 ```bash
-uv run policynim init
+policynim init
 ```
 
 That command prompts for `NVIDIA_API_KEY` and an optional custom corpus
@@ -48,7 +48,7 @@ config directory with user-owned defaults for `POLICYNIM_LANCEDB_URI`,
 and `POLICYNIM_EVAL_WORKSPACE_DIR`.
 
 After that, run `policynim ingest` as usual. Source checkouts can keep using the
-`.env.development.example` flow above.
+`.env.development.example` flow above and `uv run` for in-project commands.
 
 ## Environment Templates
 

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -32,6 +32,24 @@ server:
 uv run policynim ingest
 ```
 
+## Standalone Install
+
+If you are using an installed copy instead of a source checkout, initialize the
+user-owned config once:
+
+```bash
+uv run policynim init
+```
+
+That command prompts for `NVIDIA_API_KEY` and an optional custom corpus
+directory, then writes the standalone `config.env` file under your platform
+config directory with user-owned defaults for `POLICYNIM_LANCEDB_URI`,
+`POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH`, `POLICYNIM_RUNTIME_EVIDENCE_DB_PATH`,
+and `POLICYNIM_EVAL_WORKSPACE_DIR`.
+
+After that, run `policynim ingest` as usual. Source checkouts can keep using the
+`.env.development.example` flow above.
+
 ## Environment Templates
 
 The repo ships three related templates:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ operations into separate pages so the root README can stay short.
 
 - [../README.md](../README.md): concise project overview, current capabilities,
   quickstart, and links outward
-- [contributor-guide.md](contributor-guide.md): local setup, env templates,
-  important settings, model references, and quality gates
+- [contributor-guide.md](contributor-guide.md): local setup, standalone init,
+  env templates, important settings, model references, and quality gates
 - [workflows.md](workflows.md): CLI, route/preflight, MCP, runtime/evidence, eval, and
   troubleshooting handbook
 - [hosted-beta-operations.md](hosted-beta-operations.md): hosted beta quickstart,

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ operations into separate pages so the root README can stay short.
   quickstart, and links outward
 - [contributor-guide.md](contributor-guide.md): local setup, standalone init,
   env templates, important settings, model references, and quality gates
-- [workflows.md](workflows.md): CLI, route/preflight, MCP, runtime/evidence, eval, and
-  troubleshooting handbook
+- [workflows.md](workflows.md): CLI, standalone init, route/preflight, eval,
+  MCP, runtime/evidence, hosted HTTP, and troubleshooting handbook
 - [hosted-beta-operations.md](hosted-beta-operations.md): hosted beta quickstart,
   recovery, container build flow, and Railway deployment notes
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -58,8 +58,8 @@ constraints, not setup mistakes.
 - CI does not exercise live NVIDIA embeddings, reranking, grounded generation, or
   end-to-end MCP flows against hosted services.
 - CI does not require NeMo Evaluator SDK or NeMo Agent Toolkit packages; optional
-  package paths use fake/import-injected tests.
-- CI does not require NeMo Guardrails; output-rail tests use fakes and verify the
+  package paths use mock-backed import-injected tests.
+- CI does not require NeMo Guardrails; output-rail tests use mocks and verify the
   default factory does not import the optional package.
 - Live-provider and Railway-hosted verification remain manual or opt-in local workflows.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,7 +1,8 @@
 # PolicyNIM Workflow Handbook
 
-Use this page for the detailed CLI, MCP, runtime, eval, and troubleshooting
-reference that used to live in the root README.
+Use this page for the detailed CLI, standalone init, MCP, runtime, eval,
+hosted HTTP, and troubleshooting reference that used to live in the root
+README.
 
 ## Public Surface
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,6 +7,7 @@ reference that used to live in the root README.
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
 - `policynim dump-index`
 - `policynim search --query "..."`
@@ -42,6 +43,19 @@ reference that used to live in the root README.
   missing or empty
 
 ## Core Workflows
+
+### 0. Initialize A Standalone Install
+
+```bash
+uv run policynim init
+```
+
+Use this when you installed PolicyNIM instead of running from a source
+checkout. It prompts for `NVIDIA_API_KEY` and an optional custom corpus
+directory, then writes the standalone config file with user-owned data-path
+defaults.
+
+Source checkouts can keep using `.env.development.example` and skip this step.
 
 ### 1. Build The Local Index
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -47,15 +47,19 @@ reference that used to live in the root README.
 ### 0. Initialize A Standalone Install
 
 ```bash
-uv run policynim init
+policynim init
+policynim ingest
 ```
 
 Use this when you installed PolicyNIM instead of running from a source
 checkout. It prompts for `NVIDIA_API_KEY` and an optional custom corpus
 directory, then writes the standalone config file with user-owned data-path
-defaults.
+defaults before building the local index.
 
-Source checkouts can keep using `.env.development.example` and skip this step.
+Source checkouts can keep using `.env.development.example`, skip this step, and
+use the later `uv run policynim ...` examples inside the uv-managed project
+environment. Installed copies should keep using the direct `policynim ...`
+entrypoint.
 
 ### 1. Build The Local Index
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,8 @@ Current automated coverage includes:
   policy-compilation, and reranking payloads
 - CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
   `compile`, and JSON-first `preflight`
+- Interactive `init` standalone setup, config file writing, and missing-setup
+  guidance
 - CLI output for `eval`
 - CLI output for `eval --backend default|nemo|nemo_evaluator|nat`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,8 +30,8 @@ Current automated coverage includes:
 - Phoenix eval reporting, headless UI skipping, workspace-local
   Phoenix startup, deterministic span publishing, and synchronous code
   annotations
-- Optional NeMo Evaluator and NeMo Agent Toolkit adapter gating with fake
-  import-injected package modules; default CI does not import live optional
+- Optional NeMo Evaluator and NeMo Agent Toolkit adapter gating with
+  mock-backed import-injected package modules; default CI does not import live optional
   NVIDIA eval packages
 - Optional NVIDIA Eval Launcher dependency resolution through
   `uv sync --extra nvidia-eval --extra nvidia-eval-launcher --group test --group dev`

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
 WORKFLOWS_GUIDE = REPO_ROOT / "docs" / "workflows.md"
 CONTRIBUTOR_GUIDE = REPO_ROOT / "docs" / "contributor-guide.md"
 POLICY_TEMPLATE = REPO_ROOT / "policies" / "TEMPLATE.md"
 TESTS_README = REPO_ROOT / "tests" / "README.md"
+STANDALONE_SETUP_DOCS = (README, WORKFLOWS_GUIDE, CONTRIBUTOR_GUIDE)
 ENV_EXAMPLES = (
     REPO_ROOT / ".env.example",
     REPO_ROOT / ".env.development.example",
@@ -54,6 +56,16 @@ def test_contributor_guide_and_env_examples_include_runtime_settings() -> None:
             "POLICYNIM_RUNTIME_SHELL_TIMEOUT_SECONDS",
         ):
             assert token in text, f"{path.name} is missing {token}"
+
+
+def test_standalone_setup_docs_use_installed_cli_entrypoint() -> None:
+    for path in STANDALONE_SETUP_DOCS:
+        text = _read_text(path)
+        assert "uv run policynim init" not in text, f"{path.name} should not require uv for init"
+        assert "policynim init" in text, f"{path.name} should document standalone init"
+
+    workflows_text = _read_text(WORKFLOWS_GUIDE)
+    assert "policynim init\npolicynim ingest" in workflows_text
 
 
 def test_production_env_example_uses_absolute_runtime_paths() -> None:

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -23,7 +23,7 @@ from policynim.types import (
 )
 
 
-class FakeIngestService:
+class MockIngestService:
     """Capture the isolated live eval index path."""
 
     def __init__(self, settings: Settings, seen_paths: list[Path]) -> None:
@@ -35,7 +35,7 @@ class FakeIngestService:
         return None
 
 
-class FakeSearchService:
+class MockSearchService:
     """Static search service used for live-eval isolation tests."""
 
     def search(self, request) -> SearchResult:
@@ -66,7 +66,7 @@ class FakeSearchService:
         return None
 
 
-class FakePreflightService:
+class MockPreflightService:
     """Static preflight service used for live-eval isolation tests."""
 
     def preflight(self, request) -> PreflightResult:
@@ -101,7 +101,7 @@ class FakePreflightService:
         return None
 
 
-class FakeProcess:
+class MockProcess:
     """Subprocess stub with controllable lifecycle."""
 
     def __init__(self, returncodes: list[int | None] | None = None) -> None:
@@ -289,15 +289,15 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+        lambda active_settings: MockIngestService(active_settings, seen_paths),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
-        lambda active_settings, rerank_enabled: FakeSearchService(),
+        lambda active_settings, rerank_enabled: MockSearchService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_preflight_service",
-        lambda active_settings, rerank_enabled: FakePreflightService(),
+        lambda active_settings, rerank_enabled: MockPreflightService(),
     )
 
     result = EvalService(settings=settings).run(
@@ -321,25 +321,25 @@ def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(
     seen_paths: list[Path] = []
     closed: list[bool] = []
 
-    class FakeConformanceService:
+    class MockConformanceService:
         def close(self) -> None:
             closed.append(True)
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+        lambda active_settings: MockIngestService(active_settings, seen_paths),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
-        lambda active_settings, rerank_enabled: FakeSearchService(),
+        lambda active_settings, rerank_enabled: MockSearchService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_preflight_service",
-        lambda active_settings, rerank_enabled: FakePreflightService(),
+        lambda active_settings, rerank_enabled: MockPreflightService(),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_conformance_service",
-        lambda active_settings, *, backend: FakeConformanceService(),
+        lambda active_settings, *, backend: MockConformanceService(),
     )
 
     result = EvalService(settings=settings).run(
@@ -356,7 +356,7 @@ def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(
 
 def test_eval_service_start_ui_fails_when_process_exits_early(monkeypatch, tmp_path: Path) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[1])
+    process = MockProcess(returncodes=[1])
     monkeypatch.setattr(
         "policynim.services.eval.subprocess.Popen",
         lambda *args, **kwargs: process,
@@ -372,16 +372,16 @@ def test_eval_service_start_ui_succeeds_when_port_becomes_reachable(
     monkeypatch, tmp_path: Path
 ) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[None, None])
+    process = MockProcess(returncodes=[None, None])
     port_checks = iter([False, True])
     popen_call: dict[str, object] = {}
 
-    def fake_popen(command, **kwargs):
+    def mock_popen(command, **kwargs):
         popen_call["command"] = command
         popen_call["env"] = kwargs["env"]
         return process
 
-    monkeypatch.setattr("policynim.services.eval.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("policynim.services.eval.subprocess.Popen", mock_popen)
     monkeypatch.setattr(
         "policynim.services.eval._is_local_port_reachable",
         lambda port: next(port_checks),
@@ -404,7 +404,7 @@ def test_eval_service_start_ui_terminates_when_port_never_becomes_reachable(
     monkeypatch, tmp_path: Path
 ) -> None:
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
-    process = FakeProcess(returncodes=[None, None, None])
+    process = MockProcess(returncodes=[None, None, None])
     monotonic_values = iter([0.0, 1.0, 2.0, 6.0])
     monkeypatch.setattr(
         "policynim.services.eval.subprocess.Popen",
@@ -427,21 +427,21 @@ def test_eval_service_publish_to_ui_logs_deterministic_spans_and_annotations(
     service = EvalService(settings=Settings(eval_workspace_dir=tmp_path / "workspace"))
     result = service.run(mode="offline", compare_rerank=False)
 
-    class FakePhoenixClient:
+    class MockPhoenixClient:
         def __init__(self, *, base_url: str) -> None:
             self.base_url = base_url
-            self.projects = FakePhoenixProjects()
-            self.spans = FakePhoenixSpans()
+            self.projects = MockPhoenixProjects()
+            self.spans = MockPhoenixSpans()
             clients.append(self)
 
-    class FakePhoenixProjects:
+    class MockPhoenixProjects:
         def get(self, *, project_name: str) -> None:
             raise RuntimeError(f"missing project {project_name}")
 
         def create(self, *, name: str) -> dict[str, str]:
             return {"name": name}
 
-    class FakePhoenixSpans:
+    class MockPhoenixSpans:
         def __init__(self) -> None:
             self.logged_spans: list[dict[str, object]] = []
             self.logged_annotations: list[dict[str, object]] = []
@@ -455,10 +455,10 @@ def test_eval_service_publish_to_ui_logs_deterministic_spans_and_annotations(
             self.sync = sync
             self.logged_annotations.extend(span_annotations)
 
-    clients: list[FakePhoenixClient] = []
-    fake_client_module = types.ModuleType("phoenix.client")
-    setattr(fake_client_module, "Client", FakePhoenixClient)
-    monkeypatch.setitem(sys.modules, "phoenix.client", fake_client_module)
+    clients: list[MockPhoenixClient] = []
+    mock_client_module = types.ModuleType("phoenix.client")
+    setattr(mock_client_module, "Client", MockPhoenixClient)
+    monkeypatch.setitem(sys.modules, "phoenix.client", mock_client_module)
 
     service.publish_to_ui(result, port=8123)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -832,11 +832,11 @@ def test_healthz_constructs_service_once_and_runs_check_off_thread(monkeypatch) 
         factory_calls += 1
         return CountingHealthService()
 
-    async def fake_to_thread(func, /, *args, **kwargs):
+    async def mock_to_thread(func, /, *args, **kwargs):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(mcp_module, "create_runtime_health_service", build_service)
-    monkeypatch.setattr(mcp_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(mcp_module.asyncio, "to_thread", mock_to_thread)
 
     app = mcp_module._build_streamable_http_app(Settings())
 

--- a/tests/test_nemo_agent_toolkit_policy_conformance.py
+++ b/tests/test_nemo_agent_toolkit_policy_conformance.py
@@ -22,7 +22,7 @@ def test_nat_adapter_requires_optional_eval_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
-    evaluator = FakeEvaluator()
+    evaluator = MockEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
         NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=evaluator)
@@ -36,14 +36,14 @@ def test_nat_from_settings_checks_optional_package_first(monkeypatch) -> None:
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeEvaluator:
+    def mock_from_settings(settings: Settings) -> MockEvaluator:
         constructed.append(True)
-        return FakeEvaluator()
+        return MockEvaluator()
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
     monkeypatch.setattr(
         "policynim.providers.nvidia_eval.NVIDIAPolicyConformanceEvaluator.from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
@@ -55,12 +55,12 @@ def test_nat_from_settings_checks_optional_package_first(monkeypatch) -> None:
 def test_nat_adapter_accepts_nat_eval_package_and_delegates(monkeypatch) -> None:
     checked: list[str] = []
 
-    def fake_installed_version(distribution_name: str) -> str:
+    def mock_installed_version(distribution_name: str) -> str:
         checked.append(distribution_name)
         return "1.0"
 
-    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", fake_installed_version)
-    evaluator = FakeEvaluator()
+    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", mock_installed_version)
+    evaluator = MockEvaluator()
     adapter = NeMoAgentToolkitPolicyConformanceEvaluator(evaluator=evaluator)
 
     result = adapter.evaluate_policy_conformance(make_request())
@@ -72,7 +72,7 @@ def test_nat_adapter_accepts_nat_eval_package_and_delegates(monkeypatch) -> None
     assert evaluator.closed is True
 
 
-class FakeEvaluator:
+class MockEvaluator:
     """Static NVIDIA judge double."""
 
     def __init__(self) -> None:

--- a/tests/test_nemo_evaluator_policy_conformance.py
+++ b/tests/test_nemo_evaluator_policy_conformance.py
@@ -22,7 +22,7 @@ def test_nemo_evaluator_adapter_requires_optional_packages(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
-    evaluator = FakeEvaluator()
+    evaluator = MockEvaluator()
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
         NeMoEvaluatorPolicyConformanceEvaluator(evaluator=evaluator)
@@ -36,14 +36,14 @@ def test_nemo_evaluator_from_settings_checks_optional_packages_first(monkeypatch
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeEvaluator:
+    def mock_from_settings(settings: Settings) -> MockEvaluator:
         constructed.append(True)
-        return FakeEvaluator()
+        return MockEvaluator()
 
     monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", missing_distribution)
     monkeypatch.setattr(
         "policynim.providers.nvidia_eval.NVIDIAPolicyConformanceEvaluator.from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="uv sync --extra nvidia-eval"):
@@ -55,12 +55,12 @@ def test_nemo_evaluator_from_settings_checks_optional_packages_first(monkeypatch
 def test_nemo_evaluator_adapter_delegates_to_configured_judge(monkeypatch) -> None:
     checked: list[str] = []
 
-    def fake_installed_version(distribution_name: str) -> str:
+    def mock_installed_version(distribution_name: str) -> str:
         checked.append(distribution_name)
         return "1.0"
 
-    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", fake_installed_version)
-    evaluator = FakeEvaluator()
+    monkeypatch.setattr("policynim.providers.nvidia_eval.installed_version", mock_installed_version)
+    evaluator = MockEvaluator()
     adapter = NeMoEvaluatorPolicyConformanceEvaluator(evaluator=evaluator)
 
     result = adapter.evaluate_policy_conformance(make_request())
@@ -72,7 +72,7 @@ def test_nemo_evaluator_adapter_delegates_to_configured_judge(monkeypatch) -> No
     assert evaluator.closed is True
 
 
-class FakeEvaluator:
+class MockEvaluator:
     """Static NVIDIA judge double."""
 
     def __init__(self) -> None:

--- a/tests/test_nemo_guardrails_preflight_generator.py
+++ b/tests/test_nemo_guardrails_preflight_generator.py
@@ -67,7 +67,7 @@ def test_guardrails_generator_requires_optional_package(monkeypatch) -> None:
         raise PackageNotFoundError(distribution_name)
 
     monkeypatch.setattr(guardrails_module, "installed_version", missing_distribution)
-    base_generator = FakeGenerator([make_draft()])
+    base_generator = MockGenerator([make_draft()])
 
     with pytest.raises(ConfigurationError, match="nvidia-guardrails") as excinfo:
         NeMoGuardrailsPreflightGenerator(base_generator=base_generator)
@@ -84,15 +84,15 @@ def test_guardrails_from_settings_checks_optional_package_before_base_generator(
     def missing_distribution(distribution_name: str) -> str:
         raise PackageNotFoundError(distribution_name)
 
-    def fake_from_settings(settings: Settings) -> FakeGenerator:
+    def mock_from_settings(settings: Settings) -> MockGenerator:
         constructed.append(True)
-        return FakeGenerator([make_draft()])
+        return MockGenerator([make_draft()])
 
     monkeypatch.setattr(guardrails_module, "installed_version", missing_distribution)
     monkeypatch.setattr(
         guardrails_module.NVIDIAGenerator,
         "from_settings",
-        fake_from_settings,
+        mock_from_settings,
     )
 
     with pytest.raises(ConfigurationError, match="nvidia-guardrails"):
@@ -113,9 +113,9 @@ def test_guardrails_assets_are_packaged_and_model_scoped() -> None:
 
 def test_guardrails_generator_returns_valid_checked_draft() -> None:
     checked_draft = make_draft(summary="Checked preflight.")
-    rails = FakeRails([rail_result(status="passed", content=draft_json(checked_draft))])
+    rails = MockRails([rail_result(status="passed", content=draft_json(checked_draft))])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
         rail_type_output="output",
     )
@@ -129,9 +129,9 @@ def test_guardrails_generator_returns_valid_checked_draft() -> None:
 
 
 def test_guardrails_generator_rejects_missing_required_fields() -> None:
-    rails = FakeRails([rail_result(status="passed", content='{"citation_ids":["BACKEND-1"]}')])
+    rails = MockRails([rail_result(status="passed", content='{"citation_ids":["BACKEND-1"]}')])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -142,9 +142,9 @@ def test_guardrails_generator_rejects_missing_required_fields() -> None:
 
 
 def test_guardrails_generator_rejects_invalid_json() -> None:
-    rails = FakeRails([rail_result(status="passed", content="not json")])
+    rails = MockRails([rail_result(status="passed", content="not json")])
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -155,11 +155,11 @@ def test_guardrails_generator_rejects_invalid_json() -> None:
 
 
 def test_guardrails_generator_rejects_unsupported_citations() -> None:
-    rails = FakeRails(
+    rails = MockRails(
         [rail_result(status="modified", content=draft_json(make_draft(citation_ids=["UNKNOWN-1"])))]
     )
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=rails,
     )
 
@@ -170,8 +170,8 @@ def test_guardrails_generator_rejects_unsupported_citations() -> None:
 
 
 def test_guardrails_generator_fails_closed_when_rails_block() -> None:
-    rails = FakeRails([rail_result(status="blocked", content=draft_json(make_draft()))])
-    base_generator = FakeGenerator([make_draft()])
+    rails = MockRails([rail_result(status="blocked", content=draft_json(make_draft()))])
+    base_generator = MockGenerator([make_draft()])
     generator = NeMoGuardrailsPreflightGenerator(
         base_generator=base_generator,
         rails=rails,
@@ -187,7 +187,7 @@ def test_guardrails_generator_fails_closed_when_rails_block() -> None:
 def test_guardrails_generator_preserves_rails_exception_chain() -> None:
     raised = RuntimeError("rail runtime failed")
     generator = NeMoGuardrailsPreflightGenerator(
-        base_generator=FakeGenerator([make_draft()]),
+        base_generator=MockGenerator([make_draft()]),
         rails=RaisingRails(raised),
     )
 
@@ -199,8 +199,8 @@ def test_guardrails_generator_preserves_rails_exception_chain() -> None:
 
 
 def test_guardrails_generator_passes_regeneration_context_unchanged() -> None:
-    base_generator = FakeGenerator([make_draft()])
-    rails = FakeRails([rail_result(status="passed", content=draft_json(make_draft()))])
+    base_generator = MockGenerator([make_draft()])
+    rails = MockRails([rail_result(status="passed", content=draft_json(make_draft()))])
     generator = NeMoGuardrailsPreflightGenerator(
         base_generator=base_generator,
         rails=rails,
@@ -235,7 +235,7 @@ class GenerateCall:
         self.regeneration_context = regeneration_context
 
 
-class FakeGenerator:
+class MockGenerator:
     """Static generator double."""
 
     def __init__(self, drafts: list[GeneratedPreflightDraft]) -> None:
@@ -278,7 +278,7 @@ class RailCall:
         self.rail_types = list(rail_types) if rail_types is not None else None
 
 
-class FakeRails:
+class MockRails:
     """Static Guardrails double."""
 
     def __init__(self, results: list[object]) -> None:

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -9,14 +9,14 @@ from policynim.errors import ConfigurationError, ProviderError
 from policynim.providers.nvidia import NVIDIAEmbedder
 
 
-class FakeAuthenticationError(AuthenticationError):
+class MockAuthenticationError(AuthenticationError):
     """Minimal auth error subclass for provider classification tests."""
 
     def __init__(self) -> None:
         Exception.__init__(self, "bad API key")
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -44,7 +44,7 @@ def test_embedder_classifies_upstream_auth_failures() -> None:
         timeout_seconds=1,
         max_retries=0,
     )
-    embedder._client = RaisingEmbeddingsClient(FakeAuthenticationError())  # type: ignore[assignment]
+    embedder._client = RaisingEmbeddingsClient(MockAuthenticationError())  # type: ignore[assignment]
 
     with pytest.raises(ConfigurationError, match="authentication failed") as excinfo:
         embedder.embed_query("backend logging")
@@ -61,7 +61,7 @@ def test_embedder_classifies_upstream_rate_limits() -> None:
         timeout_seconds=1,
         max_retries=0,
     )
-    embedder._client = RaisingEmbeddingsClient(FakeRateLimitError())  # type: ignore[assignment]
+    embedder._client = RaisingEmbeddingsClient(MockRateLimitError())  # type: ignore[assignment]
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         embedder.embed_query("backend logging")

--- a/tests/test_nvidia_generator.py
+++ b/tests/test_nvidia_generator.py
@@ -37,7 +37,7 @@ class MockOpenAIClient:
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -176,7 +176,7 @@ def test_generator_classifies_upstream_rate_limits() -> None:
         base_url="https://example.invalid/v1",
         timeout_seconds=1,
         max_retries=0,
-        client=RaisingOpenAIClient(FakeRateLimitError()),  # type: ignore[arg-type]
+        client=RaisingOpenAIClient(MockRateLimitError()),  # type: ignore[arg-type]
     )
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -48,7 +48,7 @@ class MockOpenAIClient:
         self.closed = True
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -178,7 +178,7 @@ def test_policy_compiler_rejects_invalid_constraint_shape() -> None:
 
 
 def test_policy_compiler_classifies_upstream_rate_limits() -> None:
-    compiler = make_compiler(RaisingOpenAIClient(FakeRateLimitError()))
+    compiler = make_compiler(RaisingOpenAIClient(MockRateLimitError()))
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         compiler.compile_policy_packet(

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -49,7 +49,7 @@ class MockOpenAIClient:
         self.closed = True
 
 
-class FakeRateLimitError(RateLimitError):
+class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
 
     def __init__(self) -> None:
@@ -173,7 +173,7 @@ def test_policy_conformance_rejects_unsupported_chunk_ids() -> None:
 
 
 def test_policy_conformance_classifies_upstream_rate_limits() -> None:
-    evaluator = make_evaluator(RaisingOpenAIClient(FakeRateLimitError()))
+    evaluator = make_evaluator(RaisingOpenAIClient(MockRateLimitError()))
 
     with pytest.raises(ProviderError, match="failed after retries") as excinfo:
         evaluator.evaluate_policy_conformance(make_request())

--- a/tests/test_policy_regeneration_service.py
+++ b/tests/test_policy_regeneration_service.py
@@ -34,14 +34,14 @@ from policynim.types import (
 
 def test_regeneration_compiles_once_and_retries_from_typed_triggers() -> None:
     packet = make_compiled_packet()
-    compiler = FakeCompilerService(packet=packet, context=[make_chunk()])
-    generator = FakeGenerator(
+    compiler = MockCompilerService(packet=packet, context=[make_chunk()])
+    generator = MockGenerator(
         [
             make_draft(summary="Initial preflight."),
             make_draft(summary="Regenerated preflight."),
         ]
     )
-    conformance = FakeConformanceService(
+    conformance = MockConformanceService(
         [
             make_conformance_result(
                 passed=False,
@@ -97,7 +97,7 @@ def test_regeneration_compiles_once_and_retries_from_typed_triggers() -> None:
 
 def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
     packet = make_compiled_packet()
-    base_generator = FakeGenerator(
+    base_generator = MockGenerator(
         [
             make_draft(summary="Initial preflight."),
             make_draft(summary="Regenerated preflight."),
@@ -109,9 +109,9 @@ def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
         rails=rails,
     )
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=packet, context=[make_chunk()]),
+        compiler_service=MockCompilerService(packet=packet, context=[make_chunk()]),
         generator=guardrails_generator,
-        conformance_service=FakeConformanceService(
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -150,9 +150,9 @@ def test_regeneration_guardrails_wrapper_preserves_retry_context() -> None:
 
 def test_regeneration_can_include_chunk_text_for_debug_traces() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft()]),
-        conformance_service=FakeConformanceService([make_conformance_result(passed=True)]),
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft()]),
+        conformance_service=MockConformanceService([make_conformance_result(passed=True)]),
     )
 
     result = service.regenerate(
@@ -168,9 +168,9 @@ def test_regeneration_can_include_chunk_text_for_debug_traces() -> None:
 
 def test_regeneration_stops_at_max_regenerations() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft(), make_draft(summary="Retry still failing.")]),
-        conformance_service=FakeConformanceService(
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft(), make_draft(summary="Retry still failing.")]),
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -214,9 +214,9 @@ def test_regeneration_stops_at_max_regenerations() -> None:
 
 def test_regeneration_stops_when_failed_metrics_have_no_material_trigger() -> None:
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft()]),
-        conformance_service=FakeConformanceService(
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft()]),
+        conformance_service=MockConformanceService(
             [
                 make_conformance_result(
                     passed=False,
@@ -241,12 +241,12 @@ def test_regeneration_stops_when_failed_metrics_have_no_material_trigger() -> No
 
 
 def test_regeneration_treats_insufficient_compiled_context_as_terminal() -> None:
-    compiler = FakeCompilerService(
+    compiler = MockCompilerService(
         packet=make_compiled_packet(insufficient_context=True),
         context=[],
     )
-    generator = FakeGenerator([make_draft()])
-    conformance = FakeConformanceService([make_conformance_result(passed=True)])
+    generator = MockGenerator([make_draft()])
+    conformance = MockConformanceService([make_conformance_result(passed=True)])
     service = PolicyRegenerationService(
         compiler_service=compiler,
         generator=generator,
@@ -263,9 +263,9 @@ def test_regeneration_treats_insufficient_compiled_context_as_terminal() -> None
 
 
 def test_regeneration_fails_closed_for_provider_errors_without_retry() -> None:
-    compiler = FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()])
-    generator = FakeGenerator([make_draft(), make_draft(summary="Should not run.")])
-    conformance = FakeConformanceService([ProviderError("judge failed", failure_class="timeout")])
+    compiler = MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()])
+    generator = MockGenerator([make_draft(), make_draft(summary="Should not run.")])
+    conformance = MockConformanceService([ProviderError("judge failed", failure_class="timeout")])
     service = PolicyRegenerationService(
         compiler_service=compiler,
         generator=generator,
@@ -281,10 +281,10 @@ def test_regeneration_fails_closed_for_provider_errors_without_retry() -> None:
 
 
 def test_regeneration_rejects_citation_drift_as_insufficient_context() -> None:
-    conformance = FakeConformanceService([make_conformance_result(passed=True)])
+    conformance = MockConformanceService([make_conformance_result(passed=True)])
     service = PolicyRegenerationService(
-        compiler_service=FakeCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
-        generator=FakeGenerator([make_draft(citation_ids=["UNKNOWN-1"])]),
+        compiler_service=MockCompilerService(packet=make_compiled_packet(), context=[make_chunk()]),
+        generator=MockGenerator([make_draft(citation_ids=["UNKNOWN-1"])]),
         conformance_service=conformance,
     )
 
@@ -319,7 +319,7 @@ def test_trigger_mapping_preserves_judged_final_adherence_ids() -> None:
     assert triggers[0].chunk_ids == ["BACKEND-1"]
 
 
-class FakeCompilerService:
+class MockCompilerService:
     """Static compiler service double."""
 
     def __init__(self, *, packet: CompiledPolicyPacket, context: list[ScoredChunk]) -> None:
@@ -353,7 +353,7 @@ class GenerateCall:
         self.regeneration_context = regeneration_context
 
 
-class FakeGenerator:
+class MockGenerator:
     """Static generator double."""
 
     def __init__(self, drafts: list[GeneratedPreflightDraft]) -> None:
@@ -384,7 +384,7 @@ class FakeGenerator:
         self.closed = True
 
 
-class FakeConformanceService:
+class MockConformanceService:
     """Static conformance service double."""
 
     def __init__(self, outcomes: list[PolicyConformanceResult | ProviderError]) -> None:


### PR DESCRIPTION
Tighten the docs hub and workflow summaries so they reflect standalone init and hosted HTTP coverage in the current docs surface.

Tests:
- uv run pytest -q tests/test_docs_hosted_onboarding.py tests/test_docs_runtime_workflows.py