### PR TITLE
Fix weekly audit findings across runtime surfaces

### DIFF
--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -432,7 +432,7 @@ def compile(
 
 @runtime_app.command("decide")
 def runtime_decide(
-    input: Annotated[
+    input_value: Annotated[
         str,
         typer.Option(
             "--input",
@@ -443,7 +443,7 @@ def runtime_decide(
     """Return a deterministic runtime decision for one action request."""
     service = None
     try:
-        request = _load_runtime_request_payload(input)
+        request = _load_runtime_request_payload(input_value)
         service = create_runtime_decision_service(_load_setup_dependent_settings())
         result = service.decide(request)
     except PolicyNIMError as exc:
@@ -456,7 +456,7 @@ def runtime_decide(
 
 @runtime_app.command("execute")
 def runtime_execute(
-    input: Annotated[
+    input_value: Annotated[
         str,
         typer.Option(
             "--input",
@@ -467,7 +467,7 @@ def runtime_execute(
     """Enforce runtime policy, optionally confirm, and execute one action."""
     service = None
     try:
-        request = _load_runtime_request_payload(input)
+        request = _load_runtime_request_payload(input_value)
         service = create_runtime_execution_service(
             _load_setup_dependent_settings(),
             confirmer=_build_cli_confirmer(),

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -950,7 +950,11 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
     server = _create_mcp_server(settings, beta_auth_service=beta_auth_service)
     app = server.streamable_http_app()
     if settings.beta_signup_enabled:
-        assert settings.beta_session_secret is not None
+        if settings.beta_session_secret is None:
+            raise ConfigurationError(
+                "POLICYNIM_BETA_SESSION_SECRET must be set when "
+                "POLICYNIM_BETA_SIGNUP_ENABLED is true."
+            )
         app = SessionMiddleware(
             app,
             secret_key=settings.beta_session_secret,

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from types import TracebackType
-from typing import Any
+from typing import Any, Literal, overload
 
 from policynim.contracts import Embedder, Generator, IndexStore, PolicyCompiler, Reranker
 from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
@@ -51,15 +51,12 @@ class PreflightService:
                 raise ValueError(
                     "PreflightService requires either a compiler service or a policy compiler."
                 )
-            if router is None and (embedder is None or index_store is None or reranker is None):
-                raise ValueError(
-                    "PreflightService requires either a compiler service or "
-                    "router or embedder/index_store/reranker."
-                )
             if router is None:
-                assert embedder is not None
-                assert index_store is not None
-                assert reranker is not None
+                if embedder is None or index_store is None or reranker is None:
+                    raise ValueError(
+                        "PreflightService requires either a compiler service or "
+                        "router or embedder/index_store/reranker."
+                    )
                 router = PolicyRouterService(
                     embedder=embedder,
                     index_store=index_store,
@@ -90,15 +87,27 @@ class PreflightService:
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
-        output = self._run_preflight(request, with_trace=False)
-        assert isinstance(output, PreflightResult)
-        return output
+        return self._run_preflight(request, with_trace=False)
 
     def preflight_with_trace(self, request: PreflightRequest) -> PreflightTraceResult:
         """Run preflight and retain internal data needed for eval scoring."""
-        output = self._run_preflight(request, with_trace=True)
-        assert isinstance(output, PreflightTraceResult)
-        return output
+        return self._run_preflight(request, with_trace=True)
+
+    @overload
+    def _run_preflight(
+        self,
+        request: PreflightRequest,
+        *,
+        with_trace: Literal[False],
+    ) -> PreflightResult: ...
+
+    @overload
+    def _run_preflight(
+        self,
+        request: PreflightRequest,
+        *,
+        with_trace: Literal[True],
+    ) -> PreflightTraceResult: ...
 
     def _run_preflight(
         self,

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import time
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -353,7 +354,8 @@ def _run_file_write(request: FileWriteActionRequest) -> _ActionExecutionResult:
         staged_path.replace(target_path)
     except OSError:
         if staged_path is not None:
-            staged_path.unlink(missing_ok=True)
+            with suppress(OSError):
+                staged_path.unlink(missing_ok=True)
         return _ActionExecutionResult(
             succeeded=False,
             metadata=FileWriteExecutionMetadata(path=target_path, bytes_written=0),

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -623,6 +623,18 @@ class HealthCheckResult(StrictModel):
     mcp_url: str | None = None
     reason: str | None = None
 
+    @model_validator(mode="after")
+    def validate_ready_state(self) -> Self:
+        """Keep readiness booleans and status labels in sync."""
+        expected_status: Literal["ok", "error"] = "ok" if self.ready else "error"
+        if self.status != expected_status:
+            raise ValueError(
+                "status must be 'ok' when ready is true and 'error' when ready is false."
+            )
+        if self.ready and self.reason is not None:
+            raise ValueError("reason must be omitted when ready is true.")
+        return self
+
 
 BetaAccountStatus = Literal["active", "suspended"]
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -862,6 +862,17 @@ def test_streamable_http_app_keeps_mcp_open_when_auth_disabled(monkeypatch) -> N
     assert response.json() == {"ok": True}
 
 
+def test_streamable_http_app_requires_session_secret_even_without_settings_validation(
+    monkeypatch,
+) -> None:
+    _stub_streamable_http_server(monkeypatch)
+
+    settings = Settings.model_construct(beta_signup_enabled=True, beta_session_secret=None)
+
+    with pytest.raises(ConfigurationError, match="POLICYNIM_BETA_SESSION_SECRET"):
+        mcp_module._build_streamable_http_app(settings)
+
+
 def test_streamable_http_app_rejects_missing_bearer_token(monkeypatch) -> None:
     _stub_streamable_http_server(monkeypatch)
 

--- a/tests/test_runtime_execution_service.py
+++ b/tests/test_runtime_execution_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+import policynim.services.runtime_execution as runtime_execution_module
 from policynim.errors import RuntimeEvidencePersistenceError
 from policynim.services.runtime_execution import RuntimeExecutionService
 from policynim.types import (
@@ -276,6 +277,41 @@ def test_runtime_execution_service_runs_allowed_file_write(tmp_path: Path) -> No
         bytes_written=len(b"hello world"),
     )
     assert [event.event_kind for event in evidence_store.events] == ["decision", "allowed"]
+
+
+def test_runtime_execution_service_returns_failed_when_file_write_cleanup_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence_store = StubEvidenceStore()
+    service = RuntimeExecutionService(
+        decision_service=StubDecisionService("allow"),
+        evidence_store=evidence_store,
+    )
+
+    def fail_replace(self: Path, target: Path) -> Path:
+        raise OSError("replace failed")
+
+    def fail_unlink(self: Path, *, missing_ok: bool = False) -> None:
+        del missing_ok
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(runtime_execution_module.Path, "replace", fail_replace)
+    monkeypatch.setattr(runtime_execution_module.Path, "unlink", fail_unlink)
+
+    result = service.execute(
+        FileWriteActionRequest(
+            kind="file_write",
+            task="Write a file with failing temp cleanup.",
+            cwd=tmp_path,
+            path=Path("notes.txt"),
+            content="payload",
+        )
+    )
+
+    assert result.execution_outcome == "failed"
+    assert result.failure_class == "io_error"
+    assert [event.event_kind for event in evidence_store.events] == ["decision", "failed"]
 
 
 def test_runtime_execution_service_returns_failed_for_http_transport_error(

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -13,6 +13,7 @@ from policynim.settings import Settings
 from policynim.types import (
     DEFAULT_TOP_K,
     DocumentSection,
+    HealthCheckResult,
     HTTPRequestActionRequest,
     ParsedRuntimeRule,
     RuntimeActionRequest,
@@ -635,6 +636,27 @@ def test_document_section_rejects_inverted_line_ranges() -> None:
             content="Impossible line range.",
             start_line=8,
             end_line=7,
+        )
+
+
+def test_health_check_result_requires_ready_status_alignment() -> None:
+    with pytest.raises(ValidationError, match="status must be 'ok' when ready is true"):
+        HealthCheckResult(
+            status="error",
+            ready=True,
+            table_name="policy_chunks",
+            row_count=1,
+        )
+
+
+def test_health_check_result_rejects_ready_reason_text() -> None:
+    with pytest.raises(ValidationError, match="reason must be omitted when ready is true"):
+        HealthCheckResult(
+            status="ok",
+            ready=True,
+            table_name="policy_chunks",
+            row_count=1,
+            reason="still booting",
         )
 
 


### PR DESCRIPTION
## Summary
- fix a runtime file-write error path so temp-file cleanup failures do not escape and hide the intended `io_error` result
- enforce `HealthCheckResult` invariants so `status`, `ready`, and `reason` cannot drift apart
- replace production `assert`-based control flow in the preflight and hosted MCP paths with explicit guards and typed control flow
- rename the runtime CLI `input` parameters to `input_value` to avoid shadowing the Python builtin

## Audit Notes
- No new concrete findings surfaced in the abstractions, boundaries, dead-code, DX, or repo-guidelines passes during this run
- The implemented findings came from the errors, drift, idiomatic, and names passes

## Verification
- `uv run --group dev ruff check`
- `uv run --group test python -m pytest -q tests/test_runtime_execution_service.py tests/test_settings_and_types.py tests/test_mcp.py tests/test_preflight_service.py`
- `uv run --group test python -m pytest -q -m 'not live and not docker_live'`\n- `uv run policynim --help`