### PR TITLE
Harden hosted beta readiness smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
       - name: Sync dependencies
         run: uv sync --group test --group dev
 
-      - name: Run pytest
-        run: uv run pytest -q -m "not live"
+      - name: Run offline pytest
+        run: uv run pytest -q -m "not live and not docker_live"

--- a/.github/workflows/hosted-smoke.yml
+++ b/.github/workflows/hosted-smoke.yml
@@ -3,6 +3,9 @@ name: Hosted Beta Smoke
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   hosted-smoke:
     runs-on: ubuntu-24.04

--- a/.github/workflows/hosted-smoke.yml
+++ b/.github/workflows/hosted-smoke.yml
@@ -1,0 +1,39 @@
+name: Hosted Beta Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hosted-smoke:
+    runs-on: ubuntu-24.04
+    env:
+      POLICYNIM_BETA_MCP_URL: ${{ secrets.POLICYNIM_BETA_MCP_URL }}
+      POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate hosted smoke secrets
+        run: |
+          test -n "$POLICYNIM_BETA_MCP_URL" || {
+            echo "POLICYNIM_BETA_MCP_URL secret is required for hosted smoke tests."
+            exit 1
+          }
+          test -n "$POLICYNIM_BETA_MCP_TOKEN" || {
+            echo "POLICYNIM_BETA_MCP_TOKEN secret is required for hosted smoke tests."
+            exit 1
+          }
+
+      - name: Sync dependencies
+        run: uv sync --group test --group dev
+
+      - name: Run hosted live smoke
+        run: uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py

--- a/docs/hosted-beta-operations.md
+++ b/docs/hosted-beta-operations.md
@@ -102,9 +102,9 @@ GitHub Actions smoke:
   hosted service or baked local index is not ready yet
 - retry after the service becomes healthy. If you operate the service, check the
   Railway deploy state and `/healthz` first
-- if `/healthz` includes `Local index readiness could not be inspected`, inspect
-  the exception class and message in the payload, then check the Railway deploy
-  logs for index path, volume, or file-permission failures
+- if `/healthz` includes `Local index readiness could not be inspected`, use the
+  sanitized exception class in the payload, then check the Railway deploy logs
+  for detailed index path, volume, or file-permission failures
 - if `/healthz` says the local index is missing or empty, confirm the latest
   build received `NVIDIA_API_KEY`, rerun the deploy so `policynim ingest` bakes
   the index, and confirm `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`

--- a/docs/hosted-beta-operations.md
+++ b/docs/hosted-beta-operations.md
@@ -36,6 +36,41 @@ Hosted beta notes:
 - if you run the opt-in live smoke test locally, export the same deployed values
   as `POLICYNIM_BETA_MCP_URL` and `POLICYNIM_BETA_MCP_TOKEN`
 
+## 60-Day Readiness Verification
+
+Use this checklist before calling the hosted beta ready for a release window.
+The normal CI suite stays offline; this smoke path intentionally calls the
+deployed Railway service and NVIDIA-backed MCP tools.
+
+Required deployed-service checks:
+
+```bash
+curl -fsS https://<railway-domain>/healthz
+
+export POLICYNIM_BETA_MCP_URL=https://<railway-domain>/mcp
+export POLICYNIM_BETA_MCP_TOKEN=<beta-token>
+uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py
+```
+
+Expected evidence:
+
+- `/healthz` returns `200` with `ready: true`, `row_count` greater than `0`, and
+  `mcp_url` matching `https://<railway-domain>/mcp`
+- invalid bearer-token smoke returns `401 {"error":"Unauthorized."}`
+- authenticated MCP smoke lists exactly `policy_preflight` and `policy_search`
+- `policy_search` returns at least one cited hit for the smoke query
+- `policy_preflight` returns a grounded summary, citations, and
+  `insufficient_context: false`
+
+GitHub Actions smoke:
+
+- run the manual `Hosted Beta Smoke` workflow only when the deployed Railway
+  service and a beta token are available
+- set repository secrets `POLICYNIM_BETA_MCP_URL` and
+  `POLICYNIM_BETA_MCP_TOKEN` before dispatching the workflow
+- the regular `CI` workflow remains offline and runs pytest with
+  `-m "not live and not docker_live"`
+
 ## Hosted Beta Recovery
 
 ### Invalid Token
@@ -67,6 +102,15 @@ Hosted beta notes:
   hosted service or baked local index is not ready yet
 - retry after the service becomes healthy. If you operate the service, check the
   Railway deploy state and `/healthz` first
