### PR TITLE
Fix weekly audit findings in eval and health flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ PolicyNIM currently ships with two main user-facing surfaces:
 ## What Works Today
 
 - Deterministic Markdown ingest with heading-aware chunking and source line spans.
+- Ingest-time compilation of `runtime_rules` frontmatter into the persisted runtime rules artifact.
 - NVIDIA-hosted embeddings and reranking for retrieval.
 - Local LanceDB storage for the retrievable policy index.
 - Task-aware policy routing with citation-preserving selected-policy packets.
@@ -46,8 +47,9 @@ PolicyNIM currently ships with two main user-facing surfaces:
   artifacts and local Phoenix reporting for non-headless runs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
-  `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
+- Interactive `init` setup plus JSON-first CLI commands for `ingest`,
+  `dump-index`, `search`, `route`, `compile`, `preflight`, `eval`, `mcp`,
+  `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
@@ -95,10 +97,22 @@ Use this path only if you want to run PolicyNIM from a local checkout.
 
 ```bash
 uv sync --group test --group dev
-cp .env.development.example .env
 export NVIDIA_API_KEY=<your-nvidia-api-key>
 uv run policynim ingest
 uv run pytest -q
+```
+
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+If you prefer to manage `.env` manually, copy the template first:
+
+```bash
+cp .env.development.example .env
 ```
 
 After the index is built, the fastest local sanity checks are:
@@ -145,6 +159,11 @@ Start here when you want the longer version of a specific path:
 - [examples/codex/README.md](examples/codex/README.md): Codex MCP setup example
 - [examples/claude-code/README.md](examples/claude-code/README.md): Claude Code
   MCP setup example
+
+## Talks And Workflow Notes
+
+- [docs/ai-engineer-miami-context-plane.md](docs/ai-engineer-miami-context-plane.md): centralized context-plane talk notes and project framing
+- [docs/extreme-programming-with-agents.md](docs/extreme-programming-with-agents.md): XP, TDD, and agent workflow notes
 
 ## Limits And Scope
 

