### PR TITLE
Audit: harden lifecycle cleanup and hosted helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ PolicyNIM currently ships with two main user-facing surfaces:
 ## What Works Today
 
 - Deterministic Markdown ingest with heading-aware chunking and source line spans.
+- Ingest-time compilation of `runtime_rules` frontmatter into the persisted runtime rules artifact.
 - NVIDIA-hosted embeddings and reranking for retrieval.
 - Local LanceDB storage for the retrievable policy index.
 - Task-aware policy routing with citation-preserving selected-policy packets.
@@ -46,8 +47,9 @@ PolicyNIM currently ships with two main user-facing surfaces:
   artifacts and local Phoenix reporting for non-headless runs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
-  `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
+- Interactive `init` setup plus JSON-first CLI commands for `ingest`,
+  `dump-index`, `search`, `route`, `compile`, `preflight`, `eval`, `mcp`,
+  `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
@@ -95,10 +97,22 @@ Use this path only if you want to run PolicyNIM from a local checkout.
 
 ```bash
 uv sync --group test --group dev
-cp .env.development.example .env
 export NVIDIA_API_KEY=<your-nvidia-api-key>
 uv run policynim ingest
 uv run pytest -q
+```
+
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+If you prefer to manage `.env` manually, copy the template first:
+
+```bash
+cp .env.development.example .env
 ```
 
 After the index is built, the fastest local sanity checks are:
@@ -145,6 +159,11 @@ Start here when you want the longer version of a specific path:
 - [examples/codex/README.md](examples/codex/README.md): Codex MCP setup example
 - [examples/claude-code/README.md](examples/claude-code/README.md): Claude Code
   MCP setup example
+
+## Talks And Workflow Notes
+
+- [docs/ai-engineer-miami-context-plane.md](docs/ai-engineer-miami-context-plane.md): centralized context-plane talk notes and project framing
+- [docs/extreme-programming-with-agents.md](docs/extreme-programming-with-agents.md): XP, TDD, and agent workflow notes
 
 ## Limits And Scope
 

--- a/docs/ai-engineer-miami-context-plane.md
+++ b/docs/ai-engineer-miami-context-plane.md
@@ -1,0 +1,33 @@
+# The Missing Layer in AI Coding Workflows Is a Centralized Context Plane
+
+At AI Engineer Miami 2026, I gave a talk about code quality gates for AI-assisted development. The part that stayed with me happened after I stepped off stage. I had separate conversations with senior engineers from Spotify and Capital One, and both pointed at the same failure mode. Their teams were not short on AI tools. They were short on a reliable way to make the same engineering standards reach every agent, every repo, and every step in the workflow.
+
+We keep treating `AGENTS.md`, `CLAUDE.md`, internal docs, review checklists, PR comments, and tribal knowledge like different categories of information. They are the same category. They are context. When that context is scattered across laptops, wikis, old pull requests, and people's heads, the codebase starts to drift. One engineer's agent follows one set of rules. Another engineer's agent follows a different prompt. A third team catches problems only in review. The issue is not that teams need more prompt hacks. The issue is that context has no operating model.
+
+That problem also shows up earlier than most teams admit. Code quality does not break down only in PR review. It breaks down in planning and design, in development, in review, in testing, and in deployment. By the time a pull request is open, some of the most expensive mistakes have already been made. That is why a verification layer cannot be a thin wrapper around code review. It has to start where work starts.
+
+A recent community poll we ran made that gap plain: `70.7%` of developers said they are not measuring the impact of AI on code quality at all.
+
+This is why I keep coming back to the idea of a centralized context plane. By that I mean one operational layer where engineering standards, repo rules, review criteria, architectural constraints, domain requirements, and team-specific patterns live in a form that tools can actually use. If a rule matters, it should be available to the agent that plans the work, the CLI that runs local review, and the system that evaluates the pull request.
+
+Written somewhere is not the same as operationalized everywhere. Plenty of teams have excellent standards, but those standards are trapped in static documents or buried in PR history. If the only person who remembers the async error-handling rule is your staff engineer, that is dependency on memory. AI makes this worse because it increases code volume before most teams have increased the reliability of their context.
+
+The next missing piece is the verification layer. A context plane without verification becomes another library of good intentions. A verification layer is what applies the same context during planning, code generation, local review, pre-PR validation, and PR review. It is the system that says: these are the standards, and here is where we check them before bad patterns harden into the codebase.
+
+The clearest way I know to explain it is the same way I framed it in the talk:
+
+1. Define what code quality means to you.
+2. Decide where those quality standards live.
+3. Design the verification layer where engineers already work.
+
+That sequence matters. Skip the second step and the third turns into theater because every tool is checking against a different version of the truth. Skip the third step and the second turns into documentation that people admire and ignore.
+
+A simple example: teams often keep `AGENTS.md`, repo rules, and review criteria in separate lanes. One file guides the coding agent. Another system holds review rules. Human reviewers fill the gaps from memory. That setup guarantees drift. The better pattern is to treat all three as one context system and use it early. If a change touches authentication, background jobs, or API contracts, the agent should pull the relevant standards before it writes code. Local review should check the diff against those same rules before a PR opens. CI should apply the same expectations again, so human review starts at the architectural and product level instead of spending cycles on issues that should have been caught earlier.
+
+That is also why I think context engineering needs a broader definition than the one it usually gets. It is the work of codifying standards, centralizing them, scoping them to the right repos, and making them executable in the tools engineers already use. Too many teams are still building workarounds across local prompt files, agent-specific markdown, IDE extensions, and tribal memory. That does not scale across distributed teams. When senior engineers tell me their teams are getting inconsistent results from different agents, I hear a context distribution problem.
+
+If I were giving teams three practical takeaways from the Miami talk and the conversations that followed, they would be simple. Treat every standard as context, even if it currently lives in a PR comment or somebody's head. Put that context in one operational plane instead of scattering it across local files and folklore. Then verify against it before human review, not after the code has already taken a full trip through the workflow.
+
+That is the part of AI-assisted development I think deserves more attention this year. If AI increases code volume, teams need a system that makes standards executable. Otherwise the failure mode is predictable: faster output, less consistent judgment, and more cleanup pushed downstream.
+
+This is the direction I care about at Qodo. The point is not to give teams one more place to store rules. The point is to help turn those rules into something agents, local workflows, and review systems can all act on. That is how context engineering stops being a prompt trick and starts acting like engineering infrastructure.

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -172,6 +172,8 @@ flowchart TB
     subgraph Ingest["Corpus to Index"]
         direction LR
         Policies["Policy Markdown corpus"] --> Parse["Parse and normalize"]
