### PR TITLE
Fix weekly audit findings across ingest, model invariants, and DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Use this path only if you want to run PolicyNIM from a local checkout.
 uv sync --group test --group dev
 export NVIDIA_API_KEY=<your-nvidia-api-key>
 uv run policynim ingest
-uv run pytest -q
+uv run --group dev pyright
+uv run --group test pytest -q
 ```
 
 If you want the CLI to prompt for the required values and write the local config

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ PolicyNIM currently ships with two main user-facing surfaces:
 ## What Works Today
 
 - Deterministic Markdown ingest with heading-aware chunking and source line spans.
+- Ingest-time compilation of `runtime_rules` frontmatter into the persisted runtime rules artifact.
 - NVIDIA-hosted embeddings and reranking for retrieval.
 - Local LanceDB storage for the retrievable policy index.
 - Task-aware policy routing with citation-preserving selected-policy packets.
@@ -46,8 +47,9 @@ PolicyNIM currently ships with two main user-facing surfaces:
   artifacts and local Phoenix reporting for non-headless runs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- JSON-first CLI commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
-  `preflight`, `eval`, `mcp`, `runtime`, and `evidence`.
+- Interactive `init` setup plus JSON-first CLI commands for `ingest`,
+  `dump-index`, `search`, `route`, `compile`, `preflight`, `eval`, `mcp`,
+  `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
@@ -95,10 +97,22 @@ Use this path only if you want to run PolicyNIM from a local checkout.
 
 ```bash
 uv sync --group test --group dev
-cp .env.development.example .env
 export NVIDIA_API_KEY=<your-nvidia-api-key>
 uv run policynim ingest
 uv run pytest -q
+```
+
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+If you prefer to manage `.env` manually, copy the template first:
+
+```bash
+cp .env.development.example .env
 ```
 
 After the index is built, the fastest local sanity checks are:
@@ -145,6 +159,11 @@ Start here when you want the longer version of a specific path:
 - [examples/codex/README.md](examples/codex/README.md): Codex MCP setup example
 - [examples/claude-code/README.md](examples/claude-code/README.md): Claude Code
   MCP setup example
+
+## Talks And Workflow Notes
+
+- [docs/ai-engineer-miami-context-plane.md](docs/ai-engineer-miami-context-plane.md): centralized context-plane talk notes and project framing
+- [docs/extreme-programming-with-agents.md](docs/extreme-programming-with-agents.md): XP, TDD, and agent workflow notes
 
 ## Limits And Scope
 

--- a/docs/ai-engineer-miami-context-plane.md
+++ b/docs/ai-engineer-miami-context-plane.md
@@ -1,0 +1,33 @@
+# The Missing Layer in AI Coding Workflows Is a Centralized Context Plane
+
+At AI Engineer Miami 2026, I gave a talk about code quality gates for AI-assisted development. The part that stayed with me happened after I stepped off stage. I had separate conversations with senior engineers from Spotify and Capital One, and both pointed at the same failure mode. Their teams were not short on AI tools. They were short on a reliable way to make the same engineering standards reach every agent, every repo, and every step in the workflow.
+
+We keep treating `AGENTS.md`, `CLAUDE.md`, internal docs, review checklists, PR comments, and tribal knowledge like different categories of information. They are the same category. They are context. When that context is scattered across laptops, wikis, old pull requests, and people's heads, the codebase starts to drift. One engineer's agent follows one set of rules. Another engineer's agent follows a different prompt. A third team catches problems only in review. The issue is not that teams need more prompt hacks. The issue is that context has no operating model.
+
+That problem also shows up earlier than most teams admit. Code quality does not break down only in PR review. It breaks down in planning and design, in development, in review, in testing, and in deployment. By the time a pull request is open, some of the most expensive mistakes have already been made. That is why a verification layer cannot be a thin wrapper around code review. It has to start where work starts.
+
+A recent community poll we ran made that gap plain: `70.7%` of developers said they are not measuring the impact of AI on code quality at all.
+
+This is why I keep coming back to the idea of a centralized context plane. By that I mean one operational layer where engineering standards, repo rules, review criteria, architectural constraints, domain requirements, and team-specific patterns live in a form that tools can actually use. If a rule matters, it should be available to the agent that plans the work, the CLI that runs local review, and the system that evaluates the pull request.
+
+Written somewhere is not the same as operationalized everywhere. Plenty of teams have excellent standards, but those standards are trapped in static documents or buried in PR history. If the only person who remembers the async error-handling rule is your staff engineer, that is dependency on memory. AI makes this worse because it increases code volume before most teams have increased the reliability of their context.
+
+The next missing piece is the verification layer. A context plane without verification becomes another library of good intentions. A verification layer is what applies the same context during planning, code generation, local review, pre-PR validation, and PR review. It is the system that says: these are the standards, and here is where we check them before bad patterns harden into the codebase.
+
+The clearest way I know to explain it is the same way I framed it in the talk:
+
+1. Define what code quality means to you.
+2. Decide where those quality standards live.
+3. Design the verification layer where engineers already work.
+
+That sequence matters. Skip the second step and the third turns into theater because every tool is checking against a different version of the truth. Skip the third step and the second turns into documentation that people admire and ignore.
+
+A simple example: teams often keep `AGENTS.md`, repo rules, and review criteria in separate lanes. One file guides the coding agent. Another system holds review rules. Human reviewers fill the gaps from memory. That setup guarantees drift. The better pattern is to treat all three as one context system and use it early. If a change touches authentication, background jobs, or API contracts, the agent should pull the relevant standards before it writes code. Local review should check the diff against those same rules before a PR opens. CI should apply the same expectations again, so human review starts at the architectural and product level instead of spending cycles on issues that should have been caught earlier.
+
+That is also why I think context engineering needs a broader definition than the one it usually gets. It is the work of codifying standards, centralizing them, scoping them to the right repos, and making them executable in the tools engineers already use. Too many teams are still building workarounds across local prompt files, agent-specific markdown, IDE extensions, and tribal memory. That does not scale across distributed teams. When senior engineers tell me their teams are getting inconsistent results from different agents, I hear a context distribution problem.
+
+If I were giving teams three practical takeaways from the Miami talk and the conversations that followed, they would be simple. Treat every standard as context, even if it currently lives in a PR comment or somebody's head. Put that context in one operational plane instead of scattering it across local files and folklore. Then verify against it before human review, not after the code has already taken a full trip through the workflow.
+
+That is the part of AI-assisted development I think deserves more attention this year. If AI increases code volume, teams need a system that makes standards executable. Otherwise the failure mode is predictable: faster output, less consistent judgment, and more cleanup pushed downstream.
+
+This is the direction I care about at Qodo. The point is not to give teams one more place to store rules. The point is to help turn those rules into something agents, local workflows, and review systems can all act on. That is how context engineering stops being a prompt trick and starts acting like engineering infrastructure.

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -172,6 +172,8 @@ flowchart TB
     subgraph Ingest["Corpus to Index"]
         direction LR
         Policies["Policy Markdown corpus"] --> Parse["Parse and normalize"]
