### PR TITLE
Stabilize setup, runtime guards, and provider cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run Ruff
         run: uv run ruff check
 
+      - name: Run Pyright
+        run: uv run pyright
+
   test:
     runs-on: ubuntu-24.04
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,9 @@ repos:
         entry: uv run --group dev ruff format
         language: system
         types: [python]
+      - id: pyright
+        name: pyright
+        entry: uv run --group dev pyright
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ uv run policynim ingest
 uv run pytest -q
 ```
 
+If you want the CLI to prompt for the required values and write the local config
+for you, run:
+
+```bash
+uv run policynim init
+```
+
+In a source checkout, `init` writes the checkout `.env` file that PolicyNIM
+loads by default. Installed copies should keep using the direct `policynim init`
+entrypoint described below.
+
 After the index is built, the fastest local sanity checks are:
 
 ```bash

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -11,14 +11,26 @@ Install the runtime, test, and dev dependencies:
 uv sync --group test --group dev
 ```
 
-Copy the development example environment file:
+If you want the CLI to prompt for the required values and write the local config
+for you, run:
+
+```bash
+uv run policynim init
+```
+
+In a source checkout, `init` writes the checkout `.env` file, and the normal
+settings loader reads that file on subsequent `uv run policynim ...` commands.
+In an installed standalone runtime, `init` writes the user config path printed in
+the command output.
+
+Otherwise, copy the development example environment file:
 
 ```bash
 cp .env.development.example .env
 ```
 
-Then set `NVIDIA_API_KEY` in `.env` or your shell. For the official key-creation
-flow, use NVIDIA's
+If you copied the template manually, set `NVIDIA_API_KEY` in `.env` or your
+shell. For the official key-creation flow, use NVIDIA's
 [API Catalog Quickstart Guide](https://docs.api.nvidia.com/nim/docs/api-quickstart)
 and [Build catalog](https://build.nvidia.com/).
 
@@ -48,7 +60,7 @@ config directory with user-owned defaults for `POLICYNIM_LANCEDB_URI`,
 and `POLICYNIM_EVAL_WORKSPACE_DIR`.
 
 After that, run `policynim ingest` as usual. Source checkouts can keep using the
-`.env.development.example` flow above and `uv run` for in-project commands.
+checkout `.env` flow above and `uv run` for in-project commands.
 
 ## Environment Templates
 
@@ -168,6 +180,7 @@ Run the standard quality gates:
 ```bash
 uv run ruff check
 uv run pytest -q