+        Parse --> CompileRules["Compile runtime_rules frontmatter"]
+        CompileRules --> RuntimeRules
         Parse --> Chunk["Chunk by section and line span"]
         Chunk --> EmbedDocs["Embed documents"]
         EmbedDocs --> Index["Local LanceDB index"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,9 +42,10 @@ Ingest flow:
 2. parse Markdown into normalized documents
 3. infer missing metadata when possible
 4. extract heading-aware sections with stable line spans
-5. build deterministic chunk IDs
-6. embed chunk text through NVIDIA-hosted embeddings
-7. replace the local LanceDB table with the new embedded rows
+5. compile any `runtime_rules` frontmatter into the persisted runtime rules artifact
+6. build deterministic chunk IDs
+7. embed chunk text through NVIDIA-hosted embeddings
+8. replace the local LanceDB table with the new embedded rows
 
 Important ingest rules:
 
@@ -303,8 +304,9 @@ Important evaluation rules:
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query ...`
 - `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim compile --task ... [--domain ...] [--top-k ...] [--task-type ...]`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -11,7 +11,14 @@ Install the runtime, test, and dev dependencies:
 uv sync --group test --group dev
 ```
 
-Copy the development example environment file:
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+Otherwise, copy the development example environment file:
 
 ```bash
 cp .env.development.example .env

--- a/docs/extreme-programming-with-agents.md
+++ b/docs/extreme-programming-with-agents.md
@@ -1,0 +1,109 @@
+# Extreme Programming with Agents: How I Use Codex, TDD, BDD, Skills, and Review Layers
+
+Agentic coding gets dangerous when code generation becomes the first step.
+
+That is the trap inside a lot of AI workflow advice. Open Codex, ask for code, get something plausible, and hope review catches the rest. It feels fast, but it pushes feedback too far to the right. By the time you discover the design is wrong or the tests are weak, you already have a diff and a mess to unwind.
+
+Extreme Programming taught a better habit a long time ago. Create feedback first. Then write code.
+
+That is why XP matters more in the age of agents, not less. Agents collapse the cost of typing. They do not collapse the cost of bad decisions.
+
+## Why agents are rediscovering XP
+
+XP was built for unstable environments. Requirements move. Understanding changes as you work. The safest response is short feedback loops, tests first, simple design, and constant review.
+
+Modern coding agents fit that world almost too well. Codex is a strong pair programmer. It is not the whole system. It should not be deciding the plan, writing unchecked production code, judging its own output, and declaring the work done. When teams use it that way, they are not practicing leverage. They are skipping feedback.
+
+What XP gives me is an operating system for that speed. It tells me where the agent belongs, what order work should happen in, and how the system stays honest.
+
+## The two-layer system I use on PolicyNIM
+
+PolicyNIM is the project. The method is the point.
+
+I use a two-layer workflow. The first layer handles sequencing. What are we building, in what order, and what behavior are we trying to prove? The second layer handles quality. Is the slice correct, tested, idiomatic, and safe to keep?
+
+Codex lives inside that system as the pair programmer in the inner loop. It is there to help me move through small slices quickly. It is not the planner, the reviewer of record, or the approver.
+
+The whole loop from spec to merge looks like this:
+
+1. Start from a story or spec, then write the behavior in Given/When/Then form.
+2. Ask Codex for failing tests only, not implementation.
+3. Implement the smallest change that gets the test green.
+4. Refactor while the tests stay green.
+5. Run outer-loop gates such as `pre-commit`, `ruff`, `pytest`, and an independent review pass.
+6. Put a human in the final review before merge.
+
+That separation matters. The inner loop keeps momentum high. The outer loop keeps it honest.
+
+## Inner loop: TDD and BDD with Codex
+
+In the inner loop, I want Codex thinking like a disciplined pair, not a fast typist with repo access. So I start from behavior, not files.
+
+On PolicyNIM, one useful example is fail-closed preflight behavior. If the system cannot ground a task strongly enough, I do not want a polished bluff. I want the result to return `insufficient_context=true`. When grounding is strong enough, I want the output to surface concrete `review_flags` and `tests_required` rather than vague advice.
+
+That becomes a BDD-style slice before it becomes code: given a vague task and weak retained evidence, preflight should fail closed instead of inventing guidance; given a grounded task with valid evidence, preflight should preserve the review flags and test expectations that fall out of that evidence.
+
+From there I have Codex generate or extend the tests only. No implementation yet. This is the part many agent workflows skip, and it is exactly where the discipline matters.
+
+Once the tests fail for the right reason, Codex helps implement the smallest change that makes them pass. After that, we refactor. Rename things. Flatten logic. Remove speculative structure. Keep the design plain until the next behavior forces it to grow.
+
+This is still classic XP. The only difference is that the pair programmer can move much faster than a human pair. That makes the order of operations more important, not less.
+
+## Outer loop: independent review and quality governance
+
+This is where a lot of agent workflows fall apart. They let the same system that generated the code act as planner, implementer, reviewer, and closer. That is not review. That is one model talking to itself.
+
+On PolicyNIM, I want the boring safeguards on purpose. I use `pre-commit` so the local workflow catches obvious issues early. I run `ruff` to keep the Python readable and consistent. I run `pytest` because the behavior has to survive contact with the test suite, not just the prompt. Then I add an independent review layer. Qodo fits here because I want another system looking at the diff with a different job.
+
+That outer loop is not bureaucracy. It is risk management. It is how the system stays honest after the inner loop goes green.
+
+And yes, human review still matters. Agents can generate, lint, test, and flag. They do not own the codebase consequences. People do.
+
+## Packaging the discipline as a reusable skill
+
+So I turn the discipline into a reusable skill. I like the name `xp_tdd_story_runner` because it says exactly what it should do. It takes a spec or story, breaks it into behavior slices, generates failing tests first, implements minimally, and leaves clear repo guidance so the next session does not drift.
+
+The point is consistency. When I am tired or in a rush, I do not want the workflow to depend on memory.
+
+## Prompt: have your coding agent design the skill
+
+This is the prompt I would give a coding agent first.
+
+```text
+You are my engineering workflow designer.
+
+Goal:
+Design a reusable repository skill called `xp_tdd_story_runner` that enforces an Extreme Programming workflow for feature work.
+
+Context:
+- I use Codex as my coding agent.
+- I want the inner loop to follow: behavior (BDD) -> failing tests -> minimal implementation -> refactor with tests passing.
+- I want the outer loop to include linting, test execution, independent review, and human review before merge.
+- This skill should improve consistency across sessions, not generate a giant scaffold.
+
+Deliverables:
+1. Skill design
+   - Define inputs, outputs, phases, and decision rules.
+   - Show how the skill turns a spec or PRD into user stories and Given/When/Then scenarios.
+   - Show how it enforces tests-first before implementation.
+2. Repo documentation updates
+   - Propose concrete updates for repo instructions such as AGENTS.md, WORKFLOW.md, or equivalent files.
+   - Make the guidance explicit about when to use the skill and what "done" means.
+3. Usage prompts
+   - Provide short reusable prompts for:
+     - implementing from a PRD or spec
+     - implementing from an issue or ticket
+     - refactoring existing code with tests still in control
+
+Constraints:
+- Do not design enforcement automation that bypasses review or merge.
+- Do not replace independent review or human review.
+- Prefer clear workflow rules, small examples, and repo-documentation updates over large placeholders.
+- Ask clarifying questions only if a repo-specific detail is required to make the skill accurate.
+```
+
+## How to start small
+
+Pick one active project. Choose one story that matters. Write the behavior in Given/When/Then form before Codex touches implementation. Force the first pass to be tests only. Add the ordinary gates that keep the work clean: `pre-commit`, `ruff`, `pytest`, and one independent reviewer. Once the workflow works twice in a row, package it as a skill so you stop renegotiating the same standards every session.
+
+That is the real win. With the right XP discipline around them, agents let you run more feedback loops before a bad decision hardens into software.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,13 @@ operations into separate pages so the root README can stay short.
 - [public-source-grounding.md](public-source-grounding.md): provenance notes for
   the shipped sample corpus
 
+## Talks And Workflow Notes
+
+- [ai-engineer-miami-context-plane.md](ai-engineer-miami-context-plane.md):
+  centralized context-plane talk notes and project framing
+- [extreme-programming-with-agents.md](extreme-programming-with-agents.md):
+  XP, TDD, and agent workflow notes
+
 ## Testing And Coverage
 
 - [../tests/README.md](../tests/README.md): current automated coverage and the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,8 +7,9 @@ reference that used to live in the root README.
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query "..."`
 - `policynim route --task "..."`
 - `policynim compile --task "..."`
@@ -41,7 +42,19 @@ reference that used to live in the root README.
   `POLICYNIM_MCP_PUBLIC_BASE_URL` is set but the configured local index is
   missing or empty
 
+`policynim init` writes the local config file interactively when you want the
+CLI to prompt for `NVIDIA_API_KEY` and an optional custom corpus directory.
+
 ## Core Workflows
+
+### 0. Initialize The Local Config
+
+```bash
+uv run policynim init
+```
+
+Use this when you want the CLI to write the local env file for you instead of
+copying `.env.development.example` by hand.
 
 ### 1. Build The Local Index
 
@@ -53,6 +66,7 @@ What this does:
 
 - loads the bundled policy corpus, or the directory from `POLICYNIM_CORPUS_DIR`
 - chunks the documents into stable, citeable sections
+- compiles any `runtime_rules` frontmatter into the persisted runtime rules artifact
 - embeds those chunks with NVIDIA-hosted embeddings
 - rebuilds the local LanceDB table
 
@@ -67,6 +81,12 @@ uv run policynim dump-index
 
 This is the fastest way to inspect stored chunk IDs, section labels, line spans,
 and raw chunk text. Add `| less` if the output is long.
+
+If you only need the row count, use:
+
+```bash
+uv run policynim dump-index --count-only
+```
 
 ### 3. Search The Corpus
 

--- a/src/policynim/hosted_urls.py
+++ b/src/policynim/hosted_urls.py
@@ -1,0 +1,31 @@
+"""Helpers for deriving hosted public URLs from validated settings."""
+
+from __future__ import annotations
+
+from policynim.errors import ConfigurationError
+from policynim.settings import Settings
+
+
+def _require_public_base_url(settings: Settings) -> str:
+    if settings.mcp_public_base_url is None:
+        raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
+    return str(settings.mcp_public_base_url).rstrip("/")
+
+
+def derive_mcp_url(settings: Settings) -> str | None:
+    """Return the public hosted MCP URL when configured."""
+    if settings.mcp_public_base_url is None:
+        return None
+    return _require_public_base_url(settings) + "/mcp"
+
+
+def derive_beta_url(settings: Settings) -> str | None:
+    """Return the public hosted beta portal URL when configured."""
+    if settings.mcp_public_base_url is None:
+        return None
+    return _require_public_base_url(settings) + "/beta"
+
+
+def derive_github_callback_url(settings: Settings) -> str:
+    """Return the hosted GitHub OAuth callback URL."""
+    return _require_public_base_url(settings) + "/auth/github/callback"

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -142,6 +142,7 @@ def init() -> None:
 @app.command()
 def ingest() -> None:
     """Build the local policy index from the shipped corpus."""
+    service = None
     try:
         settings = _load_setup_dependent_settings()
         service = create_ingest_service(settings)
@@ -150,6 +151,8 @@ def ingest() -> None:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
+    finally:
+        _close_service(service)
 
     typer.echo(f"Indexed {result.chunk_count} chunks from {result.document_count} documents.")
     typer.echo(f"Model: {result.embedding_model}")
@@ -173,12 +176,15 @@ def dump_index(
     ] = False,
 ) -> None:
     """Print all indexed chunks in a terminal-friendly format."""