+- if `/healthz` includes `Local index readiness could not be inspected`, inspect
+  the exception class and message in the payload, then check the Railway deploy
+  logs for index path, volume, or file-permission failures
+- if `/healthz` says the local index is missing or empty, confirm the latest
+  build received `NVIDIA_API_KEY`, rerun the deploy so `policynim ingest` bakes
+  the index, and confirm `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`
+- if the live smoke passes `/healthz` but fails `policy_search` or
+  `policy_preflight`, inspect hosted MCP logs for `upstream_failure_class`
+  before rotating auth tokens or rebuilding the image
 
 ## Container Build For Hosted HTTP
 

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -515,6 +515,7 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
         fallback_reason = format_health_failure_reason(exc)
 
     def _fallback_result(reason: str = fallback_reason) -> JSONResponse:
+        """Return the public not-ready response for fallback health failures."""
         result = HealthCheckResult(
             status="error",
             ready=False,

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -32,6 +32,7 @@ from policynim.services import (
     create_runtime_health_service,
     create_search_service,
     ensure_hosted_runtime_ready,
+    format_health_failure_reason,
 )
 from policynim.settings import Settings, get_settings
 from policynim.types import (
@@ -507,19 +508,20 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
     """Register a public readiness endpoint for hosted HTTP runtimes."""
     try:
         health_service = create_runtime_health_service(settings)
-    except Exception:
+        fallback_reason = "Local index readiness could not be inspected."
+    except Exception as exc:
         LOGGER.exception("Could not construct runtime health service.")
         health_service = None
-    fallback_reason = "Local index readiness could not be inspected."
+        fallback_reason = format_health_failure_reason(exc)
 
-    def _fallback_result() -> JSONResponse:
+    def _fallback_result(reason: str = fallback_reason) -> JSONResponse:
         result = HealthCheckResult(
             status="error",
             ready=False,
             table_name=settings.lancedb_table,
             row_count=0,
             mcp_url=_derive_mcp_url(settings),
-            reason=fallback_reason,
+            reason=reason,
         )
         return JSONResponse(result.model_dump(mode="json"), status_code=503)
 
@@ -530,9 +532,9 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
 
         try:
             result = await asyncio.to_thread(health_service.check)
-        except Exception:
+        except Exception as exc:
             LOGGER.exception("Runtime health probe failed.")
-            return _fallback_result()
+            return _fallback_result(format_health_failure_reason(exc))
 
         status_code = 200 if result.ready else 503
         return JSONResponse(result.model_dump(mode="json"), status_code=status_code)

--- a/src/policynim/services/__init__.py
+++ b/src/policynim/services/__init__.py
@@ -13,6 +13,7 @@ from policynim.services.health import (
     RuntimeHealthService,
     create_runtime_health_service,
     ensure_hosted_runtime_ready,
+    format_health_failure_reason,
 )
 from policynim.services.ingest import IngestService, create_ingest_service
 from policynim.services.preflight import PreflightService, create_preflight_service
@@ -61,6 +62,7 @@ __all__ = [
     "create_runtime_execution_service",
     "create_runtime_health_service",
     "ensure_hosted_runtime_ready",
+    "format_health_failure_reason",
     "create_index_dump_service",
     "create_ingest_service",
     "create_preflight_service",

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -175,10 +175,21 @@ def _derive_mcp_url(settings: Settings) -> str | None:
 
 def format_health_failure_reason(exc: Exception) -> str:
     """Return an operator-safe reason for readiness inspection failures."""
-    message = str(exc).strip().rstrip(".")
-    if message:
-        return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
+    if isinstance(exc, OSError):
+        message = _single_line_message(exc.strerror)
+        if message:
+            return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
     return f"Local index readiness could not be inspected: {type(exc).__name__}."
+
+
+def _single_line_message(message: str | None) -> str | None:
+    """Return a compact sanitized exception message, if one is available."""
+    if message is None:
+        return None
+    message = " ".join(message.split()).strip().rstrip(".")
+    if message:
+        return message
+    return None
 
 
 def _format_hosted_runtime_error(*, index_uri: Path | str, table_name: str, reason: str) -> str:

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -50,9 +50,9 @@ class RuntimeHealthService:
                 mcp_url=self._mcp_url,
                 reason=None,
             )
-        except Exception:
+        except Exception as exc:
             LOGGER.exception("Runtime health check failed.")
-            return self._not_ready("Local index readiness could not be inspected.")
+            return self._not_ready(format_health_failure_reason(exc))
 
     def _not_ready(self, reason: str) -> HealthCheckResult:
         return HealthCheckResult(
@@ -125,7 +125,7 @@ def _check_hosted_runtime_health(
     try:
         return create_runtime_health_service(settings).check()
     except Exception as exc:
-        reason = f"Local index readiness could not be inspected: {type(exc).__name__}: {exc}."
+        reason = format_health_failure_reason(exc)
         raise ConfigurationError(
             _format_hosted_runtime_error(
                 index_uri=index_uri,
@@ -171,6 +171,14 @@ def _derive_mcp_url(settings: Settings) -> str | None:
     if settings.mcp_public_base_url is None:
         return None
     return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
+
+
+def format_health_failure_reason(exc: Exception) -> str:
+    """Return an operator-safe reason for readiness inspection failures."""
+    message = str(exc).strip().rstrip(".")
+    if message:
+        return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
+    return f"Local index readiness could not be inspected: {type(exc).__name__}."
 
 
 def _format_hosted_runtime_error(*, index_uri: Path | str, table_name: str, reason: str) -> str:

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,40 @@
+"""Workflow contract checks for offline CI and opt-in live smoke gates."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_ci_pytest_gate_excludes_all_live_markers() -> None:
+    text = _read_text(CI_WORKFLOW)
+
+    assert 'uv run pytest -q -m "not live and not docker_live"' in text
+    assert 'uv run pytest -q -m "not live"\n' not in text
+
+
+def test_hosted_smoke_workflow_is_manual_and_secret_gated() -> None:
+    text = _read_text(HOSTED_SMOKE_WORKFLOW)
+
+    assert "workflow_dispatch:" in text
+    assert "pull_request:" not in text
+    assert "push:" not in text
+    assert "POLICYNIM_BETA_MCP_URL: ${{ secrets.POLICYNIM_BETA_MCP_URL }}" in text
+    assert "POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}" in text
+    assert "Validate hosted smoke secrets" in text
+    assert "pytest -q -m live tests/test_hosted_mcp_live.py" in text
+
+
+def test_hosted_smoke_workflow_uses_pinned_actions() -> None:
+    text = _read_text(HOSTED_SMOKE_WORKFLOW)
+    action_refs = re.findall(r"uses: [^@\n]+@([0-9a-f]{40})", text)
+
+    assert len(action_refs) == 3

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -11,10 +11,12 @@ HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
 
 
 def _read_text(path: Path) -> str:
+    """Read a workflow file as UTF-8 text."""
     return path.read_text(encoding="utf-8")
 
 
 def test_ci_pytest_gate_excludes_all_live_markers() -> None:
+    """Ensure normal CI cannot discover live or Docker-only tests by accident."""
     text = _read_text(CI_WORKFLOW)
 
     assert 'uv run pytest -q -m "not live and not docker_live"' in text
@@ -22,6 +24,7 @@ def test_ci_pytest_gate_excludes_all_live_markers() -> None:
 
 
 def test_hosted_smoke_workflow_is_manual_and_secret_gated() -> None:
+    """Ensure the hosted smoke workflow is opt-in and requires deployed beta secrets."""
     text = _read_text(HOSTED_SMOKE_WORKFLOW)
 
     assert "workflow_dispatch:" in text
@@ -31,9 +34,11 @@ def test_hosted_smoke_workflow_is_manual_and_secret_gated() -> None:
     assert "POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}" in text
     assert "Validate hosted smoke secrets" in text
     assert "pytest -q -m live tests/test_hosted_mcp_live.py" in text
+    assert "permissions:\n  contents: read" in text
 
 
 def test_hosted_smoke_workflow_uses_pinned_actions() -> None:
+    """Ensure the hosted smoke workflow keeps GitHub actions pinned to SHAs."""
     text = _read_text(HOSTED_SMOKE_WORKFLOW)
     action_refs = re.findall(r"uses: [^@\n]+@([0-9a-f]{40})", text)
 

--- a/tests/test_docs_hosted_onboarding.py
+++ b/tests/test_docs_hosted_onboarding.py
@@ -109,6 +109,7 @@ def test_hosted_operations_doc_covers_required_recovery_topics() -> None:
 
 
 def test_hosted_operations_doc_covers_60_day_readiness_smoke() -> None:
+    """Ensure hosted docs describe the live readiness smoke and recovery evidence."""
     text = _read_text(HOSTED_OPERATIONS)
 
     for expected in (

--- a/tests/test_docs_hosted_onboarding.py
+++ b/tests/test_docs_hosted_onboarding.py
@@ -108,6 +108,22 @@ def test_hosted_operations_doc_covers_required_recovery_topics() -> None:
         assert topic in text
 
 
+def test_hosted_operations_doc_covers_60_day_readiness_smoke() -> None:
+    text = _read_text(HOSTED_OPERATIONS)
+
+    for expected in (
+        "## 60-Day Readiness Verification",
+        "curl -fsS https://<railway-domain>/healthz",
+        "POLICYNIM_BETA_MCP_URL=https://<railway-domain>/mcp",
+        "uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py",
+        "Hosted Beta Smoke",
+        '`-m "not live and not docker_live"`',
+        "Local index readiness could not be inspected",
+        "upstream_failure_class",
+    ):
+        assert expected in text
+
+
 def test_readme_links_to_contributor_and_workflow_guides() -> None:
     text = _read_text(README)
 

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -120,7 +120,9 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert result.ready is False
     assert result.row_count == 0
     assert result.reason is not None
-    assert result.reason == "Local index readiness could not be inspected."
+    assert result.reason == (
+        "Local index readiness could not be inspected: OSError: permission denied."
+    )
 
 
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -109,7 +109,9 @@ def test_runtime_health_service_reports_empty_index() -> None:
 
 def test_runtime_health_service_reports_unreadable_index() -> None:
     service = RuntimeHealthService(
-        index_store=StubIndexStore(count_error=OSError("permission denied")),
+        index_store=StubIndexStore(
+            count_error=PermissionError(13, "permission denied", "/tmp/key")
+        ),
         table_name="policy_chunks",
         mcp_url=None,
     )
@@ -121,8 +123,9 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert result.row_count == 0
     assert result.reason is not None
     assert result.reason == (
-        "Local index readiness could not be inspected: OSError: permission denied."
+        "Local index readiness could not be inspected: PermissionError: permission denied."
     )
+    assert "/tmp/key" not in result.reason
 
 
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -378,7 +381,7 @@ def test_ensure_hosted_runtime_ready_wraps_constructor_errors(
         raise_constructor_error,
     )
 
-    with pytest.raises(ConfigurationError, match="PermissionError: permission denied") as exc_info:
+    with pytest.raises(ConfigurationError, match="PermissionError") as exc_info:
         health_module.ensure_hosted_runtime_ready(Settings())
 
     assert exc_info.value.__cause__ is failure

--- a/tests/test_hosted_mcp_live.py
+++ b/tests/test_hosted_mcp_live.py
@@ -6,13 +6,14 @@ import asyncio
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 import pytest
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
-from policynim.types import PreflightResult, SearchResult
+from policynim.types import HealthCheckResult, PreflightResult, SearchResult
 
 _BETA_URL = os.getenv("POLICYNIM_BETA_MCP_URL", "").strip()
 _BETA_TOKEN = os.getenv("POLICYNIM_BETA_MCP_TOKEN", "").strip()
@@ -39,6 +40,35 @@ def _structured_payload(result) -> dict[str, object]:  # noqa: ANN001
     payload = result.structuredContent
     assert isinstance(payload, dict)
     return payload
+
+
+def _hosted_url(path: str) -> str:
+    parts = urlsplit(_BETA_URL)
+    if not parts.scheme or not parts.netloc:
+        raise AssertionError("POLICYNIM_BETA_MCP_URL must be an absolute URL.")
+    if parts.path.rstrip("/") != "/mcp":
+        raise AssertionError("POLICYNIM_BETA_MCP_URL must point to the hosted /mcp route.")
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+def _expected_mcp_url() -> str:
+    return _hosted_url("/mcp")
+
+
+def _health_url() -> str:
+    return _hosted_url("/healthz")
+
+
+def test_hosted_healthz_reports_ready_index_live() -> None:
+    response = httpx.get(_health_url(), timeout=30.0)
+
+    assert response.status_code == 200
+    payload = HealthCheckResult.model_validate(response.json())
+    assert payload.ready is True
+    assert payload.status == "ok"
+    assert payload.row_count > 0
+    assert payload.mcp_url == _expected_mcp_url()
+    assert payload.reason is None
 
 
 def test_hosted_mcp_lists_tools_live() -> None:
@@ -84,7 +114,7 @@ def test_hosted_policy_preflight_live() -> None:
 
 def test_hosted_mcp_rejects_invalid_token_live() -> None:
     response = httpx.get(
-        _BETA_URL,
+        _expected_mcp_url(),
         headers={
             "Accept": "text/event-stream",
             "Authorization": "Bearer invalid-token",

--- a/tests/test_hosted_mcp_live.py
+++ b/tests/test_hosted_mcp_live.py
@@ -43,6 +43,7 @@ def _structured_payload(result) -> dict[str, object]:  # noqa: ANN001
 
 
 def _hosted_url(path: str) -> str:
+    """Build a hosted URL on the same origin as the configured MCP endpoint."""
     parts = urlsplit(_BETA_URL)
     if not parts.scheme or not parts.netloc:
         raise AssertionError("POLICYNIM_BETA_MCP_URL must be an absolute URL.")
@@ -52,14 +53,17 @@ def _hosted_url(path: str) -> str:
 
 
 def _expected_mcp_url() -> str:
+    """Return the normalized hosted MCP URL expected in health payloads."""
     return _hosted_url("/mcp")
 
 
 def _health_url() -> str:
+    """Return the public hosted readiness URL for the beta service."""
     return _hosted_url("/healthz")
 
 
 def test_hosted_healthz_reports_ready_index_live() -> None:
+    """Verify the deployed beta exposes a ready health payload with an indexed corpus."""
     response = httpx.get(_health_url(), timeout=30.0)
 
     assert response.status_code == 200

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -805,16 +805,17 @@ def test_healthz_returns_fallback_payload_when_service_construction_fails(monkey
     assert response.status_code == 503
     payload = response.json()
     assert payload["ready"] is False
-    assert payload["reason"] == (
-        "Local index readiness could not be inspected: OSError: permission denied."
-    )
+    assert payload["reason"] == "Local index readiness could not be inspected: OSError."
     assert payload["mcp_url"] == "https://beta.example.com/mcp"
     assert "index_uri" not in payload
 
 
 def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
+    """Return a sanitized public fallback reason when health checks raise later."""
+
     class FailingHealthService:
         def check(self) -> HealthCheckResult:
+            """Raise a representative unexpected health-check failure."""
             raise RuntimeError("unexpected readiness failure")
 
     monkeypatch.setattr(
@@ -833,9 +834,7 @@ def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
     assert response.status_code == 503
     payload = response.json()
     assert payload["ready"] is False
-    assert payload["reason"] == (
-        "Local index readiness could not be inspected: RuntimeError: unexpected readiness failure."
-    )
+    assert payload["reason"] == ("Local index readiness could not be inspected: RuntimeError.")
     assert payload["mcp_url"] == "https://beta.example.com/mcp"
     assert "index_uri" not in payload
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -805,7 +805,37 @@ def test_healthz_returns_fallback_payload_when_service_construction_fails(monkey
     assert response.status_code == 503
     payload = response.json()
     assert payload["ready"] is False
-    assert payload["reason"] == "Local index readiness could not be inspected."
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: OSError: permission denied."
+    )
+    assert payload["mcp_url"] == "https://beta.example.com/mcp"
+    assert "index_uri" not in payload
+
+
+def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
+    class FailingHealthService:
+        def check(self) -> HealthCheckResult:
+            raise RuntimeError("unexpected readiness failure")
+
+    monkeypatch.setattr(
+        mcp_module,
+        "create_runtime_health_service",
+        lambda settings: FailingHealthService(),
+    )
+
+    app = mcp_module._build_streamable_http_app(
+        Settings.model_validate({"mcp_public_base_url": "https://beta.example.com"})
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: RuntimeError: unexpected readiness failure."
+    )
     assert payload["mcp_url"] == "https://beta.example.com/mcp"
     assert "index_uri" not in payload
 


### PR DESCRIPTION
## Summary
- harden hosted `/healthz` diagnostics while preserving the existing health payload shape
- expand deployed hosted MCP live smoke coverage for health, auth rejection, tool listing, search, and preflight
- keep normal CI offline-only and add a manual `Hosted Beta Smoke` workflow for live Railway verification
- document the 60-day hosted readiness checklist and recovery steps

## Verification
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest -q -m "not live and not docker_live"` (`463 passed, 10 deselected`)
- `uv run pytest -q tests/test_hosted_mcp_live.py` (`5 skipped`, live env vars unset)
- `git diff --check`

## Live acceptance
Requires `POLICYNIM_BETA_MCP_URL` and `POLICYNIM_BETA_MCP_TOKEN`, then run:

```bash
uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py
```