+uv run pyright
 ```
 
 For live or hosted-only checks, use the coverage notes in

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -56,10 +56,11 @@ checkout. It prompts for `NVIDIA_API_KEY` and an optional custom corpus
 directory, then writes the standalone config file with user-owned data-path
 defaults before building the local index.
 
-Source checkouts can keep using `.env.development.example`, skip this step, and
-use the later `uv run policynim ...` examples inside the uv-managed project
-environment. Installed copies should keep using the direct `policynim ...`
-entrypoint.
+Source checkouts can either copy `.env.development.example` to `.env` or run
+`uv run policynim init`, which writes the checkout `.env` file that source
+commands load by default. Then use the later `uv run policynim ...` examples
+inside the uv-managed project environment. Installed copies should keep using
+the direct `policynim ...` entrypoint.
 
 ### 1. Build The Local Index
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
 ]
 dev = [
   "pre-commit==4.3.0",
+  "pyright==1.1.409",
   "ruff==0.15.7",
 ]
 

--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -72,17 +72,25 @@ def discover_config_files(
     current_dir = Path.cwd() if cwd is None else cwd
     process_env = os.environ if environ is None else environ
     standalone = standalone_paths()
+    source_root = find_source_checkout_root(cwd=current_dir)
+    is_hosted_process = is_hosted_process_environment(process_env)
 
     env_files: list[Path] = []
     active_config_file: Path | None = None
 
-    if not is_source_checkout(cwd=current_dir) and not is_hosted_process_environment(process_env):
+    if source_root is None and not is_hosted_process:
         if standalone.config_file.is_file():
             env_files.append(standalone.config_file)
             active_config_file = standalone.config_file
 
+    if source_root is not None and not is_hosted_process:
+        checkout_env_file = source_root / ".env"
+        if checkout_env_file.is_file():
+            env_files.append(checkout_env_file)
+            active_config_file = checkout_env_file
+
     cwd_env_file = current_dir / ".env"
-    if cwd_env_file.is_file():
+    if cwd_env_file.is_file() and cwd_env_file not in env_files:
         env_files.append(cwd_env_file)
         active_config_file = cwd_env_file
 

--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -57,6 +57,9 @@ def resolve_init_config_file(*, environ: Mapping[str, str] | None = None) -> Pat
     explicit_config = _explicit_config_file(process_env)
     if explicit_config is not None:
         return explicit_config
+    source_root = find_source_checkout_root()
+    if source_root is not None and not is_hosted_process_environment(process_env):
+        return source_root / ".env"
     return standalone_paths().config_file
 
 
@@ -126,6 +129,7 @@ def build_init_config_contents(
     *,
     api_key: str,
     corpus_dir: Path | str | None,
+    include_data_paths: bool = True,
 ) -> str:
     """Return the env-file contents for standalone local CLI setup."""
     normalized_api_key = str(api_key).strip()
@@ -139,23 +143,24 @@ def build_init_config_contents(
     if normalized_corpus_dir is not None:
         lines.append(_env_assignment("POLICYNIM_CORPUS_DIR", normalized_corpus_dir.as_posix()))
 
-    lines.extend(
-        [
-            _env_assignment("POLICYNIM_LANCEDB_URI", standalone.lancedb_uri.as_posix()),
-            _env_assignment(
-                "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
-                standalone.runtime_rules_artifact_path.as_posix(),
-            ),
-            _env_assignment(
-                "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
-                standalone.runtime_evidence_db_path.as_posix(),
-            ),
-            _env_assignment(
-                "POLICYNIM_EVAL_WORKSPACE_DIR",
-                standalone.eval_workspace_dir.as_posix(),
-            ),
-        ]
-    )
+    if include_data_paths:
+        lines.extend(
+            [
+                _env_assignment("POLICYNIM_LANCEDB_URI", standalone.lancedb_uri.as_posix()),
+                _env_assignment(
+                    "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
+                    standalone.runtime_rules_artifact_path.as_posix(),
+                ),
+                _env_assignment(
+                    "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
+                    standalone.runtime_evidence_db_path.as_posix(),
+                ),
+                _env_assignment(
+                    "POLICYNIM_EVAL_WORKSPACE_DIR",
+                    standalone.eval_workspace_dir.as_posix(),
+                ),
+            ]
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -164,10 +169,15 @@ def write_init_config_file(
     destination: Path,
     api_key: str,
     corpus_dir: Path | str | None,
+    include_data_paths: bool = True,
 ) -> Path:
     """Write the standalone init config atomically and return the destination."""
     resolved_destination = destination.expanduser()
-    contents = build_init_config_contents(api_key=api_key, corpus_dir=corpus_dir)
+    contents = build_init_config_contents(
+        api_key=api_key,
+        corpus_dir=corpus_dir,
+        include_data_paths=include_data_paths,
+    )
     resolved_destination.parent.mkdir(parents=True, exist_ok=True)
 
     handle, temp_name = tempfile.mkstemp(

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -96,13 +96,16 @@ def root(
 
 @app.command(
     help=(
-        "Run interactive standalone setup, prompt for NVIDIA_API_KEY and an optional "
+        "Run interactive local setup, prompt for NVIDIA_API_KEY and an optional "
         "custom corpus directory, and write the local PolicyNIM config file."
     ),
 )
 def init() -> None:
-    """Prompt for standalone local CLI settings and write them to an env file."""
+    """Prompt for local CLI settings and write them to an env file."""
     destination = config_discovery.resolve_init_config_file()
+    include_data_paths = not (
+        config_discovery.is_source_checkout() or config_discovery.is_hosted_process_environment()
+    )
     api_key = typer.prompt(
         "NVIDIA_API_KEY",
         default="",
@@ -123,6 +126,7 @@ def init() -> None:
             destination=destination,
             api_key=api_key,
             corpus_dir=resolved_corpus_dir,
+            include_data_paths=include_data_paths,
         )
     except ValueError as exc:
         _exit_with_error(str(exc))
@@ -142,6 +146,7 @@ def init() -> None:
 @app.command()
 def ingest() -> None:
     """Build the local policy index from the shipped corpus."""
+    service = None
     try:
         settings = _load_setup_dependent_settings()
         service = create_ingest_service(settings)
@@ -150,6 +155,8 @@ def ingest() -> None:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
+    finally:
+        _close_service(service)
 
     typer.echo(f"Indexed {result.chunk_count} chunks from {result.document_count} documents.")
     typer.echo(f"Model: {result.embedding_model}")
@@ -173,12 +180,15 @@ def dump_index(
     ] = False,
 ) -> None:
     """Print all indexed chunks in a terminal-friendly format."""
+    service = None
     try:
         settings = _load_setup_dependent_settings()
         service = create_index_dump_service(settings)
         chunks = service.list_chunks()
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
+    finally:
+        _close_service(service)
 
     typer.echo(f"Indexed chunks: {len(chunks)}")
     if count_only:

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -909,6 +909,8 @@ class _BearerProtectedASGIApp:
             response = JSONResponse({"error": "Unauthorized."}, status_code=401)
 
         if auth_result != "authorized":
+            if response is None:
+                response = JSONResponse({"error": "Unauthorized."}, status_code=401)
             _emit_hosted_event(
                 "mcp.auth",
                 auth_result=auth_result or "unauthorized",
@@ -917,7 +919,6 @@ class _BearerProtectedASGIApp:
                 upstream_failure_class=None,
                 request_id=None,
             )
-            assert response is not None
             await response(scope, receive, send)
             return
 
@@ -950,10 +951,15 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
     server = _create_mcp_server(settings, beta_auth_service=beta_auth_service)
     app = server.streamable_http_app()
     if settings.beta_signup_enabled:
-        assert settings.beta_session_secret is not None
+        session_secret = settings.beta_session_secret
+        if session_secret is None or not session_secret.strip():
+            raise ConfigurationError(
+                "POLICYNIM_BETA_SESSION_SECRET must be set when "
+                "POLICYNIM_BETA_SIGNUP_ENABLED is true."
+            )
         app = SessionMiddleware(
             app,
-            secret_key=settings.beta_session_secret,
+            secret_key=session_secret,
             same_site="lax",
             https_only=_beta_session_https_only(settings),
         )

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -882,6 +882,7 @@ class _BearerProtectedASGIApp:
         self._beta_auth_service = beta_auth_service
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Authorize protected MCP HTTP requests before delegating to the app."""
         if scope["type"] != "http" or scope.get("path") != self._protected_path:
             await self._app(scope, receive, send)
             return

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -57,6 +57,7 @@ class NVIDIAEmbedder(Embedder):
         max_retries: int,
         client: OpenAI | Any | None = None,
     ) -> None:
+        """Create an embedder with either an owned or injected SDK client."""
         api_key = api_key.strip()
         if not api_key:
             raise ConfigurationError("NVIDIA_API_KEY is required for embeddings.")
@@ -197,6 +198,7 @@ class NVIDIAReranker(Reranker):
         max_retries: int,
         client: httpx.Client | None = None,
     ) -> None:
+        """Create a reranker with either an owned or injected HTTP client."""
         api_key = api_key.strip()
         if not api_key:
             raise ConfigurationError("NVIDIA_API_KEY is required for reranking.")
@@ -343,6 +345,7 @@ class NVIDIAGenerator(Generator):
         max_retries: int,
         client: OpenAI | Any | None = None,
     ) -> None:
+        """Create a generator with either an owned or injected SDK client."""
         api_key = api_key.strip()
         if not api_key:
             raise ConfigurationError("NVIDIA_API_KEY is required for grounded generation.")
@@ -414,6 +417,7 @@ class NVIDIAPolicyCompiler:
         max_retries: int,
         client: OpenAI | Any | None = None,
     ) -> None:
+        """Create a policy compiler with either an owned or injected SDK client."""
         api_key = api_key.strip()
         if not api_key:
             raise ConfigurationError("NVIDIA_API_KEY is required for policy compilation.")
@@ -478,6 +482,7 @@ class NVIDIAPolicyConformanceEvaluator:
         max_retries: int,
         client: OpenAI | Any | None = None,
     ) -> None:
+        """Create a conformance evaluator with either an owned or injected client."""
         api_key = api_key.strip()
         if not api_key:
             raise ConfigurationError(

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -55,6 +55,7 @@ class NVIDIAEmbedder(Embedder):
         batch_size: int,
         timeout_seconds: float,
         max_retries: int,
+        client: OpenAI | Any | None = None,
     ) -> None:
         api_key = api_key.strip()
         if not api_key:
@@ -63,12 +64,16 @@ class NVIDIAEmbedder(Embedder):
         self._model = model
         self._batch_size = batch_size
         self._max_retries = max_retries
-        self._client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            timeout=timeout_seconds,
-            max_retries=0,
-        )
+        self._owns_client = client is None
+        if client is None:
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=timeout_seconds,
+                max_retries=0,
+            )
+        else:
+            self._client = client
 
     @classmethod
     def from_settings(cls, settings: Settings) -> NVIDIAEmbedder:
@@ -81,6 +86,11 @@ class NVIDIAEmbedder(Embedder):
             timeout_seconds=settings.nvidia_timeout_seconds,
             max_retries=settings.nvidia_max_retries,
         )
+
+    def close(self) -> None:
+        """Release the owned OpenAI client when supported by the SDK."""
+        if self._owns_client:
+            _close_client(self._client)
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed policy chunk text in batches."""
@@ -194,15 +204,18 @@ class NVIDIAReranker(Reranker):
         self._model = model
         self._max_retries = max_retries
         self._owns_client = client is None
-        self._client = client or httpx.Client(
-            base_url=base_url.rstrip("/"),
-            timeout=timeout_seconds,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-        )
+        if client is None:
+            self._client = httpx.Client(
+                base_url=base_url.rstrip("/"),
+                timeout=timeout_seconds,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+            )
+        else:
+            self._client = client
 
     @classmethod
     def from_settings(cls, settings: Settings) -> NVIDIAReranker:
@@ -337,12 +350,15 @@ class NVIDIAGenerator(Generator):
         self._model = model
         self._max_retries = max_retries
         self._owns_client = client is None
-        self._client = client or OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            timeout=timeout_seconds,
-            max_retries=0,
-        )
+        if client is None:
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=timeout_seconds,
+                max_retries=0,
+            )
+        else:
+            self._client = client
 
     @classmethod
     def from_settings(cls, settings: Settings) -> NVIDIAGenerator:
@@ -405,12 +421,15 @@ class NVIDIAPolicyCompiler:
         self._model = model
         self._max_retries = max_retries
         self._owns_client = client is None
-        self._client = client or OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            timeout=timeout_seconds,
-            max_retries=0,
-        )
+        if client is None:
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=timeout_seconds,
+                max_retries=0,
+            )
+        else:
+            self._client = client
 
     @classmethod
     def from_settings(cls, settings: Settings) -> NVIDIAPolicyCompiler:
@@ -468,12 +487,15 @@ class NVIDIAPolicyConformanceEvaluator:
         self._model = model
         self._max_retries = max_retries
         self._owns_client = client is None
-        self._client = client or OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            timeout=timeout_seconds,
-            max_retries=0,
-        )
+        if client is None:
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=timeout_seconds,
+                max_retries=0,
+            )
+        else:
+            self._client = client
 
     @classmethod
     def from_settings(cls, settings: Settings) -> NVIDIAPolicyConformanceEvaluator:

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -308,6 +308,7 @@ class EvalService:
         regenerate: bool,
         max_regenerations: int,
     ) -> list[EvalCaseResult]:
+        """Run live eval cases against an isolated temporary index."""
         with TemporaryDirectory(prefix="policynim-eval-") as temp_dir:
             temp_settings = self._settings.model_copy(
                 update={"lancedb_uri": Path(temp_dir) / "lancedb"}

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -313,7 +313,10 @@ class EvalService:
                 update={"lancedb_uri": Path(temp_dir) / "lancedb"}
             )
             ingest_service = create_ingest_service(temp_settings)
-            ingest_service.run()
+            try:
+                ingest_service.run()
+            finally:
+                _close_component(ingest_service)
 
             search_service = _create_live_search_service(
                 temp_settings,

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Sequence
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from types import TracebackType
 from typing import Protocol
 
 from policynim.contracts import Embedder
@@ -58,6 +59,21 @@ class IngestService:
         self._corpus_root = corpus_root
         self._embedding_model = embedding_model
         self._runtime_rules_artifact_path = runtime_rules_artifact_path
+
+    def __enter__(self) -> IngestService:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release owned provider resources held by this service."""
+        _close_component(self._embedder)
 
     def run(self) -> IngestResult:
         """Load, chunk, embed, and persist the policy corpus."""
@@ -190,3 +206,9 @@ def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> No
 def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
     """Best-effort cleanup for staged artifact files after a failed ingest."""
     staged_path.unlink(missing_ok=True)
+
+
+def _close_component(component: object | None) -> None:
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -61,6 +61,7 @@ class IngestService:
         self._runtime_rules_artifact_path = runtime_rules_artifact_path
 
     def __enter__(self) -> IngestService:
+        """Return this service for context-managed ingest runs."""
         return self
 
     def __exit__(
@@ -69,6 +70,7 @@ class IngestService:
         exc: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Release owned resources when leaving a context-managed ingest run."""
         self.close()
 
     def close(self) -> None:
@@ -209,6 +211,7 @@ def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
 
 
 def _close_component(component: object | None) -> None:
+    """Close an optional owned component when it exposes a close hook."""
     close = getattr(component, "close", None)
     if callable(close):
         close()

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import time
 from collections.abc import Callable
@@ -46,6 +47,7 @@ from policynim.types import (
 )
 
 _DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,11 +74,14 @@ class RuntimeExecutionService:
         self._decision_service = decision_service
         self._evidence_store = evidence_store
         self._confirmer = confirmer
-        self._http_client = http_client or httpx.Client(
-            timeout=_DEFAULT_HTTP_TIMEOUT_SECONDS,
-            follow_redirects=False,
-        )
         self._owns_http_client = http_client is None
+        if http_client is None:
+            self._http_client = httpx.Client(
+                timeout=_DEFAULT_HTTP_TIMEOUT_SECONDS,
+                follow_redirects=False,
+            )
+        else:
+            self._http_client = http_client
         self._shell_timeout_seconds = shell_timeout_seconds
 
     def __enter__(self) -> RuntimeExecutionService:
@@ -353,7 +358,14 @@ def _run_file_write(request: FileWriteActionRequest) -> _ActionExecutionResult:
         staged_path.replace(target_path)
     except OSError:
         if staged_path is not None:
-            staged_path.unlink(missing_ok=True)
+            try:
+                staged_path.unlink(missing_ok=True)
+            except OSError as cleanup_exc:
+                LOGGER.warning(
+                    "Could not remove staged runtime file-write temp file %s: %s",
+                    staged_path,
+                    cleanup_exc,
+                )
         return _ActionExecutionResult(
             succeeded=False,
             metadata=FileWriteExecutionMetadata(path=target_path, bytes_written=0),

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -71,6 +71,7 @@ class RuntimeExecutionService:
         http_client: HTTPRequestClientProtocol | None = None,
         shell_timeout_seconds: float = 300.0,
     ) -> None:
+        """Create an executor with explicit collaborators and owned defaults."""
         self._decision_service = decision_service
         self._evidence_store = evidence_store
         self._confirmer = confirmer
@@ -335,6 +336,7 @@ def _run_shell_command(
 
 
 def _run_file_write(request: FileWriteActionRequest) -> _ActionExecutionResult:
+    """Write a file atomically and report typed write failures."""
     target_path = _resolve_action_path(request.path, base=request.cwd)
     if not target_path.parent.exists():
         return _ActionExecutionResult(

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -41,6 +41,7 @@ class SearchService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
+        _close_component(self._embedder)
         _close_component(self._reranker)
 
     def search(self, request: SearchRequest) -> SearchResult:

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -623,6 +623,17 @@ class HealthCheckResult(StrictModel):
     mcp_url: str | None = None
     reason: str | None = None
 
+    @model_validator(mode="after")
+    def validate_status_shape(self) -> Self:
+        """Keep readiness booleans, status labels, and reason text synchronized."""
+        if self.ready != (self.status == "ok"):
+            raise ValueError("ready must match status.")
+        if self.ready and self.reason is not None:
+            raise ValueError("ready health checks must not include a reason.")
+        if not self.ready and self.reason is None:
+            raise ValueError("not-ready health checks must include a reason.")
+        return self
+
 
 BetaAccountStatus = Literal["active", "suspended"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,8 +126,45 @@ def configure_standalone_cli_environment(
     return workspace, config_root, data_root
 
 
+def configure_checkout_cli_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, Path, Path]:
+    """Simulate running the CLI from a source checkout."""
+    clear_installer_env(monkeypatch)
+
+    checkout_root = tmp_path / "checkout"
+    package_root = checkout_root / "src" / "policynim"
+    package_root.mkdir(parents=True)
+    (checkout_root / "pyproject.toml").write_text(
+        "[project]\nname = 'policynim'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(checkout_root)
+
+    config_root = tmp_path / "user-config"
+    data_root = tmp_path / "user-data"
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_config_path",
+        lambda *args, **kwargs: config_root,
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_data_path",
+        lambda *args, **kwargs: data_root,
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+
+    return checkout_root, config_root, data_root
+
+
 class MockIngestService:
     """Static ingest service for CLI tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
 
     def run(self) -> IngestResult:
         return IngestResult(
@@ -139,6 +176,9 @@ class MockIngestService:
             chunk_count=24,
             embedding_dimension=2,
         )
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockSearchService:
@@ -404,6 +444,9 @@ class MockPreflightService:
 class MockIndexDumpService:
     """Static dump service for CLI tests."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def list_chunks(self) -> list[PolicyChunk]:
         return [
             PolicyChunk(
@@ -420,6 +463,9 @@ class MockIndexDumpService:
                 ),
             )
         ]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockRuntimeDecisionService:
@@ -791,9 +837,10 @@ def make_stderr_prompt_confirmer():
 
 
 def test_ingest_command_prints_summary(monkeypatch) -> None:
+    service = MockIngestService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_ingest_service",
-        lambda settings: MockIngestService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["ingest"])
@@ -801,6 +848,7 @@ def test_ingest_command_prints_summary(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "Indexed 24 chunks from 8 documents." in result.stdout
     assert "mock-model" in result.stdout
+    assert service.closed is True
 
 
 def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
@@ -813,6 +861,24 @@ def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "chunk/vector mismatch" in result.stderr
+
+
+def test_ingest_command_closes_service_when_run_fails(monkeypatch) -> None:
+    class FailingIngestService(MockIngestService):
+        def run(self) -> IngestResult:
+            raise ValueError("chunk/vector mismatch")
+
+    service = FailingIngestService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_ingest_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(app, ["ingest"])
+
+    assert result.exit_code == 1
+    assert "chunk/vector mismatch" in result.stderr
+    assert service.closed is True
 
 
 def test_search_command_prints_json(monkeypatch) -> None:
@@ -1349,9 +1415,10 @@ def test_preflight_command_formats_route_validation_errors(
 
 
 def test_dump_index_command_prints_chunks(monkeypatch) -> None:
+    service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
-        lambda settings: MockIndexDumpService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["dump-index"])
@@ -1360,18 +1427,21 @@ def test_dump_index_command_prints_chunks(monkeypatch) -> None:
     assert "Indexed chunks: 1" in result.stdout
     assert "BACKEND-1" in result.stdout
     assert "Use request ids in backend logs." in result.stdout
+    assert service.closed is True
 
 
 def test_dump_index_count_only_prints_only_count(monkeypatch) -> None:
+    service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
-        lambda settings: MockIndexDumpService(),
+        lambda settings: service,
     )
 
     result = runner.invoke(app, ["dump-index", "--count-only"])
 
     assert result.exit_code == 0
     assert result.stdout == "Indexed chunks: 1\n"
+    assert service.closed is True
 
 
 def test_help_includes_dump_index_command() -> None:
@@ -1464,6 +1534,21 @@ def test_init_command_writes_config_and_prints_next_step(
         f"'{data_root / 'runtime' / 'runtime_evidence.sqlite3'}'\n"
         f"POLICYNIM_EVAL_WORKSPACE_DIR='{data_root / 'evals' / 'workspace'}'\n"
     )
+
+
+def test_init_command_writes_checkout_dotenv_without_standalone_path_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    checkout_root, config_root, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["init"], input="nvapi-test-key\n\n")
+
+    dotenv_path = checkout_root / ".env"
+    assert result.exit_code == 0
+    assert str(dotenv_path) in result.stdout
+    assert dotenv_path.read_text(encoding="utf-8") == "NVIDIA_API_KEY='nvapi-test-key'\n"
+    assert not (config_root / "config.env").exists()
 
 
 def test_init_command_rejects_blank_required_api_key(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,7 @@ class MockIngestService:
     """Static ingest service for CLI tests."""
 
     def __init__(self) -> None:
+        """Track whether the CLI closed the service."""
         self.closed = False
 
     def run(self) -> IngestResult:
@@ -178,6 +179,7 @@ class MockIngestService:
         )
 
     def close(self) -> None:
+        """Record that the CLI released the service."""
         self.closed = True
 
 
@@ -445,6 +447,7 @@ class MockIndexDumpService:
     """Static dump service for CLI tests."""
 
     def __init__(self) -> None:
+        """Track whether the CLI closed the dump service."""
         self.closed = False
 
     def list_chunks(self) -> list[PolicyChunk]:
@@ -465,6 +468,7 @@ class MockIndexDumpService:
         ]
 
     def close(self) -> None:
+        """Record that the CLI released the dump service."""
         self.closed = True
 
 
@@ -837,6 +841,7 @@ def make_stderr_prompt_confirmer():
 
 
 def test_ingest_command_prints_summary(monkeypatch) -> None:
+    """Print ingest output and close the created service on success."""
     service = MockIngestService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_ingest_service",
@@ -852,6 +857,7 @@ def test_ingest_command_prints_summary(monkeypatch) -> None:
 
 
 def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
+    """Surface ingest construction failures as CLI errors."""
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_ingest_service",
         lambda settings: (_ for _ in ()).throw(ValueError("chunk/vector mismatch")),
@@ -864,8 +870,11 @@ def test_ingest_command_surfaces_value_errors(monkeypatch) -> None:
 
 
 def test_ingest_command_closes_service_when_run_fails(monkeypatch) -> None:
+    """Close the created ingest service when its run fails."""
+
     class FailingIngestService(MockIngestService):
         def run(self) -> IngestResult:
+            """Raise a deterministic ingest failure."""
             raise ValueError("chunk/vector mismatch")
 
     service = FailingIngestService()
@@ -1415,6 +1424,7 @@ def test_preflight_command_formats_route_validation_errors(
 
 
 def test_dump_index_command_prints_chunks(monkeypatch) -> None:
+    """Print dump-index details and close the created service."""
     service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
@@ -1431,6 +1441,7 @@ def test_dump_index_command_prints_chunks(monkeypatch) -> None:
 
 
 def test_dump_index_count_only_prints_only_count(monkeypatch) -> None:
+    """Print only the dump-index count and close the created service."""
     service = MockIndexDumpService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_index_dump_service",
@@ -1540,6 +1551,7 @@ def test_init_command_writes_checkout_dotenv_without_standalone_path_overrides(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """Write checkout env config without standalone data-path defaults."""
     checkout_root, config_root, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
 
     result = runner.invoke(app, ["init"], input="nvapi-test-key\n\n")

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -59,13 +59,21 @@ def test_contributor_guide_and_env_examples_include_runtime_settings() -> None:
 
 
 def test_standalone_setup_docs_use_installed_cli_entrypoint() -> None:
-    for path in STANDALONE_SETUP_DOCS:
-        text = _read_text(path)
-        assert "uv run policynim init" not in text, f"{path.name} should not require uv for init"
-        assert "policynim init" in text, f"{path.name} should document standalone init"
-
     workflows_text = _read_text(WORKFLOWS_GUIDE)
     assert "policynim init\npolicynim ingest" in workflows_text
+    assert "Installed copies should keep using" in workflows_text
+    assert "the direct `policynim ...` entrypoint" in workflows_text
+
+    for path in STANDALONE_SETUP_DOCS:
+        text = _read_text(path)
+        assert "policynim init" in text, f"{path.name} should document standalone init"
+
+
+def test_source_checkout_setup_docs_state_init_writes_checkout_dotenv() -> None:
+    for path in STANDALONE_SETUP_DOCS:
+        text = _read_text(path)
+        assert "uv run policynim init" in text
+        assert "checkout `.env`" in text
 
 
 def test_production_env_example_uses_absolute_runtime_paths() -> None:

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -59,6 +59,7 @@ def test_contributor_guide_and_env_examples_include_runtime_settings() -> None:
 
 
 def test_standalone_setup_docs_use_installed_cli_entrypoint() -> None:
+    """Document standalone setup with the installed CLI entrypoint."""
     workflows_text = _read_text(WORKFLOWS_GUIDE)
     assert "policynim init\npolicynim ingest" in workflows_text
     assert "Installed copies should keep using" in workflows_text
@@ -70,6 +71,7 @@ def test_standalone_setup_docs_use_installed_cli_entrypoint() -> None:
 
 
 def test_source_checkout_setup_docs_state_init_writes_checkout_dotenv() -> None:
+    """Document source-checkout init as writing the checkout env file."""
     for path in STANDALONE_SETUP_DOCS:
         text = _read_text(path)
         assert "uv run policynim init" in text

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -26,13 +26,24 @@ from policynim.types import (
 class MockIngestService:
     """Capture the isolated live eval index path."""
 
-    def __init__(self, settings: Settings, seen_paths: list[Path]) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        seen_paths: list[Path],
+        *,
+        closed: list[bool] | None = None,
+    ) -> None:
         self._settings = settings
         self._seen_paths = seen_paths
+        self._closed = closed
 
     def run(self):
         self._seen_paths.append(self._settings.lancedb_uri)
         return None
+
+    def close(self) -> None:
+        if self._closed is not None:
+            self._closed.append(True)
 
 
 class MockSearchService:
@@ -286,10 +297,11 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
         eval_workspace_dir=tmp_path / "workspace",
     )
     seen_paths: list[Path] = []
+    closed: list[bool] = []
 
     monkeypatch.setattr(
         "policynim.services.eval.create_ingest_service",
-        lambda active_settings: MockIngestService(active_settings, seen_paths),
+        lambda active_settings: MockIngestService(active_settings, seen_paths, closed=closed),
     )
     monkeypatch.setattr(
         "policynim.services.eval._create_live_search_service",
@@ -309,6 +321,7 @@ def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: 
     assert seen_paths
     assert seen_paths[0] != settings.lancedb_uri
     assert settings.lancedb_uri == tmp_path / "caller-index"
+    assert closed == [True]
 
 
 def test_eval_service_live_nemo_backend_uses_isolated_conformance_service(

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -33,6 +33,7 @@ class MockIngestService:
         *,
         closed: list[bool] | None = None,
     ) -> None:
+        """Store live-eval ingest settings and close tracking hooks."""
         self._settings = settings
         self._seen_paths = seen_paths
         self._closed = closed
@@ -42,6 +43,7 @@ class MockIngestService:
         return None
 
     def close(self) -> None:
+        """Record that live-eval cleanup closed the ingest service."""
         if self._closed is not None:
             self._closed.append(True)
 
@@ -292,6 +294,7 @@ def test_eval_service_regeneration_runs_for_preflight_cases_only(tmp_path: Path)
 
 
 def test_eval_service_live_mode_uses_isolated_temp_index(monkeypatch, tmp_path: Path) -> None:
+    """Close live ingest while keeping caller index settings unchanged."""
     settings = Settings(
         lancedb_uri=tmp_path / "caller-index",
         eval_workspace_dir=tmp_path / "workspace",

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -17,11 +17,17 @@ from policynim.types import EmbeddedChunk
 class MockEmbedder:
     """Deterministic offline embedder for service tests."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         return [[float(index + 1), float(len(text))] for index, text in enumerate(texts)]
 
     def embed_query(self, text: str) -> list[float]:
         return [1.0, float(len(text))]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class FailingEmbedder:
@@ -254,3 +260,18 @@ def test_ingest_service_rejects_directory_runtime_rules_artifact_before_index_re
 
     assert store.replace_calls == 0
     assert not list(artifact_path.parent.glob(".runtime_rules.json.*.tmp"))
+
+
+def test_ingest_service_close_closes_embedder(tmp_path: Path) -> None:
+    embedder = MockEmbedder()
+    service = IngestService(
+        embedder=embedder,
+        index_store=RecordingIndexStore(uri=tmp_path / "index", table_name="policy_chunks"),
+        corpus_root=tmp_path / "policies",
+        embedding_model="mock-embedder",
+        runtime_rules_artifact_path=tmp_path / "runtime" / "runtime_rules.json",
+    )
+
+    service.close()
+
+    assert embedder.closed is True

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -18,6 +18,7 @@ class MockEmbedder:
     """Deterministic offline embedder for service tests."""
 
     def __init__(self) -> None:
+        """Track whether the ingest service closed the embedder."""
         self.closed = False
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
@@ -27,6 +28,7 @@ class MockEmbedder:
         return [1.0, float(len(text))]
 
     def close(self) -> None:
+        """Record that the embedder was closed."""
         self.closed = True
 
 
@@ -263,6 +265,7 @@ def test_ingest_service_rejects_directory_runtime_rules_artifact_before_index_re
 
 
 def test_ingest_service_close_closes_embedder(tmp_path: Path) -> None:
+    """Release the embedder when the ingest service is closed."""
     embedder = MockEmbedder()
     service = IngestService(
         embedder=embedder,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -867,6 +867,7 @@ def test_streamable_http_app_requires_non_empty_session_secret_without_settings_
     monkeypatch: pytest.MonkeyPatch,
     secret: str | None,
 ) -> None:
+    """Guard hosted beta startup even when settings validation is bypassed."""
     _stub_streamable_http_server(monkeypatch)
 
     settings = Settings.model_construct(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -862,6 +862,24 @@ def test_streamable_http_app_keeps_mcp_open_when_auth_disabled(monkeypatch) -> N
     assert response.json() == {"ok": True}
 
 
+@pytest.mark.parametrize("secret", [None, "", "   "])
+def test_streamable_http_app_requires_non_empty_session_secret_without_settings_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    secret: str | None,
+) -> None:
+    _stub_streamable_http_server(monkeypatch)
+
+    settings = Settings.model_construct(
+        beta_signup_enabled=True,
+        beta_session_secret=secret,
+        mcp_require_auth=True,
+        mcp_public_base_url="https://beta.example.com",
+    )
+
+    with pytest.raises(ConfigurationError, match="POLICYNIM_BETA_SESSION_SECRET"):
+        mcp_module._build_streamable_http_app(settings)
+
+
 def test_streamable_http_app_rejects_missing_bearer_token(monkeypatch) -> None:
     _stub_streamable_http_server(monkeypatch)
 

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -39,9 +39,11 @@ class CloseableEmbeddingsClient:
     """Embeddings client stub that exposes a close hook."""
 
     def __init__(self) -> None:
+        """Track whether the adapter closed the injected SDK client."""
         self.closed = False
 
     def close(self) -> None:
+        """Record that the SDK client was closed."""
         self.closed = True
 
 
@@ -80,6 +82,7 @@ def test_embedder_classifies_upstream_rate_limits() -> None:
 
 
 def test_embedder_close_closes_owned_client() -> None:
+    """Close the owned SDK client created by the embedder."""
     injected_client = CloseableEmbeddingsClient()
     embedder = NVIDIAEmbedder(
         api_key="test-key",

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -35,6 +35,16 @@ class RaisingEmbeddingsClient:
         raise self._exc
 
 
+class CloseableEmbeddingsClient:
+    """Embeddings client stub that exposes a close hook."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_embedder_classifies_upstream_auth_failures() -> None:
     embedder = NVIDIAEmbedder(
         api_key="test-key",
@@ -67,3 +77,35 @@ def test_embedder_classifies_upstream_rate_limits() -> None:
         embedder.embed_query("backend logging")
 
     assert excinfo.value.failure_class == "rate_limit"
+
+
+def test_embedder_close_closes_owned_client() -> None:
+    injected_client = CloseableEmbeddingsClient()
+    embedder = NVIDIAEmbedder(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        batch_size=2,
+        timeout_seconds=1,
+        max_retries=0,
+        client=injected_client,
+    )
+
+    embedder.close()
+
+    assert injected_client.closed is False
+
+    owned_client = CloseableEmbeddingsClient()
+    owned_embedder = NVIDIAEmbedder(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        batch_size=2,
+        timeout_seconds=1,
+        max_retries=0,
+    )
+    owned_embedder._client = owned_client  # type: ignore[assignment]
+
+    owned_embedder.close()
+
+    assert owned_client.closed is True

--- a/tests/test_nvidia_generator.py
+++ b/tests/test_nvidia_generator.py
@@ -34,13 +34,16 @@ class MockOpenAIClient:
     """OpenAI client stub with the minimum chat surface."""
 
     def __init__(self, content: str) -> None:
+        """Create a falsy chat client with close tracking."""
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
         self.closed = False
 
     def close(self) -> None:
+        """Record that the generator closed the client."""
         self.closed = True
 
     def __bool__(self) -> bool:
+        """Behave like a falsy injected client."""
         return False
 
 
@@ -204,6 +207,7 @@ def test_generator_requires_api_key() -> None:
 
 
 def test_generator_preserves_falsy_injected_client() -> None:
+    """Use a falsy injected client instead of replacing it."""
     client = MockOpenAIClient('{"summary":"ok","citation_ids":["BACKEND-1"]}')
     generator = NVIDIAGenerator(
         api_key="test-key",

--- a/tests/test_nvidia_generator.py
+++ b/tests/test_nvidia_generator.py
@@ -35,6 +35,13 @@ class MockOpenAIClient:
 
     def __init__(self, content: str) -> None:
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __bool__(self) -> bool:
+        return False
 
 
 class MockRateLimitError(RateLimitError):
@@ -194,6 +201,22 @@ def test_generator_requires_api_key() -> None:
             timeout_seconds=1,
             max_retries=0,
         )
+
+
+def test_generator_preserves_falsy_injected_client() -> None:
+    client = MockOpenAIClient('{"summary":"ok","citation_ids":["BACKEND-1"]}')
+    generator = NVIDIAGenerator(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1",
+        timeout_seconds=1,
+        max_retries=0,
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert generator._client is client
+    generator.close()
+    assert client.closed is False
 
 
 def make_chunk() -> ScoredChunk:

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -41,13 +41,16 @@ class MockOpenAIClient:
     """OpenAI client stub with the minimum chat surface."""
 
     def __init__(self, content: str) -> None:
+        """Create a falsy chat client with close tracking."""
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
         self.closed = False
 
     def close(self) -> None:
+        """Record that the compiler closed the client."""
         self.closed = True
 
     def __bool__(self) -> bool:
+        """Behave like a falsy injected client."""
         return False
 
 
@@ -227,6 +230,7 @@ def test_policy_compiler_close_leaves_injected_client_open() -> None:
 
 
 def test_policy_compiler_preserves_falsy_injected_client() -> None:
+    """Use a falsy injected client instead of replacing it."""
     client = MockOpenAIClient('{"required_steps":[]}')
     compiler = make_compiler(client)
 

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -47,6 +47,9 @@ class MockOpenAIClient:
     def close(self) -> None:
         self.closed = True
 
+    def __bool__(self) -> bool:
+        return False
+
 
 class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
@@ -220,6 +223,15 @@ def test_policy_compiler_close_leaves_injected_client_open() -> None:
 
     compiler.close()
 
+    assert client.closed is False
+
+
+def test_policy_compiler_preserves_falsy_injected_client() -> None:
+    client = MockOpenAIClient('{"required_steps":[]}')
+    compiler = make_compiler(client)
+
+    assert compiler._client is client
+    compiler.close()
     assert client.closed is False
 
 

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -48,6 +48,9 @@ class MockOpenAIClient:
     def close(self) -> None:
         self.closed = True
 
+    def __bool__(self) -> bool:
+        return False
+
 
 class MockRateLimitError(RateLimitError):
     """Minimal rate-limit error subclass for provider classification tests."""
@@ -198,6 +201,15 @@ def test_policy_conformance_close_leaves_injected_client_open() -> None:
 
     evaluator.close()
 
+    assert client.closed is False
+
+
+def test_policy_conformance_preserves_falsy_injected_client() -> None:
+    client = MockOpenAIClient('{"final_adherence_score":1}')
+    evaluator = make_evaluator(client)
+
+    assert evaluator._client is client
+    evaluator.close()
     assert client.closed is False
 
 

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -42,13 +42,16 @@ class MockOpenAIClient:
     """OpenAI client stub with the minimum chat surface."""
 
     def __init__(self, content: str) -> None:
+        """Create a falsy chat client with close tracking."""
         self.chat = SimpleNamespace(completions=MockChatCompletions(content))
         self.closed = False
 
     def close(self) -> None:
+        """Record that the evaluator closed the client."""
         self.closed = True
 
     def __bool__(self) -> bool:
+        """Behave like a falsy injected client."""
         return False
 
 
@@ -205,6 +208,7 @@ def test_policy_conformance_close_leaves_injected_client_open() -> None:
 
 
 def test_policy_conformance_preserves_falsy_injected_client() -> None:
+    """Use a falsy injected client instead of replacing it."""
     client = MockOpenAIClient('{"final_adherence_score":1}')
     evaluator = make_evaluator(client)
 

--- a/tests/test_nvidia_reranker.py
+++ b/tests/test_nvidia_reranker.py
@@ -39,6 +39,7 @@ class SpyRerankClient:
         self.closed = True
 
     def __bool__(self) -> bool:
+        """Behave like a falsy injected client."""
         return False
 
 
@@ -140,6 +141,7 @@ def test_reranker_close_does_not_close_injected_client() -> None:
 
 
 def test_reranker_preserves_falsy_injected_client() -> None:
+    """Use a falsy injected client instead of replacing it."""
     client = SpyRerankClient({"scores": [0.5]})
     reranker = NVIDIAReranker(
         api_key="test-key",

--- a/tests/test_nvidia_reranker.py
+++ b/tests/test_nvidia_reranker.py
@@ -38,6 +38,9 @@ class SpyRerankClient:
     def close(self) -> None:
         self.closed = True
 
+    def __bool__(self) -> bool:
+        return False
+
 
 class OwnedClientSpy:
     """Tracks lifecycle of internally created clients."""
@@ -134,6 +137,22 @@ def test_reranker_close_does_not_close_injected_client() -> None:
     reranker.close()
 
     assert not client.closed
+
+
+def test_reranker_preserves_falsy_injected_client() -> None:
+    client = SpyRerankClient({"scores": [0.5]})
+    reranker = NVIDIAReranker(
+        api_key="test-key",
+        model="mock-model",
+        base_url="https://example.invalid/v1/retrieval",
+        timeout_seconds=1,
+        max_retries=0,
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert reranker._client is client
+    reranker.close()
+    assert client.closed is False
 
 
 def test_reranker_close_closes_owned_client(monkeypatch) -> None:

--- a/tests/test_runtime_execution_service.py
+++ b/tests/test_runtime_execution_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+import policynim.services.runtime_execution as runtime_execution_module
 from policynim.errors import RuntimeEvidencePersistenceError
 from policynim.services.runtime_execution import RuntimeExecutionService
 from policynim.types import (
@@ -276,6 +277,41 @@ def test_runtime_execution_service_runs_allowed_file_write(tmp_path: Path) -> No
         bytes_written=len(b"hello world"),
     )
     assert [event.event_kind for event in evidence_store.events] == ["decision", "allowed"]
+
+
+def test_runtime_execution_service_returns_failed_when_file_write_cleanup_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence_store = StubEvidenceStore()
+    service = RuntimeExecutionService(
+        decision_service=StubDecisionService("allow"),
+        evidence_store=evidence_store,
+    )
+
+    def fail_replace(self: Path, target: Path) -> Path:
+        raise OSError("replace failed")
+
+    def fail_unlink(self: Path, *, missing_ok: bool = False) -> None:
+        del missing_ok
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(runtime_execution_module.Path, "replace", fail_replace)
+    monkeypatch.setattr(runtime_execution_module.Path, "unlink", fail_unlink)
+
+    result = service.execute(
+        FileWriteActionRequest(
+            kind="file_write",
+            task="Write a file with failing temp cleanup.",
+            cwd=tmp_path,
+            path=Path("notes.txt"),
+            content="payload",
+        )
+    )
+
+    assert result.execution_outcome == "failed"
+    assert result.failure_class == "io_error"
+    assert [event.event_kind for event in evidence_store.events] == ["decision", "failed"]
 
 
 def test_runtime_execution_service_returns_failed_for_http_transport_error(

--- a/tests/test_runtime_execution_service.py
+++ b/tests/test_runtime_execution_service.py
@@ -283,6 +283,7 @@ def test_runtime_execution_service_returns_failed_when_file_write_cleanup_also_f
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Preserve the primary file-write failure when temp cleanup also fails."""
     evidence_store = StubEvidenceStore()
     service = RuntimeExecutionService(
         decision_service=StubDecisionService("allow"),
@@ -290,9 +291,11 @@ def test_runtime_execution_service_returns_failed_when_file_write_cleanup_also_f
     )
 
     def fail_replace(self: Path, target: Path) -> Path:
+        """Simulate an atomic replace failure."""
         raise OSError("replace failed")
 
     def fail_unlink(self: Path, *, missing_ok: bool = False) -> None:
+        """Simulate cleanup failure for the staged temp file."""
         del missing_ok
         raise OSError("cleanup failed")
 

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -14,6 +14,9 @@ from policynim.types import EmbeddedChunk, PolicyChunk, PolicyMetadata, ScoredCh
 class MockEmbedder:
     """Returns deterministic query embeddings."""
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def embed_query(self, text: str) -> list[float]:
         mapping = {
             "backend logs": [1.0, 0.0],
@@ -24,6 +27,9 @@ class MockEmbedder:
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         return [[1.0, 0.0] for _ in texts]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockIndexStore:
@@ -216,16 +222,18 @@ def test_search_service_requires_existing_index() -> None:
         service.search(SearchRequest(query="backend logs", top_k=1))
 
 
-def test_search_service_close_closes_reranker() -> None:
+def test_search_service_close_closes_embedder_and_reranker() -> None:
+    embedder = MockEmbedder()
     reranker = MockReranker()
     service = SearchService(
-        embedder=MockEmbedder(),
+        embedder=embedder,
         index_store=MockIndexStore([make_chunk(chunk_id="BACKEND-1", domain="backend")]),
         reranker=reranker,
     )
 
     service.close()
 
+    assert embedder.closed is True
     assert reranker.closed is True
 
 

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -15,6 +15,7 @@ class MockEmbedder:
     """Returns deterministic query embeddings."""
 
     def __init__(self) -> None:
+        """Track whether the search service closed the embedder."""
         self.closed = False
 
     def embed_query(self, text: str) -> list[float]:
@@ -29,6 +30,7 @@ class MockEmbedder:
         return [[1.0, 0.0] for _ in texts]
 
     def close(self) -> None:
+        """Record that the embedder was closed."""
         self.closed = True
 
 
@@ -223,6 +225,7 @@ def test_search_service_requires_existing_index() -> None:
 
 
 def test_search_service_close_closes_embedder_and_reranker() -> None:
+    """Release both owned search providers when the service closes."""
     embedder = MockEmbedder()
     reranker = MockReranker()
     service = SearchService(

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -535,10 +535,56 @@ def test_settings_keeps_checkout_defaults_when_running_from_source_checkout(
 def test_init_config_file_targets_checkout_dotenv(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Ensure source checkout init writes the env file the checkout owns."""
     clear_config_precedence_env(monkeypatch)
     checkout_root, _, _ = configure_checkout_discovery(monkeypatch, tmp_path)
 
     assert config_discovery.resolve_init_config_file() == checkout_root / ".env"
+
+
+def test_settings_loads_checkout_dotenv_from_subdirectory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Load the checkout root env file when commands run below the root."""
+    clear_config_precedence_env(monkeypatch)
+    checkout_root, _, _ = configure_checkout_discovery(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", POLICYNIM_DEFAULT_TOP_K="12")
+    subdirectory = checkout_root / "docs"
+    subdirectory.mkdir()
+    monkeypatch.chdir(subdirectory)
+
+    discovery = config_discovery.discover_config_files(
+        cwd=subdirectory,
+        environ=dict(config_discovery.os.environ),
+    )
+    settings = Settings()
+
+    assert discovery.env_files == (checkout_root / ".env",)
+    assert discovery.active_config_file == checkout_root / ".env"
+    assert settings.default_top_k == 12
+
+
+def test_settings_prefers_subdirectory_dotenv_over_checkout_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Let a nearer subdirectory env file override the checkout root env file."""
+    clear_config_precedence_env(monkeypatch)
+    checkout_root, _, _ = configure_checkout_discovery(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", POLICYNIM_DEFAULT_TOP_K="12")
+    subdirectory = checkout_root / "docs"
+    subdirectory.mkdir()
+    write_env_file(subdirectory / ".env", POLICYNIM_DEFAULT_TOP_K="13")
+    monkeypatch.chdir(subdirectory)
+
+    discovery = config_discovery.discover_config_files(
+        cwd=subdirectory,
+        environ=dict(config_discovery.os.environ),
+    )
+    settings = Settings()
+
+    assert discovery.env_files == (checkout_root / ".env", subdirectory / ".env")
+    assert discovery.active_config_file == subdirectory / ".env"
+    assert settings.default_top_k == 13
 
 
 def test_settings_keeps_hosted_defaults_out_of_standalone_platformdirs(
@@ -649,6 +695,7 @@ def test_document_section_rejects_inverted_line_ranges() -> None:
 
 
 def test_health_check_result_rejects_drifted_status_fields() -> None:
+    """Reject readiness/status/reason combinations that disagree."""
     with pytest.raises(ValidationError, match="ready must match status"):
         HealthCheckResult(
             status="ok",

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -13,6 +13,7 @@ from policynim.settings import Settings
 from policynim.types import (
     DEFAULT_TOP_K,
     DocumentSection,
+    HealthCheckResult,
     HTTPRequestActionRequest,
     ParsedRuntimeRule,
     RuntimeActionRequest,
@@ -531,6 +532,15 @@ def test_settings_keeps_checkout_defaults_when_running_from_source_checkout(
     assert settings.eval_workspace_dir == Path("data/evals/workspace")
 
 
+def test_init_config_file_targets_checkout_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clear_config_precedence_env(monkeypatch)
+    checkout_root, _, _ = configure_checkout_discovery(monkeypatch, tmp_path)
+
+    assert config_discovery.resolve_init_config_file() == checkout_root / ".env"
+
+
 def test_settings_keeps_hosted_defaults_out_of_standalone_platformdirs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -635,6 +645,34 @@ def test_document_section_rejects_inverted_line_ranges() -> None:
             content="Impossible line range.",
             start_line=8,
             end_line=7,
+        )
+
+
+def test_health_check_result_rejects_drifted_status_fields() -> None:
+    with pytest.raises(ValidationError, match="ready must match status"):
+        HealthCheckResult(
+            status="ok",
+            ready=False,
+            table_name="policy_chunks",
+            row_count=0,
+            reason="index missing",
+        )
+
+    with pytest.raises(ValidationError, match="not-ready health checks must include a reason"):
+        HealthCheckResult(
+            status="error",
+            ready=False,
+            table_name="policy_chunks",
+            row_count=0,
+        )
+
+    with pytest.raises(ValidationError, match="ready health checks must not include a reason"):
+        HealthCheckResult(
+            status="ok",
+            ready=True,
+            table_name="policy_chunks",
+            row_count=1,
+            reason="stale startup failure",
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2813,6 +2813,7 @@ nvidia-guardrails = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "ruff" },
 ]
 test = [
@@ -2847,6 +2848,7 @@ provides-extras = ["nvidia-guardrails", "nvidia-eval", "nvidia-eval-launcher"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.3.0" },
+    { name = "pyright", specifier = "==1.1.409" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
 test = [{ name = "pytest", specifier = "==8.3.4" }]
@@ -3227,6 +3229,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/d7/c5d1381248a33975ccc864a0f980f93270ecc35354de8646c8a16443cccb/pymilvus-2.6.12.tar.gz", hash = "sha256:8323e990dc305e607fef525498eb779e42940a69e0691dde009cd02d48845f7a", size = 1584521, upload-time = "2026-04-09T07:49:11.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/5d/44b0fa94c91503381e6f12298277f84f8e7b0bb00715ab89fc273c4d681e/pymilvus-2.6.12-py3-none-any.whl", hash = "sha256:69051b8b62712f157b2b50aeb7bde7fd7cdb5940aac0122094eb3cd58bc20f0d", size = 315183, upload-time = "2026-04-09T07:49:09.013Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Consolidates the stale stabilization train into one PR from current `main`.

- fixes source-checkout setup so `policynim init` writes the checkout `.env` that source runs actually load, while installed standalone runtimes keep the user config file path
- replaces hosted MCP beta session `assert` handling with explicit non-empty secret guards and defensive auth failure responses
- prevents runtime file-write temp cleanup failures from masking the primary typed `io_error` result or terminal evidence outcome
- adds deterministic provider/service cleanup for owned NVIDIA clients and service-created providers, with injected clients selected by `client is None`
- adds `HealthCheckResult` invariants for readiness/status/reason parity
- makes `pyright==1.1.409` an official dev dependency and CI check

Supersedes the overlapping stale PRs #44, #47, #48, and #49. This branch also includes the current local docs-alignment base commit that overlaps with #45.

## Test Plan

- `uv run ruff check`
- `uv run pytest -q -m "not live"`
- `uv run pyright`
- `uv run pytest -q`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- Optional live evidence: `uv run pytest -q -m live tests/test_nvidia_live.py`

Hosted MCP live was not run because hosted URL/token env vars were not set. Docker live tests were not run because Docker tests were not explicitly opted in.