+    service = None
     try:
         settings = _load_setup_dependent_settings()
         service = create_index_dump_service(settings)
         chunks = service.list_chunks()
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
+    finally:
+        _close_service(service)
 
     typer.echo(f"Indexed chunks: {len(chunks)}")
     if count_only:

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -25,6 +25,7 @@ from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Redire
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.hosted_urls import derive_beta_url, derive_mcp_url
 from policynim.services import (
     BetaAuthService,
     create_beta_auth_service,
@@ -518,7 +519,7 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
             ready=False,
             table_name=settings.lancedb_table,
             row_count=0,
-            mcp_url=_derive_mcp_url(settings),
+            mcp_url=derive_mcp_url(settings),
             reason=fallback_reason,
         )
         return JSONResponse(result.model_dump(mode="json"), status_code=503)
@@ -536,18 +537,6 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
 
         status_code = 200 if result.ready else 503
         return JSONResponse(result.model_dump(mode="json"), status_code=status_code)
-
-
-def _derive_mcp_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
-
-
-def _derive_beta_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + _BETA_PATH
 
 
 def _beta_asset_path(filename: str) -> Path:
@@ -637,8 +626,8 @@ def _render_beta_landing(
     message: str | None = None,
     status_code: int = 200,
 ) -> HTMLResponse:
-    portal_url = _derive_beta_url(settings) or _BETA_PATH
-    mcp_url = _derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
+    portal_url = derive_beta_url(settings) or _BETA_PATH
+    mcp_url = derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
     notices: list[dict[str, str]] = []
     if message:
         notices.append(
@@ -704,8 +693,8 @@ def _render_beta_dashboard(
     message: str | None = None,
     message_tone: str = "warning",
 ) -> HTMLResponse:
-    portal_url = _derive_beta_url(settings) or _BETA_PATH
-    mcp_url = _derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
+    portal_url = derive_beta_url(settings) or _BETA_PATH
+    mcp_url = derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
     current_key = account.api_key_prefix or "No active key"
     current_key_created = (
         account.api_key_created_at.isoformat() if account.api_key_created_at is not None else "N/A"

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -55,6 +55,7 @@ class NVIDIAEmbedder(Embedder):
         batch_size: int,
         timeout_seconds: float,
         max_retries: int,
+        client: OpenAI | Any | None = None,
     ) -> None:
         api_key = api_key.strip()
         if not api_key:
@@ -63,7 +64,8 @@ class NVIDIAEmbedder(Embedder):
         self._model = model
         self._batch_size = batch_size
         self._max_retries = max_retries
-        self._client = OpenAI(
+        self._owns_client = client is None
+        self._client = client or OpenAI(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout_seconds,
@@ -81,6 +83,11 @@ class NVIDIAEmbedder(Embedder):
             timeout_seconds=settings.nvidia_timeout_seconds,
             max_retries=settings.nvidia_max_retries,
         )
+
+    def close(self) -> None:
+        """Release the owned OpenAI client when supported by the SDK."""
+        if self._owns_client:
+            _close_client(self._client)
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed policy chunk text in batches."""

--- a/src/policynim/services/beta_auth.py
+++ b/src/policynim/services/beta_auth.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 import httpx
 
 from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.hosted_urls import derive_beta_url, derive_github_callback_url, derive_mcp_url
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import AuthStore
@@ -45,23 +46,23 @@ class BetaAuthService:
     @property
     def mcp_url(self) -> str:
         """Return the public hosted MCP URL."""
-        if self._settings.mcp_public_base_url is None:
+        mcp_url = derive_mcp_url(self._settings)
+        if mcp_url is None:
             raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/mcp"
+        return mcp_url
 
     @property
     def portal_url(self) -> str:
         """Return the public hosted beta portal URL."""
-        if self._settings.mcp_public_base_url is None:
+        beta_url = derive_beta_url(self._settings)
+        if beta_url is None:
             raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/beta"
+        return beta_url
 
     @property
     def github_callback_url(self) -> str:
         """Return the configured GitHub OAuth callback URL."""
-        if self._settings.mcp_public_base_url is None:
-            raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/auth/github/callback"
+        return derive_github_callback_url(self._settings)
 
     def list_accounts(self) -> list[BetaAccount]:
         """Return all hosted beta accounts."""

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -313,7 +313,10 @@ class EvalService:
                 update={"lancedb_uri": Path(temp_dir) / "lancedb"}
             )
             ingest_service = create_ingest_service(temp_settings)
-            ingest_service.run()
+            try:
+                ingest_service.run()
+            finally:
+                _close_component(ingest_service)
 
             search_service = _create_live_search_service(
                 temp_settings,

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from policynim.contracts import IndexStore
 from policynim.errors import ConfigurationError
+from policynim.hosted_urls import derive_mcp_url
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services.ingest import create_ingest_service
 from policynim.settings import Settings, get_settings
@@ -75,7 +76,7 @@ def create_runtime_health_service(settings: Settings | None = None) -> RuntimeHe
             table_name=active_settings.lancedb_table,
         ),
         table_name=active_settings.lancedb_table,
-        mcp_url=_derive_mcp_url(active_settings),
+        mcp_url=derive_mcp_url(active_settings),
     )
 
 
@@ -147,8 +148,10 @@ def _rebuild_hosted_runtime_index(
         index_uri,
         summary,
     )
+    ingest_service = None
     try:
-        result = create_ingest_service(settings).run()
+        ingest_service = create_ingest_service(settings)
+        result = ingest_service.run()
     except Exception as exc:
         rebuild_reason = f"Automatic hosted-index rebuild failed: {type(exc).__name__}: {exc}."
         raise ConfigurationError(
@@ -158,6 +161,10 @@ def _rebuild_hosted_runtime_index(
                 reason=rebuild_reason,
             )
         ) from exc
+    finally:
+        close = getattr(ingest_service, "close", None)
+        if callable(close):
+            close()
 
     LOGGER.info(
         "Hosted runtime index rebuilt at %s with %s chunks across %s documents.",
@@ -165,12 +172,6 @@ def _rebuild_hosted_runtime_index(
         result.chunk_count,
         result.document_count,
     )
-
-
-def _derive_mcp_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
 
 
 def _format_hosted_runtime_error(*, index_uri: Path | str, table_name: str, reason: str) -> str:

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Sequence
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from types import TracebackType
 from typing import Protocol
 
 from policynim.contracts import Embedder
@@ -58,6 +59,21 @@ class IngestService:
         self._corpus_root = corpus_root
         self._embedding_model = embedding_model
         self._runtime_rules_artifact_path = runtime_rules_artifact_path
+
+    def __enter__(self) -> IngestService:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release owned provider resources held by this service."""
+        _close_component(self._embedder)
 
     def run(self) -> IngestResult:
         """Load, chunk, embed, and persist the policy corpus."""
@@ -190,3 +206,9 @@ def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> No
 def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
     """Best-effort cleanup for staged artifact files after a failed ingest."""
     staged_path.unlink(missing_ok=True)
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -41,6 +41,7 @@ class SearchService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
+        _close_component(self._embedder)
         _close_component(self._reranker)
 
     def search(self, request: SearchRequest) -> SearchResult:

--- a/src/policynim/storage/_sqlite.py
+++ b/src/policynim/storage/_sqlite.py
@@ -1,0 +1,38 @@
+"""Shared SQLite helpers for PolicyNIM storage adapters."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def database_artifact_paths(path: Path) -> tuple[Path, ...]:
+    """Return the primary SQLite file plus WAL sidecars for cleanup flows."""
+    return (
+        path,
+        path.with_name(f"{path.name}-wal"),
+        path.with_name(f"{path.name}-shm"),
+    )
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    """Open one SQLite connection with the repo's standard pragmas."""
+    connection = sqlite3.connect(path, timeout=30.0, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 30000")
+    connection.execute("PRAGMA journal_mode = WAL")
+    return connection
+
+
+def begin_immediate(conn: sqlite3.Connection) -> None:
+    """Start one write transaction eagerly to serialize concurrent writers."""
+    conn.execute("BEGIN IMMEDIATE")
+
+
+def iso_utc(value: datetime) -> str:
+    """Serialize one datetime as an aware UTC ISO 8601 string."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()

--- a/src/policynim/storage/auth_store.py
+++ b/src/policynim/storage/auth_store.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import closing
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, cast
 
 from policynim.errors import PolicyNIMError
 from policynim.types import BetaAccount, BetaAccountStatus, BetaUsageSnapshot
+
+from . import _sqlite
 
 _ACTIVE_STATUS = "active"
 _SUSPENDED_STATUS = "suspended"
@@ -63,8 +65,9 @@ class AuthStore:
 
     def reset_for_tests(self) -> None:
         """Reset the backing SQLite file for deterministic test re-entry."""
-        if self._path.exists():
-            self._path.unlink()
+        for candidate in _sqlite.database_artifact_paths(self._path):
+            if candidate.exists():
+                candidate.unlink()
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._initialize_schema()
 
@@ -94,7 +97,7 @@ class AuthStore:
     ) -> BetaAccount:
         """Create or update one hosted beta account after GitHub login."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 row = conn.execute(
                     "SELECT id FROM accounts WHERE github_user_id = ?",
@@ -118,8 +121,8 @@ class AuthStore:
                             github_login,
                             email,
                             _ACTIVE_STATUS,
-                            _iso_utc(now),
-                            _iso_utc(now),
+                            _sqlite.iso_utc(now),
+                            _sqlite.iso_utc(now),
                         ),
                     )
                     lastrowid = cursor.lastrowid
@@ -144,7 +147,7 @@ class AuthStore:
                         SET github_login = ?, email = ?, last_login_at = ?
                         WHERE id = ?
                         """,
-                        (github_login, email, _iso_utc(now), account_id),
+                        (github_login, email, _sqlite.iso_utc(now), account_id),
                     )
                     self._insert_audit_event(
                         conn,
@@ -173,7 +176,7 @@ class AuthStore:
     ) -> BetaAccount:
         """Revoke the current active key and persist a new one atomically."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 self._require_account(conn, account_id)
                 conn.execute(
@@ -181,14 +184,14 @@ class AuthStore:
                         "UPDATE api_keys SET revoked_at = ? "
                         "WHERE account_id = ? AND revoked_at IS NULL"
                     ),
-                    (_iso_utc(now), account_id),
+                    (_sqlite.iso_utc(now), account_id),
                 )
                 conn.execute(
                     """
                     INSERT INTO api_keys (account_id, key_prefix, key_hash, created_at, revoked_at)
                     VALUES (?, ?, ?, ?, NULL)
                     """,
-                    (account_id, key_prefix, key_hash, _iso_utc(now)),
+                    (account_id, key_prefix, key_hash, _sqlite.iso_utc(now)),
                 )
                 self._insert_audit_event(
                     conn,
@@ -207,7 +210,7 @@ class AuthStore:
     def revoke_active_key(self, *, account_id: int, now: datetime) -> BetaAccount:
         """Revoke the current active key, if one exists."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 account = self._require_account(conn, account_id)
                 active_key = conn.execute(
@@ -225,7 +228,7 @@ class AuthStore:
                         "UPDATE api_keys SET revoked_at = ? "
                         "WHERE account_id = ? AND revoked_at IS NULL"
                     ),
-                    (_iso_utc(now), account_id),
+                    (_sqlite.iso_utc(now), account_id),
                 )
                 if active_key is not None:
                     self._insert_audit_event(
@@ -245,7 +248,7 @@ class AuthStore:
     def set_account_status(self, *, account_id: int, status: str, now: datetime) -> BetaAccount:
         """Persist the supplied account status."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 if status not in {_ACTIVE_STATUS, _SUSPENDED_STATUS}:
                     raise PolicyNIMError(f"Unsupported beta account status {status!r}.")
@@ -294,7 +297,7 @@ class AuthStore:
     ) -> tuple[BetaUsageSnapshot, bool]:
         """Consume one request from the current UTC-day quota if capacity remains."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 self._require_account(conn, account_id)
                 row = conn.execute(
@@ -416,12 +419,7 @@ class AuthStore:
             )
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self._path, timeout=30.0, isolation_level=None)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys = ON")
-        connection.execute("PRAGMA busy_timeout = 30000")
-        connection.execute("PRAGMA journal_mode = WAL")
-        return connection
+        return _sqlite.connect(self._path)
 
     def _fetch_account_by_column(
         self,
@@ -461,19 +459,9 @@ class AuthStore:
                 account_id,
                 event_type,
                 json.dumps(details, sort_keys=True),
-                _iso_utc(now),
+                _sqlite.iso_utc(now),
             ),
         )
-
-
-def _begin_immediate(conn: sqlite3.Connection) -> None:
-    conn.execute("BEGIN IMMEDIATE")
-
-
-def _iso_utc(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
-    return value.astimezone(UTC).isoformat()
 
 
 def _parse_datetime(value: object) -> datetime | None:

--- a/src/policynim/storage/runtime_evidence.py
+++ b/src/policynim/storage/runtime_evidence.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import closing
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 
 from policynim.contracts import RuntimeEvidenceStoreProtocol
 from policynim.types import RuntimeExecutionEvidenceRecord
+
+from . import _sqlite
 
 
 class RuntimeEvidenceStore(RuntimeEvidenceStoreProtocol):
@@ -34,11 +36,7 @@ class RuntimeEvidenceStore(RuntimeEvidenceStoreProtocol):
 
     def reset_for_tests(self) -> None:
         """Reset the backing SQLite file and WAL sidecars for deterministic tests."""
-        for candidate in (
-            self._path,
-            self._path.with_name(f"{self._path.name}-wal"),
-            self._path.with_name(f"{self._path.name}-shm"),
-        ):
+        for candidate in _sqlite.database_artifact_paths(self._path):
             if candidate.exists():
                 candidate.unlink()
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -47,7 +45,7 @@ class RuntimeEvidenceStore(RuntimeEvidenceStoreProtocol):
     def append_event(self, record: RuntimeExecutionEvidenceRecord) -> None:
         """Persist one immutable evidence event."""
         with closing(self._connect()) as conn:
-            _begin_immediate(conn)
+            _sqlite.begin_immediate(conn)
             try:
                 conn.execute(
                     """