--- a/docs/ai-engineer-miami-context-plane.md
+++ b/docs/ai-engineer-miami-context-plane.md
@@ -1,0 +1,33 @@
+# The Missing Layer in AI Coding Workflows Is a Centralized Context Plane
+
+At AI Engineer Miami 2026, I gave a talk about code quality gates for AI-assisted development. The part that stayed with me happened after I stepped off stage. I had separate conversations with senior engineers from Spotify and Capital One, and both pointed at the same failure mode. Their teams were not short on AI tools. They were short on a reliable way to make the same engineering standards reach every agent, every repo, and every step in the workflow.
+
+We keep treating `AGENTS.md`, `CLAUDE.md`, internal docs, review checklists, PR comments, and tribal knowledge like different categories of information. They are the same category. They are context. When that context is scattered across laptops, wikis, old pull requests, and people's heads, the codebase starts to drift. One engineer's agent follows one set of rules. Another engineer's agent follows a different prompt. A third team catches problems only in review. The issue is not that teams need more prompt hacks. The issue is that context has no operating model.
+
+That problem also shows up earlier than most teams admit. Code quality does not break down only in PR review. It breaks down in planning and design, in development, in review, in testing, and in deployment. By the time a pull request is open, some of the most expensive mistakes have already been made. That is why a verification layer cannot be a thin wrapper around code review. It has to start where work starts.
+
+A recent community poll we ran made that gap plain: `70.7%` of developers said they are not measuring the impact of AI on code quality at all.
+
+This is why I keep coming back to the idea of a centralized context plane. By that I mean one operational layer where engineering standards, repo rules, review criteria, architectural constraints, domain requirements, and team-specific patterns live in a form that tools can actually use. If a rule matters, it should be available to the agent that plans the work, the CLI that runs local review, and the system that evaluates the pull request.
+
+Written somewhere is not the same as operationalized everywhere. Plenty of teams have excellent standards, but those standards are trapped in static documents or buried in PR history. If the only person who remembers the async error-handling rule is your staff engineer, that is dependency on memory. AI makes this worse because it increases code volume before most teams have increased the reliability of their context.
+
+The next missing piece is the verification layer. A context plane without verification becomes another library of good intentions. A verification layer is what applies the same context during planning, code generation, local review, pre-PR validation, and PR review. It is the system that says: these are the standards, and here is where we check them before bad patterns harden into the codebase.
+
+The clearest way I know to explain it is the same way I framed it in the talk:
+
+1. Define what code quality means to you.
+2. Decide where those quality standards live.
+3. Design the verification layer where engineers already work.
+
+That sequence matters. Skip the second step and the third turns into theater because every tool is checking against a different version of the truth. Skip the third step and the second turns into documentation that people admire and ignore.
+
+A simple example: teams often keep `AGENTS.md`, repo rules, and review criteria in separate lanes. One file guides the coding agent. Another system holds review rules. Human reviewers fill the gaps from memory. That setup guarantees drift. The better pattern is to treat all three as one context system and use it early. If a change touches authentication, background jobs, or API contracts, the agent should pull the relevant standards before it writes code. Local review should check the diff against those same rules before a PR opens. CI should apply the same expectations again, so human review starts at the architectural and product level instead of spending cycles on issues that should have been caught earlier.
+
+That is also why I think context engineering needs a broader definition than the one it usually gets. It is the work of codifying standards, centralizing them, scoping them to the right repos, and making them executable in the tools engineers already use. Too many teams are still building workarounds across local prompt files, agent-specific markdown, IDE extensions, and tribal memory. That does not scale across distributed teams. When senior engineers tell me their teams are getting inconsistent results from different agents, I hear a context distribution problem.
+
+If I were giving teams three practical takeaways from the Miami talk and the conversations that followed, they would be simple. Treat every standard as context, even if it currently lives in a PR comment or somebody's head. Put that context in one operational plane instead of scattering it across local files and folklore. Then verify against it before human review, not after the code has already taken a full trip through the workflow.
+
+That is the part of AI-assisted development I think deserves more attention this year. If AI increases code volume, teams need a system that makes standards executable. Otherwise the failure mode is predictable: faster output, less consistent judgment, and more cleanup pushed downstream.
+
+This is the direction I care about at Qodo. The point is not to give teams one more place to store rules. The point is to help turn those rules into something agents, local workflows, and review systems can all act on. That is how context engineering stops being a prompt trick and starts acting like engineering infrastructure.

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -172,6 +172,8 @@ flowchart TB
     subgraph Ingest["Corpus to Index"]
         direction LR
         Policies["Policy Markdown corpus"] --> Parse["Parse and normalize"]