+        Parse --> CompileRules["Compile runtime_rules frontmatter"]
+        CompileRules --> RuntimeRules
         Parse --> Chunk["Chunk by section and line span"]
         Chunk --> EmbedDocs["Embed documents"]
         EmbedDocs --> Index["Local LanceDB index"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,9 +42,10 @@ Ingest flow:
 2. parse Markdown into normalized documents
 3. infer missing metadata when possible
 4. extract heading-aware sections with stable line spans
-5. build deterministic chunk IDs
-6. embed chunk text through NVIDIA-hosted embeddings
-7. replace the local LanceDB table with the new embedded rows
+5. compile any `runtime_rules` frontmatter into the persisted runtime rules artifact
+6. build deterministic chunk IDs
+7. embed chunk text through NVIDIA-hosted embeddings
+8. replace the local LanceDB table with the new embedded rows
 
 Important ingest rules:
 
@@ -303,8 +304,9 @@ Important evaluation rules:
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query ...`
 - `policynim route --task ... [--domain ...] [--top-k ...] [--task-type ...]`
 - `policynim compile --task ... [--domain ...] [--top-k ...] [--task-type ...]`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -155,8 +155,9 @@ uv run --group dev pre-commit install
 Run the standard quality gates:
 
 ```bash
-uv run ruff check
-uv run pytest -q
+uv run --group dev ruff check
+uv run --group dev pyright
+uv run --group test pytest -q
 ```
 
 For live or hosted-only checks, use the coverage notes in

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -11,7 +11,14 @@ Install the runtime, test, and dev dependencies:
 uv sync --group test --group dev
 ```
 
-Copy the development example environment file:
+If you want the CLI to prompt for the required values and write the local config
+file for you, run:
+
+```bash
+uv run policynim init
+```
+
+Otherwise, copy the development example environment file:
 
 ```bash
 cp .env.development.example .env

--- a/docs/extreme-programming-with-agents.md
+++ b/docs/extreme-programming-with-agents.md
@@ -1,0 +1,109 @@
+# Extreme Programming with Agents: How I Use Codex, TDD, BDD, Skills, and Review Layers
+
+Agentic coding gets dangerous when code generation becomes the first step.
+
+That is the trap inside a lot of AI workflow advice. Open Codex, ask for code, get something plausible, and hope review catches the rest. It feels fast, but it pushes feedback too far to the right. By the time you discover the design is wrong or the tests are weak, you already have a diff and a mess to unwind.
+
+Extreme Programming taught a better habit a long time ago. Create feedback first. Then write code.
+
+That is why XP matters more in the age of agents, not less. Agents collapse the cost of typing. They do not collapse the cost of bad decisions.
+
+## Why agents are rediscovering XP
+
+XP was built for unstable environments. Requirements move. Understanding changes as you work. The safest response is short feedback loops, tests first, simple design, and constant review.
+
+Modern coding agents fit that world almost too well. Codex is a strong pair programmer. It is not the whole system. It should not be deciding the plan, writing unchecked production code, judging its own output, and declaring the work done. When teams use it that way, they are not practicing leverage. They are skipping feedback.
+
+What XP gives me is an operating system for that speed. It tells me where the agent belongs, what order work should happen in, and how the system stays honest.
+
+## The two-layer system I use on PolicyNIM
+
+PolicyNIM is the project. The method is the point.
+
+I use a two-layer workflow. The first layer handles sequencing. What are we building, in what order, and what behavior are we trying to prove? The second layer handles quality. Is the slice correct, tested, idiomatic, and safe to keep?
+
+Codex lives inside that system as the pair programmer in the inner loop. It is there to help me move through small slices quickly. It is not the planner, the reviewer of record, or the approver.
+
+The whole loop from spec to merge looks like this:
+
+1. Start from a story or spec, then write the behavior in Given/When/Then form.
+2. Ask Codex for failing tests only, not implementation.
+3. Implement the smallest change that gets the test green.
+4. Refactor while the tests stay green.
+5. Run outer-loop gates such as `pre-commit`, `ruff`, `pytest`, and an independent review pass.
+6. Put a human in the final review before merge.
+
+That separation matters. The inner loop keeps momentum high. The outer loop keeps it honest.
+
+## Inner loop: TDD and BDD with Codex
+
+In the inner loop, I want Codex thinking like a disciplined pair, not a fast typist with repo access. So I start from behavior, not files.
+
+On PolicyNIM, one useful example is fail-closed preflight behavior. If the system cannot ground a task strongly enough, I do not want a polished bluff. I want the result to return `insufficient_context=true`. When grounding is strong enough, I want the output to surface concrete `review_flags` and `tests_required` rather than vague advice.
+
+That becomes a BDD-style slice before it becomes code: given a vague task and weak retained evidence, preflight should fail closed instead of inventing guidance; given a grounded task with valid evidence, preflight should preserve the review flags and test expectations that fall out of that evidence.
+
+From there I have Codex generate or extend the tests only. No implementation yet. This is the part many agent workflows skip, and it is exactly where the discipline matters.
+
+Once the tests fail for the right reason, Codex helps implement the smallest change that makes them pass. After that, we refactor. Rename things. Flatten logic. Remove speculative structure. Keep the design plain until the next behavior forces it to grow.
+
+This is still classic XP. The only difference is that the pair programmer can move much faster than a human pair. That makes the order of operations more important, not less.
+
+## Outer loop: independent review and quality governance
+
+This is where a lot of agent workflows fall apart. They let the same system that generated the code act as planner, implementer, reviewer, and closer. That is not review. That is one model talking to itself.
+
+On PolicyNIM, I want the boring safeguards on purpose. I use `pre-commit` so the local workflow catches obvious issues early. I run `ruff` to keep the Python readable and consistent. I run `pytest` because the behavior has to survive contact with the test suite, not just the prompt. Then I add an independent review layer. Qodo fits here because I want another system looking at the diff with a different job.
+
+That outer loop is not bureaucracy. It is risk management. It is how the system stays honest after the inner loop goes green.
+
+And yes, human review still matters. Agents can generate, lint, test, and flag. They do not own the codebase consequences. People do.
+
+## Packaging the discipline as a reusable skill
+
+So I turn the discipline into a reusable skill. I like the name `xp_tdd_story_runner` because it says exactly what it should do. It takes a spec or story, breaks it into behavior slices, generates failing tests first, implements minimally, and leaves clear repo guidance so the next session does not drift.
+
+The point is consistency. When I am tired or in a rush, I do not want the workflow to depend on memory.
+
+## Prompt: have your coding agent design the skill
+
+This is the prompt I would give a coding agent first.
+
+```text
+You are my engineering workflow designer.
+
+Goal:
+Design a reusable repository skill called `xp_tdd_story_runner` that enforces an Extreme Programming workflow for feature work.
+
+Context:
+- I use Codex as my coding agent.
+- I want the inner loop to follow: behavior (BDD) -> failing tests -> minimal implementation -> refactor with tests passing.
+- I want the outer loop to include linting, test execution, independent review, and human review before merge.
+- This skill should improve consistency across sessions, not generate a giant scaffold.
+
+Deliverables:
+1. Skill design
+   - Define inputs, outputs, phases, and decision rules.
+   - Show how the skill turns a spec or PRD into user stories and Given/When/Then scenarios.
+   - Show how it enforces tests-first before implementation.
+2. Repo documentation updates
+   - Propose concrete updates for repo instructions such as AGENTS.md, WORKFLOW.md, or equivalent files.
+   - Make the guidance explicit about when to use the skill and what "done" means.
+3. Usage prompts
+   - Provide short reusable prompts for:
+     - implementing from a PRD or spec
+     - implementing from an issue or ticket
+     - refactoring existing code with tests still in control
+
+Constraints:
+- Do not design enforcement automation that bypasses review or merge.
+- Do not replace independent review or human review.
+- Prefer clear workflow rules, small examples, and repo-documentation updates over large placeholders.
+- Ask clarifying questions only if a repo-specific detail is required to make the skill accurate.
+```
+
+## How to start small
+
+Pick one active project. Choose one story that matters. Write the behavior in Given/When/Then form before Codex touches implementation. Force the first pass to be tests only. Add the ordinary gates that keep the work clean: `pre-commit`, `ruff`, `pytest`, and one independent reviewer. Once the workflow works twice in a row, package it as a skill so you stop renegotiating the same standards every session.
+
+That is the real win. With the right XP discipline around them, agents let you run more feedback loops before a bad decision hardens into software.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,13 @@ operations into separate pages so the root README can stay short.
 - [public-source-grounding.md](public-source-grounding.md): provenance notes for
   the shipped sample corpus
 
+## Talks And Workflow Notes
+
+- [ai-engineer-miami-context-plane.md](ai-engineer-miami-context-plane.md):
+  centralized context-plane talk notes and project framing
+- [extreme-programming-with-agents.md](extreme-programming-with-agents.md):
+  XP, TDD, and agent workflow notes
+
 ## Testing And Coverage
 
 - [../tests/README.md](../tests/README.md): current automated coverage and the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,8 +7,9 @@ reference that used to live in the root README.
 
 ### CLI
 
+- `policynim init`
 - `policynim ingest`
-- `policynim dump-index`
+- `policynim dump-index [--count-only]`
 - `policynim search --query "..."`
 - `policynim route --task "..."`
 - `policynim compile --task "..."`
@@ -41,7 +42,19 @@ reference that used to live in the root README.
   `POLICYNIM_MCP_PUBLIC_BASE_URL` is set but the configured local index is
   missing or empty
 
+`policynim init` writes the local config file interactively when you want the
+CLI to prompt for `NVIDIA_API_KEY` and an optional custom corpus directory.
+
 ## Core Workflows
+
+### 0. Initialize The Local Config
+
+```bash
+uv run policynim init
+```
+
+Use this when you want the CLI to write the local env file for you instead of
+copying `.env.development.example` by hand.
 
 ### 1. Build The Local Index
 
@@ -53,6 +66,7 @@ What this does:
 
 - loads the bundled policy corpus, or the directory from `POLICYNIM_CORPUS_DIR`
 - chunks the documents into stable, citeable sections
+- compiles any `runtime_rules` frontmatter into the persisted runtime rules artifact
 - embeds those chunks with NVIDIA-hosted embeddings
 - rebuilds the local LanceDB table
 
@@ -67,6 +81,12 @@ uv run policynim dump-index
 
 This is the fastest way to inspect stored chunk IDs, section labels, line spans,
 and raw chunk text. Add `| less` if the output is long.
+
+If you only need the row count, use:
+
+```bash
+uv run policynim dump-index --count-only
+```
 
 ### 3. Search The Corpus
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
 ]
 dev = [
   "pre-commit==4.3.0",
+  "pyright==1.1.409",
   "ruff==0.15.7",
 ]
 

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -23,18 +23,8 @@ from policynim.types import (
 )
 
 
-class _IngestIndexStore(Protocol):
-    """Index-store surface required by ingest."""
-
-    @property
-    def uri(self) -> Path:
-        """Return the underlying index URI."""
-        ...
-
-    @property
-    def table_name(self) -> str:
-        """Return the configured table name."""
-        ...
+class _IndexReplaceStore(Protocol):
+    """Minimal index-store behavior required by ingest."""
 
     def replace(self, chunks: Sequence[EmbeddedChunk]) -> None:
         """Replace the local index contents with embedded chunks."""
@@ -48,13 +38,17 @@ class IngestService:
         self,
         *,
         embedder: Embedder,
-        index_store: _IngestIndexStore,
+        index_store: _IndexReplaceStore,
+        index_uri: Path,
+        table_name: str,
         corpus_root: Path,
         embedding_model: str,
         runtime_rules_artifact_path: Path,
     ) -> None:
         self._embedder = embedder
         self._index_store = index_store
+        self._index_uri = index_uri
+        self._table_name = table_name
         self._corpus_root = corpus_root
         self._embedding_model = embedding_model
         self._runtime_rules_artifact_path = runtime_rules_artifact_path
@@ -83,8 +77,8 @@ class IngestService:
 
         return IngestResult(
             corpus_path=self._corpus_root.as_posix(),
-            index_uri=self._index_store.uri.as_posix(),
-            table_name=self._index_store.table_name,
+            index_uri=self._index_uri.as_posix(),
+            table_name=self._table_name,
             embedding_model=self._embedding_model,
             document_count=len(documents),
             chunk_count=len(embedded_chunks),
@@ -95,12 +89,15 @@ class IngestService:
 def create_ingest_service(settings: Settings | None = None) -> IngestService:
     """Build the default ingest service from application settings."""
     active_settings = settings or get_settings()
+    index_uri = resolve_runtime_path(active_settings.lancedb_uri)
     return IngestService(
         embedder=_create_default_embedder(active_settings),
         index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
+            uri=index_uri,
             table_name=active_settings.lancedb_table,
         ),
+        index_uri=index_uri,
+        table_name=active_settings.lancedb_table,
         corpus_root=resolve_corpus_root(active_settings.corpus_dir),
         embedding_model=active_settings.nvidia_embed_model,
         runtime_rules_artifact_path=resolve_runtime_path(

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -623,6 +623,17 @@ class HealthCheckResult(StrictModel):
     mcp_url: str | None = None
     reason: str | None = None
 
+    @model_validator(mode="after")
+    def validate_status_shape(self) -> Self:
+        """Keep readiness booleans and status strings from drifting apart."""
+        if self.ready != (self.status == "ok"):
+            raise ValueError("ready must match status.")
+        if self.ready and self.reason is not None:
+            raise ValueError("ready health checks must not include a reason.")
+        if not self.ready and self.reason is None:
+            raise ValueError("not-ready health checks must include a reason.")
+        return self
+
 
 BetaAccountStatus = Literal["active", "suspended"]
 
@@ -682,6 +693,14 @@ def _validate_non_empty_path(value: object, *, field_name: str) -> object:
     if isinstance(value, str) and not value.strip():
         raise ValueError(f"{field_name} must not be empty.")
     return value
+
+
+def _validate_pass_fail_shape(*, passed: bool, failure_reasons: list[str], label: str) -> None:
+    """Require pass/fail booleans and failure reasons to agree."""
+    if passed and failure_reasons:
+        raise ValueError(f"{label} must not include failure_reasons when passed is true.")
+    if not passed and not failure_reasons:
+        raise ValueError(f"{label} must include failure_reasons when passed is false.")
 
 
 class PolicyGuidance(StrictModel):
@@ -789,6 +808,15 @@ class PolicyConformanceMetric(StrictModel):
     passed: bool
     failure_reasons: list[str] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def validate_failure_shape(self) -> Self:
+        _validate_pass_fail_shape(
+            passed=self.passed,
+            failure_reasons=self.failure_reasons,
+            label="policy conformance metrics",
+        )
+        return self
+
 
 class PolicyConformanceTraceStep(StrictModel):
     """One optional intermediate step available for trajectory-aware judging."""
@@ -825,6 +853,15 @@ class PolicyConformanceResult(StrictModel):
     constraint_ids: list[str] = Field(default_factory=list)
     chunk_ids: list[str] = Field(default_factory=list)
     failure_reasons: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_failure_shape(self) -> Self:
+        _validate_pass_fail_shape(
+            passed=self.passed,
+            failure_reasons=self.failure_reasons,
+            label="policy conformance results",
+        )
+        return self
 
 
 class PolicyConformanceRequest(StrictModel):
@@ -914,6 +951,15 @@ class PolicyEvidenceTraceConformanceCheck(StrictModel):
     failure_reasons: list[str] = Field(default_factory=list)
     constraint_ids: list[str] = Field(default_factory=list)
     chunk_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_failure_shape(self) -> Self:
+        _validate_pass_fail_shape(
+            passed=self.passed,
+            failure_reasons=self.failure_reasons,
+            label="policy evidence trace conformance checks",
+        )
+        return self
 
 
 class PolicyEvidenceTrace(StrictModel):
@@ -1033,6 +1079,15 @@ class EvalCaseResult(StrictModel):
     regeneration_result: PreflightRegenerationResult | None = None
     metrics: EvalCaseMetrics
 
+    @model_validator(mode="after")
+    def validate_failure_shape(self) -> Self:
+        _validate_pass_fail_shape(
+            passed=self.passed,
+            failure_reasons=self.failure_reasons,
+            label="eval case results",
+        )
+        return self
+
 
 class EvalAggregateMetrics(StrictModel):
     """Aggregate metrics for one rerank mode run."""
@@ -1089,3 +1144,27 @@ class EvalRunResult(StrictModel):
     compare_rerank: bool = True
     runs: list[EvalModeRunResult] = Field(default_factory=list)
     comparison: EvalComparisonDelta | None = None
+
+    @model_validator(mode="after")
+    def validate_compare_rerank_shape(self) -> Self:
+        """Keep compare-mode metadata aligned with the persisted runs."""
+        if self.compare_rerank:
+            if len(self.runs) != 2:
+                raise ValueError("compare_rerank=true requires exactly two runs.")
+            if {run.rerank_enabled for run in self.runs} != {True, False}:
+                raise ValueError(
+                    "compare_rerank=true requires one rerank-enabled and one rerank-disabled run."
+                )
+            if self.comparison is None:
+                raise ValueError("compare_rerank=true requires a comparison summary.")
+            return self
+
+        if len(self.runs) != 1:
+            raise ValueError("compare_rerank=false requires exactly one run.")
+        if not self.runs[0].rerank_enabled:
+            raise ValueError(
+                "compare_rerank=false requires the single run to keep reranking enabled."
+            )
+        if self.comparison is not None:
+            raise ValueError("compare_rerank=false must not include a comparison summary.")
+        return self

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,8 +41,8 @@ Current automated coverage includes:
 - Citation-deduplication and policy-vs-draft citation validation edge cases
 - NVIDIA response-validation coverage for malformed grounded-generation,
   policy-compilation, and reranking payloads
-- CLI output for `ingest`, JSON-first `search`, JSON-first `route`, JSON-first
-  `compile`, and JSON-first `preflight`
+- CLI output for `init`, `ingest`, JSON-first `search`, JSON-first `route`,
+  JSON-first `compile`, JSON-first `preflight`, and `dump-index --count-only`
 - CLI output for `eval`
 - CLI output for `eval --backend default|nemo|nemo_evaluator|nat`
 - CLI output for `runtime decide`, `runtime execute`, and `evidence report`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -591,16 +591,81 @@ class MockEvalService:
         self.last_regenerate = regenerate
         self.last_max_regenerations = max_regenerations
         passed_count = 2 if self.passed else 1
-        return EvalRunResult(
-            mode=mode,
-            backend=backend,
-            suite_name="day-6-default",
-            suite_path="evals/default_cases.json",
-            workspace_path="data/evals/workspace",
-            compare_rerank=compare_rerank,
-            runs=[
+        runs = [
+            EvalModeRunResult(
+                rerank_enabled=True,
+                metrics=EvalAggregateMetrics(
+                    case_count=2,
+                    passed_count=passed_count,
+                    search_case_count=1,
+                    search_passed_count=1,
+                    preflight_case_count=1,
+                    preflight_passed_count=passed_count - 1,
+                    overall_pass_rate=passed_count / 2,
+                    search_pass_rate=1.0,
+                    preflight_pass_rate=(passed_count - 1) / 1,
+                    expected_chunk_recall=1.0,
+                    expected_policy_recall=1.0 if self.passed else 0.5,
+                    insufficient_context_accuracy=1.0,
+                ),
+                result_json_path="data/evals/workspace/results/run.json",
+                report_html_path="data/evals/workspace/reports/run.html",
+                case_results=[
+                    EvalCaseResult(
+                        case_id="search-case",
+                        kind="search",
+                        input="backend logs",
+                        domain=None,
+                        top_k=1,
+                        rerank_enabled=True,
+                        passed=True,
+                        failure_reasons=[],
+                        expected_insufficient_context=False,
+                        actual_insufficient_context=False,
+                        expected_chunk_ids=["BACKEND-1"],
+                        actual_chunk_ids=["BACKEND-1"],
+                        matched_chunk_ids=["BACKEND-1"],
+                        expected_policy_ids=[],
+                        actual_policy_ids=[],
+                        matched_policy_ids=[],
+                        metrics=EvalCaseMetrics(
+                            expected_chunk_recall=1.0,
+                            expected_policy_recall=1.0,
+                            insufficient_context_correct=True,
+                        ),
+                    ),
+                    EvalCaseResult(
+                        case_id="preflight-case",
+                        kind="preflight",
+                        input="refresh token cleanup",
+                        domain=None,
+                        top_k=1,
+                        rerank_enabled=True,
+                        passed=self.passed,
+                        failure_reasons=(
+                            [] if self.passed else ["missing expected policy_id values: AUTH-1"]
+                        ),
+                        expected_insufficient_context=False,
+                        actual_insufficient_context=False,
+                        expected_chunk_ids=[],
+                        actual_chunk_ids=["AUTH-1"],
+                        matched_chunk_ids=[],
+                        expected_policy_ids=["AUTH-1"],
+                        actual_policy_ids=["AUTH-1"] if self.passed else [],
+                        matched_policy_ids=["AUTH-1"] if self.passed else [],
+                        metrics=EvalCaseMetrics(
+                            expected_chunk_recall=1.0,
+                            expected_policy_recall=1.0 if self.passed else 0.0,
+                            insufficient_context_correct=True,
+                        ),
+                    ),
+                ],
+            )
+        ]
+        if compare_rerank:
+            runs.append(
                 EvalModeRunResult(
-                    rerank_enabled=True,
+                    rerank_enabled=False,
                     metrics=EvalAggregateMetrics(
                         case_count=2,
                         passed_count=passed_count,
@@ -615,8 +680,8 @@ class MockEvalService:
                         expected_policy_recall=1.0 if self.passed else 0.5,
                         insufficient_context_accuracy=1.0,
                     ),
-                    result_json_path="data/evals/workspace/results/run.json",
-                    report_html_path="data/evals/workspace/reports/run.html",
+                    result_json_path="data/evals/workspace/results/run-no-rerank.json",
+                    report_html_path="data/evals/workspace/reports/run-no-rerank.html",
                     case_results=[
                         EvalCaseResult(
                             case_id="search-case",
@@ -624,7 +689,7 @@ class MockEvalService:
                             input="backend logs",
                             domain=None,
                             top_k=1,
-                            rerank_enabled=True,
+                            rerank_enabled=False,
                             passed=True,
                             failure_reasons=[],
                             expected_insufficient_context=False,
@@ -647,7 +712,7 @@ class MockEvalService:
                             input="refresh token cleanup",
                             domain=None,
                             top_k=1,
-                            rerank_enabled=True,
+                            rerank_enabled=False,
                             passed=self.passed,
                             failure_reasons=(
                                 [] if self.passed else ["missing expected policy_id values: AUTH-1"]
@@ -668,15 +733,27 @@ class MockEvalService:
                         ),
                     ],
                 )
-            ],
-            comparison=EvalComparisonDelta(
-                overall_pass_rate_delta=0.5,
-                expected_chunk_recall_delta=0.5,
-                expected_policy_recall_delta=0.5,
-                insufficient_context_accuracy_delta=0.0,
-                improved_case_ids=["preflight-case"],
-                regressed_case_ids=[],
-                unchanged_case_ids=["search-case"],
+            )
+        return EvalRunResult(
+            mode=mode,
+            backend=backend,
+            suite_name="day-6-default",
+            suite_path="evals/default_cases.json",
+            workspace_path="data/evals/workspace",
+            compare_rerank=compare_rerank,
+            runs=runs,
+            comparison=(
+                EvalComparisonDelta(
+                    overall_pass_rate_delta=0.0,
+                    expected_chunk_recall_delta=0.0,
+                    expected_policy_recall_delta=0.0,
+                    insufficient_context_accuracy_delta=0.0,
+                    improved_case_ids=[],
+                    regressed_case_ids=[],
+                    unchanged_case_ids=["search-case", "preflight-case"],
+                )
+                if compare_rerank
+                else None
             ),
         )
 

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -99,6 +99,8 @@ def test_ingest_service_builds_and_rebuilds_local_index(tmp_path: Path) -> None:
     service = IngestService(
         embedder=MockEmbedder(),
         index_store=store,
+        index_uri=store.uri,
+        table_name=store.table_name,
         corpus_root=policies_dir,
         embedding_model="mock-embedder",
         runtime_rules_artifact_path=artifact_path,
@@ -165,6 +167,8 @@ def test_ingest_service_rejects_unwritable_runtime_rules_artifact_before_index_r
     service = IngestService(
         embedder=MockEmbedder(),
         index_store=store,
+        index_uri=store.uri,
+        table_name=store.table_name,
         corpus_root=policies_dir,
         embedding_model="mock-embedder",
         runtime_rules_artifact_path=blocking_parent / "runtime_rules.json",
@@ -207,6 +211,8 @@ def test_ingest_service_does_not_leave_staged_runtime_rule_artifacts_on_embed_fa
     service = IngestService(
         embedder=FailingEmbedder(),
         index_store=RecordingIndexStore(uri=tmp_path / "index", table_name="policy_chunks"),
+        index_uri=tmp_path / "index",
+        table_name="policy_chunks",
         corpus_root=policies_dir,
         embedding_model="mock-embedder",
         runtime_rules_artifact_path=artifact_path,
@@ -244,6 +250,8 @@ def test_ingest_service_rejects_directory_runtime_rules_artifact_before_index_re
     service = IngestService(
         embedder=MockEmbedder(),
         index_store=store,
+        index_uri=store.uri,
+        table_name=store.table_name,
         corpus_root=policies_dir,
         embedding_model="mock-embedder",
         runtime_rules_artifact_path=artifact_path,

--- a/tests/test_service_factories.py
+++ b/tests/test_service_factories.py
@@ -87,6 +87,8 @@ def test_create_ingest_service_builds_default_components(monkeypatch, tmp_path: 
 
     assert service._embedder is mock_embedder
     assert isinstance(service._index_store, MockIndexStore)
+    assert service._index_uri == (tmp_path / "ingest-index").resolve(strict=False)
+    assert service._table_name == settings.lancedb_table
     assert service._index_store.uri == (tmp_path / "ingest-index").resolve(strict=False)
     assert service._index_store.table_name == settings.lancedb_table
     assert service._corpus_root == (tmp_path / "policies").resolve(strict=False)

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -13,8 +13,18 @@ from policynim.settings import Settings
 from policynim.types import (
     DEFAULT_TOP_K,
     DocumentSection,
+    EvalAggregateMetrics,
+    EvalCaseMetrics,
+    EvalCaseResult,
+    EvalComparisonDelta,
+    EvalModeRunResult,
+    EvalRunResult,
+    HealthCheckResult,
     HTTPRequestActionRequest,
     ParsedRuntimeRule,
+    PolicyConformanceMetric,
+    PolicyConformanceResult,
+    PolicyEvidenceTraceConformanceCheck,
     RuntimeActionRequest,
     RuntimeDecisionResult,
     RuntimeEvidenceExecutionSummary,
@@ -830,3 +840,123 @@ def test_runtime_evidence_session_summary_accepts_aggregate_counts() -> None:
     assert summary.execution_count == 1
     assert summary.allowed_count == 1
     assert summary.executions[0].execution_outcome == "allowed"
+
+
+def test_health_check_result_rejects_drifted_status_fields() -> None:
+    with pytest.raises(ValidationError, match="ready must match status"):
+        HealthCheckResult(
+            status="ok",
+            ready=False,
+            table_name="policy_chunks",
+            row_count=0,
+            reason="index missing",
+        )
+
+    with pytest.raises(ValidationError, match="not-ready health checks must include a reason"):
+        HealthCheckResult(
+            status="error",
+            ready=False,
+            table_name="policy_chunks",
+            row_count=0,
+        )
+
+
+def test_policy_conformance_models_require_failure_reason_parity() -> None:
+    with pytest.raises(ValidationError, match="must include failure_reasons"):
+        PolicyConformanceMetric(name="plan_completeness", score=0.0, passed=False)
+
+    with pytest.raises(ValidationError, match="must not include failure_reasons"):
+        PolicyConformanceResult(
+            backend="nemo",
+            passed=True,
+            overall_score=1.0,
+            metrics=[
+                PolicyConformanceMetric(
+                    name="plan_completeness",
+                    score=1.0,
+                    passed=True,
+                )
+            ],
+            failure_reasons=["unexpected failure"],
+        )
+
+    with pytest.raises(ValidationError, match="must include failure_reasons"):
+        PolicyEvidenceTraceConformanceCheck(
+            backend="nemo",
+            name="final_adherence",
+            passed=False,
+            score=0.0,
+        )
+
+
+def test_eval_run_result_rejects_invalid_compare_rerank_shape() -> None:
+    base_metrics = EvalAggregateMetrics(
+        case_count=1,
+        passed_count=1,
+        search_case_count=1,
+        search_passed_count=1,
+        preflight_case_count=0,
+        preflight_passed_count=0,
+        overall_pass_rate=1.0,
+        search_pass_rate=1.0,
+        preflight_pass_rate=0.0,
+        expected_chunk_recall=1.0,
+        expected_policy_recall=1.0,
+        insufficient_context_accuracy=1.0,
+    )
+    base_case = EvalCaseResult(
+        case_id="search-case",
+        kind="search",
+        input="backend logs",
+        top_k=1,
+        rerank_enabled=True,
+        passed=True,
+        expected_insufficient_context=False,
+        actual_insufficient_context=False,
+        metrics=EvalCaseMetrics(
+            expected_chunk_recall=1.0,
+            expected_policy_recall=1.0,
+            insufficient_context_correct=True,
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="compare_rerank=true requires exactly two runs"):
+        EvalRunResult(
+            mode="offline",
+            suite_name="default",
+            suite_path="evals/default_cases.json",
+            workspace_path="data/evals/workspace",
+            compare_rerank=True,
+            runs=[
+                EvalModeRunResult(
+                    rerank_enabled=True,
+                    metrics=base_metrics,
+                    result_json_path="run.json",
+                    report_html_path="run.html",
+                    case_results=[base_case],
+                )
+            ],
+            comparison=EvalComparisonDelta(),
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="compare_rerank=false must not include a comparison summary",
+    ):
+        EvalRunResult(
+            mode="offline",
+            suite_name="default",
+            suite_path="evals/default_cases.json",
+            workspace_path="data/evals/workspace",
+            compare_rerank=False,
+            runs=[
+                EvalModeRunResult(
+                    rerank_enabled=True,
+                    metrics=base_metrics,
+                    result_json_path="run.json",
+                    report_html_path="run.html",
+                    case_results=[base_case],
+                )
+            ],
+            comparison=EvalComparisonDelta(),
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2813,6 +2813,7 @@ nvidia-guardrails = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "ruff" },
 ]
 test = [
@@ -2847,6 +2848,7 @@ provides-extras = ["nvidia-guardrails", "nvidia-eval", "nvidia-eval-launcher"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.3.0" },
+    { name = "pyright", specifier = "==1.1.409" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
 test = [{ name = "pytest", specifier = "==8.3.4" }]
@@ -3227,6 +3229,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/d7/c5d1381248a33975ccc864a0f980f93270ecc35354de8646c8a16443cccb/pymilvus-2.6.12.tar.gz", hash = "sha256:8323e990dc305e607fef525498eb779e42940a69e0691dde009cd02d48845f7a", size = 1584521, upload-time = "2026-04-09T07:49:11.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/5d/44b0fa94c91503381e6f12298277f84f8e7b0bb00715ab89fc273c4d681e/pymilvus-2.6.12-py3-none-any.whl", hash = "sha256:69051b8b62712f157b2b50aeb7bde7fd7cdb5940aac0122094eb3cd58bc20f0d", size = 315183, upload-time = "2026-04-09T07:49:09.013Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- narrow `IngestService` to the index behavior it actually needs and keep index metadata as explicit constructor state
- add model validators for drift-prone result shapes in health, conformance, and eval result models
- make static type checking a first-class quality gate by pinning `pyright` and documenting the correct `uv` commands

## Findings addressed
- Abstractions audit: `IngestService` depended on a bespoke store contract that mixed replacement behavior with metadata access; the service now depends on a minimal replace-only protocol and receives `index_uri`/`table_name` explicitly.
- Drift audit: `HealthCheckResult`, policy conformance models, evidence trace checks, and eval result models could previously represent contradictory states. Validators now enforce status/ready parity, pass/fail reason parity, and compare-rerank result shape.
- DX audit: the repo had a `pyrightconfig.json` but no pinned `pyright` dependency or documented command, and contributor commands did not consistently use the right dependency groups for tests. The dev dependency and docs now align.

## Verification
- `uv run --group dev ruff check .`
- `uv run --group test --with pyright pyright`
- `uv run --group test pytest -q tests/test_settings_and_types.py tests/test_ingest_service.py tests/test_service_factories.py tests/test_health_service.py tests/test_mcp.py tests/test_cli.py`
- `uv run --group test pytest -q -m 'not live and not docker_live'`