@@ -74,7 +72,7 @@ class RuntimeEvidenceStore(RuntimeEvidenceStoreProtocol):
                         record.event_id,
                         record.execution_id,
                         record.session_id,
-                        _iso_utc(record.created_at),
+                        _sqlite.iso_utc(record.created_at),
                         record.event_kind,
                         json.dumps(record.request.model_dump(mode="json"), sort_keys=True),
                         record.decision,
@@ -166,22 +164,7 @@ class RuntimeEvidenceStore(RuntimeEvidenceStoreProtocol):
             )
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self._path, timeout=30.0, isolation_level=None)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys = ON")
-        connection.execute("PRAGMA busy_timeout = 30000")
-        connection.execute("PRAGMA journal_mode = WAL")
-        return connection
-
-
-def _begin_immediate(conn: sqlite3.Connection) -> None:
-    conn.execute("BEGIN IMMEDIATE")
-
-
-def _iso_utc(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
-    return value.astimezone(UTC).isoformat()
+        return _sqlite.connect(self._path)
 
 
 def _evidence_record_from_row(row: sqlite3.Row) -> RuntimeExecutionEvidenceRecord:

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,8 +41,8 @@ Current automated coverage includes:
 - Citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads
-- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
-  `compile`, and JSON-first `preflight`
+- CLI output for `init`, `ingest`, JSON-first `search`, JSON-first `route`,
+  JSON-first `compile`, JSON-first `preflight`, and `dump-index --count-only`
 - CLI output for `eval`
 - CLI output for `eval --backend default|nemo|nemo_evaluator|nat`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -127,3 +127,17 @@ def test_auth_store_reset_for_tests_clears_existing_state(tmp_path) -> None:
     store.reset_for_tests()
 
     assert store.list_accounts() == []
+
+
+def test_auth_store_reset_for_tests_removes_wal_sidecars(tmp_path) -> None:
+    db_path = tmp_path / "auth.sqlite3"
+    store = AuthStore(path=db_path)
+    wal_path = db_path.with_name(f"{db_path.name}-wal")
+    shm_path = db_path.with_name(f"{db_path.name}-shm")
+    wal_path.write_text("stale wal", encoding="utf-8")
+    shm_path.write_text("stale shm", encoding="utf-8")
+
+    store.reset_for_tests()
+
+    assert wal_path.exists() is False
+    assert shm_path.exists() is False

--- a/tests/test_beta_auth.py
+++ b/tests/test_beta_auth.py
@@ -81,6 +81,14 @@ def _service(tmp_path: Path) -> BetaAuthService:
     )
 
 