+        Parse --> CompileRules["Compile runtime_rules frontmatter"]
+        CompileRules --> RuntimeRules
         Parse --> Chunk["Chunk by section and line span"]
         Chunk --> EmbedDocs["Embed documents"]
         EmbedDocs --> Index["Local LanceDB index"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,9 +42,10 @@ Ingest flow:
 2. parse Markdown into normalized documents
 3. infer missing metadata when possible
 4. extract heading-aware sections with stable line spans
-5. build deterministic chunk IDs
-6. embed chunk text through NVIDIA-hosted embeddings
-7. replace the local LanceDB table with the new embedded rows
+5. compile any `runtime_rules` frontmatter into the persisted runtime rules artifact
+6. build deterministic chunk IDs
+7. embed chunk text through NVIDIA-hosted embeddings
+8. replace the local LanceDB table with the new embedded rows
 
 Important ingest rules:
 
@@ -303,8 +304,9 @@ Important evaluation rules:
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query ...`
 - `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim compile --task ... [--domain ...] [--top-k ...] [--task-type ...]`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -11,7 +11,14 @@ Install the runtime, test, and dev dependencies:
 uv sync --group test --group dev
 ```
 
-Copy the development example environment file:
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+Otherwise, copy the development example environment file:
 
 ```bash
 cp .env.development.example .env

--- a/docs/extreme-programming-with-agents.md
+++ b/docs/extreme-programming-with-agents.md
@@ -1,0 +1,109 @@
+# Extreme Programming with Agents: How I Use Codex, TDD, BDD, Skills, and Review Layers
+
+Agentic coding gets dangerous when code generation becomes the first step.
+
+That is the trap inside a lot of AI workflow advice. Open Codex, ask for code, get something plausible, and hope review catches the rest. It feels fast, but it pushes feedback too far to the right. By the time you discover the design is wrong or the tests are weak, you already have a diff and a mess to unwind.
+
+Extreme Programming taught a better habit a long time ago. Create feedback first. Then write code.
+
+That is why XP matters more in the age of agents, not less. Agents collapse the cost of typing. They do not collapse the cost of bad decisions.
+
+## Why agents are rediscovering XP
+
+XP was built for unstable environments. Requirements move. Understanding changes as you work. The safest response is short feedback loops, tests first, simple design, and constant review.
+
+Modern coding agents fit that world almost too well. Codex is a strong pair programmer. It is not the whole system. It should not be deciding the plan, writing unchecked production code, judging its own output, and declaring the work done. When teams use it that way, they are not practicing leverage. They are skipping feedback.
+
+What XP gives me is an operating system for that speed. It tells me where the agent belongs, what order work should happen in, and how the system stays honest.
+
+## The two-layer system I use on PolicyNIM
+
+PolicyNIM is the project. The method is the point.
+
+I use a two-layer workflow. The first layer handles sequencing. What are we building, in what order, and what behavior are we trying to prove? The second layer handles quality. Is the slice correct, tested, idiomatic, and safe to keep?
+
+Codex lives inside that system as the pair programmer in the inner loop. It is there to help me move through small slices quickly. It is not the planner, the reviewer of record, or the approver.
+
+The whole loop from spec to merge looks like this:
+
+1. Start from a story or spec, then write the behavior in Given/When/Then form.
+2. Ask Codex for failing tests only, not implementation.
+3. Implement the smallest change that gets the test green.
+4. Refactor while the tests stay green.
+5. Run outer-loop gates such as `pre-commit`, `ruff`, `pytest`, and an independent review pass.
+6. Put a human in the final review before merge.
+
+That separation matters. The inner loop keeps momentum high. The outer loop keeps it honest.
+
+## Inner loop: TDD and BDD with Codex
+
+In the inner loop, I want Codex thinking like a disciplined pair, not a fast typist with repo access. So I start from behavior, not files.
+
+On PolicyNIM, one useful example is fail-closed preflight behavior. If the system cannot ground a task strongly enough, I do not want a polished bluff. I want the result to return `insufficient_context=true`. When grounding is strong enough, I want the output to surface concrete `review_flags` and `tests_required` rather than vague advice.
+
+That becomes a BDD-style slice before it becomes code: given a vague task and weak retained evidence, preflight should fail closed instead of inventing guidance; given a grounded task with valid evidence, preflight should preserve the review flags and test expectations that fall out of that evidence.
+
+From there I have Codex generate or extend the tests only. No implementation yet. This is the part many agent workflows skip, and it is exactly where the discipline matters.
+
+Once the tests fail for the right reason, Codex helps implement the smallest change that makes them pass. After that, we refactor. Rename things. Flatten logic. Remove speculative structure. Keep the design plain until the next behavior forces it to grow.
+
+This is still classic XP. The only difference is that the pair programmer can move much faster than a human pair. That makes the order of operations more important, not less.
+
+## Outer loop: independent review and quality governance
+
+This is where a lot of agent workflows fall apart. They let the same system that generated the code act as planner, implementer, reviewer, and closer. That is not review. That is one model talking to itself.
+
+On PolicyNIM, I want the boring safeguards on purpose. I use `pre-commit` so the local workflow catches obvious issues early. I run `ruff` to keep the Python readable and consistent. I run `pytest` because the behavior has to survive contact with the test suite, not just the prompt. Then I add an independent review layer. Qodo fits here because I want another system looking at the diff with a different job.
+
+That outer loop is not bureaucracy. It is risk management. It is how the system stays honest after the inner loop goes green.
+
+And yes, human review still matters. Agents can generate, lint, test, and flag. They do not own the codebase consequences. People do.
+
+## Packaging the discipline as a reusable skill
+
+So I turn the discipline into a reusable skill. I like the name `xp_tdd_story_runner` because it says exactly what it should do. It takes a spec or story, breaks it into behavior slices, generates failing tests first, implements minimally, and leaves clear repo guidance so the next session does not drift.
+
+The point is consistency. When I am tired or in a rush, I do not want the workflow to depend on memory.
+
+## Prompt: have your coding agent design the skill
+
+This is the prompt I would give a coding agent first.
+
+```text
+You are my engineering workflow designer.
+
+Goal:
+Design a reusable repository skill called `xp_tdd_story_runner` that enforces an Extreme Programming workflow for feature work.
+
+Context:
+- I use Codex as my coding agent.
+- I want the inner loop to follow: behavior (BDD) -> failing tests -> minimal implementation -> refactor with tests passing.
+- I want the outer loop to include linting, test execution, independent review, and human review before merge.
+- This skill should improve consistency across sessions, not generate a giant scaffold.
+
+Deliverables:
+1. Skill design
+   - Define inputs, outputs, phases, and decision rules.
+   - Show how the skill turns a spec or PRD into user stories and Given/When/Then scenarios.
+   - Show how it enforces tests-first before implementation.
+2. Repo documentation updates
+   - Propose concrete updates for repo instructions such as AGENTS.md, WORKFLOW.md, or equivalent files.
+   - Make the guidance explicit about when to use the skill and what "done" means.
+3. Usage prompts
+   - Provide short reusable prompts for:
+     - implementing from a PRD or spec
+     - implementing from an issue or ticket
+     - refactoring existing code with tests still in control
+
+Constraints:
+- Do not design enforcement automation that bypasses review or merge.
+- Do not replace independent review or human review.
+- Prefer clear workflow rules, small examples, and repo-documentation updates over large placeholders.
+- Ask clarifying questions only if a repo-specific detail is required to make the skill accurate.
+```
+
+## How to start small
+
+Pick one active project. Choose one story that matters. Write the behavior in Given/When/Then form before Codex touches implementation. Force the first pass to be tests only. Add the ordinary gates that keep the work clean: `pre-commit`, `ruff`, `pytest`, and one independent reviewer. Once the workflow works twice in a row, package it as a skill so you stop renegotiating the same standards every session.
+
+That is the real win. With the right XP discipline around them, agents let you run more feedback loops before a bad decision hardens into software.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,13 @@ operations into separate pages so the root README can stay short.
 - [public-source-grounding.md](public-source-grounding.md): provenance notes for
   the shipped sample corpus
 
+## Talks And Workflow Notes
+
+- [ai-engineer-miami-context-plane.md](ai-engineer-miami-context-plane.md):
+  centralized context-plane talk notes and project framing
+- [extreme-programming-with-agents.md](extreme-programming-with-agents.md):
+  XP, TDD, and agent workflow notes
+
 ## Testing And Coverage
 
 - [../tests/README.md](../tests/README.md): current automated coverage and the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,8 +7,9 @@ reference that used to live in the root README.
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query "..."`
 - `policynim route --task "..."`
 - `policynim compile --task "..."`
@@ -41,7 +42,19 @@ reference that used to live in the root README.
   `POLICYNIM_MCP_PUBLIC_BASE_URL` is set but the configured local index is
   missing or empty
 
+`policynim init` writes the local config file interactively when you want the
+CLI to prompt for `NVIDIA_API_KEY` and an optional custom corpus directory.
+
 ## Core Workflows
+
+### 0. Initialize The Local Config
+
+```bash
+uv run policynim init
+```
+
+Use this when you want the CLI to write the local env file for you instead of
+copying `.env.development.example` by hand.
 
 ### 1. Build The Local Index
 
@@ -53,6 +66,7 @@ What this does:
 
 - loads the bundled policy corpus, or the directory from `POLICYNIM_CORPUS_DIR`
 - chunks the documents into stable, citeable sections
+- compiles any `runtime_rules` frontmatter into the persisted runtime rules artifact
 - embeds those chunks with NVIDIA-hosted embeddings
 - rebuilds the local LanceDB table
 
@@ -67,6 +81,12 @@ uv run policynim dump-index
 
 This is the fastest way to inspect stored chunk IDs, section labels, line spans,
 and raw chunk text. Add `| less` if the output is long.
+
+If you only need the row count, use:
+
+```bash
+uv run policynim dump-index --count-only
+```
 
 ### 3. Search The Corpus
 

--- a/src/policynim/providers/nvidia_eval.py
+++ b/src/policynim/providers/nvidia_eval.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
-from typing import Protocol
+from typing import ClassVar, Protocol, Self
 
 from policynim.errors import ConfigurationError
 from policynim.providers.nvidia import NVIDIAPolicyConformanceEvaluator
@@ -31,88 +31,60 @@ class _ClosablePolicyConformanceEvaluator(Protocol):
         ...
 
 
-class NeMoEvaluatorPolicyConformanceEvaluator:
+class _OptionalPolicyConformanceEvaluatorAdapter:
+    """Common optional-package wrapper for NVIDIA policy conformance evaluators."""
+
+    distribution_names: ClassVar[tuple[str, ...]]
+    backend: ClassVar[str]
+
+    def __init__(self, *, evaluator: _ClosablePolicyConformanceEvaluator) -> None:
+        try:
+            _require_optional_distributions(
+                self.distribution_names,
+                install_hint=_NVIDIA_EVAL_INSTALL_HINT,
+                backend=self.backend,
+            )
+        except ConfigurationError:
+            evaluator.close()
+            raise
+        self._evaluator = evaluator
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> Self:
+        _require_optional_distributions(
+            cls.distribution_names,
+            install_hint=_NVIDIA_EVAL_INSTALL_HINT,
+            backend=cls.backend,
+        )
+        evaluator = NVIDIAPolicyConformanceEvaluator.from_settings(settings)
+        try:
+            return cls(evaluator=evaluator)
+        except Exception:
+            evaluator.close()
+            raise
+
+    def evaluate_policy_conformance(
+        self,
+        request: PolicyConformanceRequest,
+    ) -> GeneratedPolicyConformanceDraft:
+        return self._evaluator.evaluate_policy_conformance(request)
+
+    def close(self) -> None:
+        self._evaluator.close()
+
+
+class NeMoEvaluatorPolicyConformanceEvaluator(_OptionalPolicyConformanceEvaluatorAdapter):
     """Policy conformance adapter gated on NeMo Evaluator SDK packages."""
 
-    def __init__(self, *, evaluator: _ClosablePolicyConformanceEvaluator) -> None:
-        try:
-            _require_optional_distributions(
-                _NEMO_EVALUATOR_DISTRIBUTIONS,
-                install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-                backend=_NEMO_EVALUATOR_BACKEND,
-            )
-        except ConfigurationError:
-            evaluator.close()
-            raise
-        self._evaluator = evaluator
-
-    @classmethod
-    def from_settings(cls, settings: Settings) -> NeMoEvaluatorPolicyConformanceEvaluator:
-        """Construct a NeMo Evaluator backed conformance evaluator from settings."""
-        _require_optional_distributions(
-            _NEMO_EVALUATOR_DISTRIBUTIONS,
-            install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-            backend=_NEMO_EVALUATOR_BACKEND,
-        )
-        evaluator = NVIDIAPolicyConformanceEvaluator.from_settings(settings)
-        try:
-            return cls(evaluator=evaluator)
-        except Exception:
-            evaluator.close()
-            raise
-
-    def evaluate_policy_conformance(
-        self,
-        request: PolicyConformanceRequest,
-    ) -> GeneratedPolicyConformanceDraft:
-        """Evaluate final adherence through the configured NVIDIA judge endpoint."""
-        return self._evaluator.evaluate_policy_conformance(request)
-
-    def close(self) -> None:
-        """Release owned evaluator resources."""
-        self._evaluator.close()
+    distribution_names = tuple(_NEMO_EVALUATOR_DISTRIBUTIONS)
+    backend = _NEMO_EVALUATOR_BACKEND
 
 
-class NeMoAgentToolkitPolicyConformanceEvaluator:
+class NeMoAgentToolkitPolicyConformanceEvaluator(_OptionalPolicyConformanceEvaluatorAdapter):
     """Policy conformance adapter gated on NeMo Agent Toolkit eval packages."""
 
-    def __init__(self, *, evaluator: _ClosablePolicyConformanceEvaluator) -> None:
-        try:
-            _require_optional_distributions(
-                _NAT_DISTRIBUTIONS,
-                install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-                backend=_NAT_BACKEND,
-            )
-        except ConfigurationError:
-            evaluator.close()
-            raise
-        self._evaluator = evaluator
-
-    @classmethod
-    def from_settings(cls, settings: Settings) -> NeMoAgentToolkitPolicyConformanceEvaluator:
-        """Construct a NeMo Agent Toolkit backed conformance evaluator from settings."""
-        _require_optional_distributions(
-            _NAT_DISTRIBUTIONS,
-            install_hint=_NVIDIA_EVAL_INSTALL_HINT,
-            backend=_NAT_BACKEND,
-        )
-        evaluator = NVIDIAPolicyConformanceEvaluator.from_settings(settings)
-        try:
-            return cls(evaluator=evaluator)
-        except Exception:
-            evaluator.close()
-            raise
-
-    def evaluate_policy_conformance(
-        self,
-        request: PolicyConformanceRequest,
-    ) -> GeneratedPolicyConformanceDraft:
-        """Evaluate trajectory-aware conformance through the configured NVIDIA judge endpoint."""
-        return self._evaluator.evaluate_policy_conformance(request)
-
-    def close(self) -> None:
-        """Release owned evaluator resources."""
-        self._evaluator.close()
+    distribution_names = tuple(_NAT_DISTRIBUTIONS)
+    backend = _NAT_BACKEND
 
 
 def _require_optional_distributions(

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -10,7 +10,7 @@ import re
 import socket
 import subprocess
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -74,9 +74,15 @@ _UI_START_POLL_INTERVAL_SECONDS = 0.1
 class EvalService:
     """Run PolicyNIM eval suites and persist comparable reports."""
 
-    def __init__(self, *, settings: Settings) -> None:
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        base_environment: Mapping[str, str] | None = None,
+    ) -> None:
         self._settings = settings
         self._workspace_path = resolve_runtime_path(settings.eval_workspace_dir)
+        self._base_environment = dict(os.environ if base_environment is None else base_environment)
         self._ui_port: int | None = None
 
     def __enter__(self) -> EvalService:
@@ -177,7 +183,7 @@ class EvalService:
         phoenix_dir.mkdir(parents=True, exist_ok=True)
         log_path = _phoenix_log_path(self._workspace_path)
         command = ["phoenix", "serve"]
-        env = os.environ.copy()
+        env = dict(self._base_environment)
         env.update(
             {
                 "PHOENIX_WORKING_DIR": phoenix_dir.as_posix(),
@@ -425,9 +431,13 @@ class EvalService:
         )
 
 
-def create_eval_service(settings: Settings | None = None) -> EvalService:
+def create_eval_service(
+    settings: Settings | None = None,
+    *,
+    base_environment: Mapping[str, str] | None = None,
+) -> EvalService:
     """Build the default eval service from application settings."""
-    return EvalService(settings=settings or get_settings())
+    return EvalService(settings=settings or get_settings(), base_environment=base_environment)
 
 
 def _score_suite_cases(

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -50,9 +50,9 @@ class RuntimeHealthService:
                 mcp_url=self._mcp_url,
                 reason=None,
             )
-        except Exception:
+        except Exception as exc:
             LOGGER.exception("Runtime health check failed.")
-            return self._not_ready("Local index readiness could not be inspected.")
+            return self._not_ready(_inspection_failure_reason(exc))
 
     def _not_ready(self, reason: str) -> HealthCheckResult:
         return HealthCheckResult(
@@ -171,6 +171,10 @@ def _derive_mcp_url(settings: Settings) -> str | None:
     if settings.mcp_public_base_url is None:
         return None
     return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
+
+
+def _inspection_failure_reason(exc: Exception) -> str:
+    return f"Local index readiness could not be inspected: {type(exc).__name__}: {exc}."
 
 
 def _format_hosted_runtime_error(*, index_uri: Path | str, table_name: str, reason: str) -> str:

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,8 +41,8 @@ Current automated coverage includes:
 - Citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads
-- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
-  `compile`, and JSON-first `preflight`
+- CLI output for `init`, `ingest`, JSON-first `search`, JSON-first `route`,
+  JSON-first `compile`, JSON-first `preflight`, and `dump-index --count-only`
 - CLI output for `eval`
 - CLI output for `eval --backend default|nemo|nemo_evaluator|nat`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -400,6 +400,40 @@ def test_eval_service_start_ui_succeeds_when_port_becomes_reachable(
     assert env["PHOENIX_PROJECT_NAME"] == "PolicyNIM Eval"
 
 
+def test_eval_service_start_ui_uses_injected_base_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SHOULD_NOT_LEAK", "process-value")
+    service = EvalService(
+        settings=Settings(eval_workspace_dir=tmp_path / "workspace"),
+        base_environment={"ONLY_THIS": "injected-value"},
+    )
+    process = FakeProcess(returncodes=[None, None])
+    port_checks = iter([False, True])
+    popen_call: dict[str, object] = {}
+
+    def fake_popen(command, **kwargs):
+        popen_call["command"] = command
+        popen_call["env"] = kwargs["env"]
+        return process
+
+    monkeypatch.setattr("policynim.services.eval.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "policynim.services.eval._is_local_port_reachable",
+        lambda port: next(port_checks),
+    )
+    monkeypatch.setattr("policynim.services.eval.time.sleep", lambda seconds: None)
+
+    service.start_ui(port=8018)
+
+    env = popen_call["env"]
+    assert isinstance(env, dict)
+    assert env["ONLY_THIS"] == "injected-value"
+    assert "SHOULD_NOT_LEAK" not in env
+    assert env["PHOENIX_PORT"] == "8018"
+
+
 def test_eval_service_start_ui_terminates_when_port_never_becomes_reachable(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -120,7 +120,9 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert result.ready is False
     assert result.row_count == 0
     assert result.reason is not None
-    assert result.reason == "Local index readiness could not be inspected."
+    assert result.reason == (
+        "Local index readiness could not be inspected: OSError: permission denied."
+    )
 
 
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- improve hosted runtime health diagnostics so readiness failures keep the underlying exception type and message
- make Phoenix UI startup use an injectable base environment instead of always copying the live process env
- remove duplicated optional NVIDIA eval adapter wrapper logic behind one shared private base class

## Audit findings addressed
- Errors/DX: readiness checks were swallowing actionable failure details behind a generic not-ready reason
- Boundaries/Testability: eval UI startup was hardwired to `os.environ`, which made the subprocess environment harder to reason about and test
- Abstractions/Idiomatic: the optional NeMo eval adapters duplicated the same wrapper lifecycle logic in two classes

## Verification
- `./.venv/bin/python -m ruff check src tests`
- `PYTHONPATH=src ./.venv/bin/python -m pytest -q tests/test_health_service.py tests/test_eval_service.py tests/test_nemo_evaluator_policy_conformance.py tests/test_nemo_agent_toolkit_policy_conformance.py tests/test_service_factories.py`