+def test_service_derives_public_urls_from_shared_helper(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    assert service.mcp_url == "https://beta.example.com/mcp"
+    assert service.portal_url == "https://beta.example.com/beta"
+    assert service.github_callback_url == "https://beta.example.com/auth/github/callback"
+
+
 def test_exchange_code_rejects_invalid_json(monkeypatch, tmp_path: Path) -> None:
     service = _service(tmp_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,9 @@ def configure_standalone_cli_environment(
 class MockIngestService:
     """Static ingest service for CLI tests."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def run(self) -> IngestResult:
         return IngestResult(
             corpus_path="policies",
@@ -139,6 +142,9 @@ class MockIngestService:
             chunk_count=24,
             embedding_dimension=2,
         )
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockSearchService:
@@ -404,6 +410,9 @@ class MockPreflightService:
 class MockIndexDumpService:
     """Static dump service for CLI tests."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def list_chunks(self) -> list[PolicyChunk]:
         return [
             PolicyChunk(
@@ -420,6 +429,9 @@ class MockIndexDumpService:
                 ),
             )
         ]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockRuntimeDecisionService:
@@ -791,9 +803,10 @@ def make_stderr_prompt_confirmer():
 
 
 def test_ingest_command_prints_summary(monkeypatch) -> None:
+    service = MockIngestService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_ingest_service",
-        lambda settings: MockIngestService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["ingest"])
@@ -801,6 +814,7 @@ def test_ingest_command_prints_summary(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "Indexed 24 chunks from 8 documents." in result.stdout
     assert "mock-model" in result.stdout
+    assert service.closed is True
 
 
 def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
@@ -813,6 +827,24 @@ def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "chunk/vector mismatch" in result.stderr
+
+
+def test_ingest_command_closes_service_when_run_fails(monkeypatch) -> None:
+    class FailingIngestService(MockIngestService):
+        def run(self) -> IngestResult:
+            raise ValueError("chunk/vector mismatch")
+
+    service = FailingIngestService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_ingest_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, ["ingest"])
+
+    assert result.exit_code == 1
+    assert "chunk/vector mismatch" in result.stderr
+    assert service.closed is True
 
 
 def test_search_command_prints_json(monkeypatch) -> None:
@@ -1349,9 +1381,10 @@ def test_preflight_command_formats_route_validation_errors(
 
 
 def test_dump_index_command_prints_chunks(monkeypatch) -> None:
+    service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
-        lambda settings: MockIndexDumpService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["dump-index"])
@@ -1360,18 +1393,21 @@ def test_dump_index_command_prints_chunks(monkeypatch) -> None:
     assert "Indexed chunks: 1" in result.stdout
     assert "BACKEND-1" in result.stdout
     assert "Use request ids in backend logs." in result.stdout
+    assert service.closed is True
 
 
 def test_dump_index_count_only_prints_only_count(monkeypatch) -> None:
+    service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
-        lambda settings: MockIndexDumpService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["dump-index", "--count-only"])
 
     assert result.exit_code == 0
     assert result.stdout == "Indexed chunks: 1\n"
+    assert service.closed is True
 
 
 def test_help_includes_dump_index_command() -> None:

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -26,13 +26,24 @@ from policynim.types import (
 class FakeIngestService:
     """Capture the isolated live eval index path."""
 
-    def __init__(self, settings: Settings, seen_paths: list[Path]) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        seen_paths: list[Path],
+        *,
+        closed: list[bool] | None = None,
+    ) -> None:
         self._settings = settings
         self._seen_paths = seen_paths
+        self._closed = closed
 
     def run(self):
         self._seen_paths.append(self._settings.lancedb_uri)
         return None
+
+    def close(self) -> None:
+        if self._closed is not None:
+            self._closed.append(True)
 
 
 class FakeSearchService:
@@ -286,10 +297,11 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
         eval_workspace_dir=tmp_path / "workspace",
     )
     seen_paths: list[Path] = []
+    closed: list[bool] = []
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: FakeIngestService(active_settings, seen_paths),
+        lambda active_settings: FakeIngestService(active_settings, seen_paths, closed=closed),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
@@ -309,6 +321,7 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
     assert seen_paths
     assert seen_paths[0] != settings.lancedb_uri
     assert settings.lancedb_uri == tmp_path / "caller-index"
+    assert closed == [True]
 
 
 def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -210,6 +210,15 @@ def test_ensure_hosted_runtime_ready_rebuilds_missing_index(
         ]
     )
     rebuilds: list[str] = []
+    closed: list[bool] = []
+
+    class FakeIngestService:
+        def run(self):
+            rebuilds.append("run")
+            return SimpleNamespace(index_uri="/tmp/index", chunk_count=4, document_count=2)
+
+        def close(self) -> None:
+            closed.append(True)
 
     monkeypatch.setattr(
         health_module,
@@ -219,17 +228,13 @@ def test_ensure_hosted_runtime_ready_rebuilds_missing_index(
     monkeypatch.setattr(
         health_module,
         "create_ingest_service",
-        lambda settings: SimpleNamespace(
-            run=lambda: (
-                rebuilds.append("run")
-                or SimpleNamespace(index_uri="/tmp/index", chunk_count=4, document_count=2)
-            )
-        ),
+        lambda settings: FakeIngestService(),
     )
 
     health_module.ensure_hosted_runtime_ready(Settings(), rebuild_if_missing=True)
 
     assert rebuilds == ["run"]
+    assert closed == [True]
 
 
 def test_ensure_hosted_runtime_ready_rebuilds_empty_index(

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -35,6 +35,16 @@ class RaisingEmbeddingsClient:
         raise self._exc
 
 
+class CloseableEmbeddingsClient:
+    """Embeddings client stub that exposes a close hook."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_embedder_classifies_upstream_auth_failures() -> None:
     embedder = NVIDIAEmbedder(
         api_key="test-key",
@@ -67,3 +77,35 @@ def test_embedder_classifies_upstream_rate_limits() -> None:
         embedder.embed_query("backend logging")
 
     assert excinfo.value.failure_class == "rate_limit"
+
+
+def test_embedder_close_closes_owned_client() -> None:
+    client = CloseableEmbeddingsClient()
+    embedder = NVIDIAEmbedder(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        batch_size=2,
+        timeout_seconds=1,
+        max_retries=0,
+        client=client,
+    )
+
+    embedder.close()
+
+    assert client.closed is False
+
+    owned_client = CloseableEmbeddingsClient()
+    owned_embedder = NVIDIAEmbedder(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        batch_size=2,
+        timeout_seconds=1,
+        max_retries=0,
+    )
+    owned_embedder._client = owned_client  # type: ignore[assignment]
+
+    owned_embedder.close()
+
+    assert owned_client.closed is True

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -14,6 +14,9 @@ from policynim.types import EmbeddedChunk, PolicyChunk, PolicyMetadata, ScoredCh
 class MockEmbedder:
     """Returns deterministic query embeddings."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def embed_query(self, text: str) -> list[float]:
         mapping = {
             "backend logs": [1.0, 0.0],
@@ -24,6 +27,9 @@ class MockEmbedder:
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         return [[1.0, 0.0] for _ in texts]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockIndexStore:
@@ -216,16 +222,18 @@ def test_search_service_requires_existing_index() -> None:
         service.search(SearchRequest(query="backend logs", top_k=1))
 
 
-def test_search_service_close_closes_reranker() -> None:
+def test_search_service_close_closes_embedder_and_reranker() -> None:
+    embedder = MockEmbedder()
     reranker = MockReranker()
     service = SearchService(
-        embedder=MockEmbedder(),
+        embedder=embedder,
         index_store=MockIndexStore([make_chunk(chunk_id="BACKEND-1", domain="backend")]),
         reranker=reranker,
     )
 
     service.close()
 
+    assert embedder.closed is True
     assert reranker.closed is True
 
 


### PR DESCRIPTION
## Summary
- close owned embedder clients deterministically and add ingest/search cleanup coverage across CLI, hosted rebuild, and live eval flows
- centralize hosted public URL derivation for MCP, beta portal, and GitHub callback surfaces
- harden SQLite test reset behavior by sharing WAL-aware cleanup helpers and removing stale sidecars

## Verification
- All checks passed!
- ........................................................................ [ 15%]
..............................................ss........................ [ 31%]
................ssss.................................................... [ 47%]
.................................sss.................................... [ 63%]
........................................................................ [ 79%]
........................................................................ [ 95%]
.....................                                                    [100%]
444 passed, 9 skipped in 5.06s
