### PR TITLE
Add operator beta audit and evidence exports

### DIFF
--- a/docs/hosted-beta-operations.md
+++ b/docs/hosted-beta-operations.md
@@ -253,6 +253,48 @@ Important hosted behavior:
   including `auth_result`, `tool_name`, `latency_ms`, and
   `upstream_failure_class`
 
+## 90-Day Operator Beta Release Gate
+
+Use this gate before tagging a hosted beta release or handing a deployment to an
+operator. The default checks stay offline and deterministic:
+
+```bash
+uv run ruff check .
+uv run pyright
+uv run pytest -q -m "not live and not docker_live"
+git diff --check
+```
+
+Capture runtime evidence for any local release workflow that uses
+`policynim runtime execute`:
+
+```bash
+uv run policynim evidence report \
+  --session-id <id> \
+  --format markdown \
+  --output reports/<id>.md
+```
+
+Inspect hosted beta account and key activity from the operator CLI:
+
+```bash
+uv run policynim beta-admin audit-log --limit 50
+uv run policynim beta-admin audit-log --github-login <login>
+uv run policynim beta-admin audit-log --event-type api_key_rotated --limit 10
+```
+
+The audit log output is JSON, newest-first, and redacts secret-bearing detail
+keys. It may show API key prefixes because those are stored as recovery metadata;
+it must not expose full API keys, bearer tokens, or key hashes.
+
+Optional checks stay explicitly opt-in:
+
+- run the deployed-service smoke only when hosted secrets are configured:
+  `uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py`
+- run Docker hosted-image checks only when Docker is running and the local opt-in
+  flag is set:
+  `POLICYNIM_RUN_DOCKER_TESTS=1 uv run --group test pytest -q -m docker_live tests/test_docker_build_live.py`
+
 Opt-in Railway smoke test:
 
 ```bash

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,7 @@ reference that used to live in the root README.
 - `policynim runtime decide --input <path|->`
 - `policynim runtime execute --input <path|->`
 - `policynim evidence report --session-id <id>`
+- `policynim evidence report --session-id <id> --format markdown --output reports/<id>.md`
 
 ### MCP Tools
 
@@ -32,6 +33,7 @@ reference that used to live in the root README.
 - `policynim beta-admin suspend --github-login <login>`
 - `policynim beta-admin resume --github-login <login>`
 - `policynim beta-admin revoke-key --github-login <login>`
+- `policynim beta-admin audit-log [--github-login <login>] [--event-type <type>] [--limit 50]`
 
 ### Hosted HTTP
 
@@ -437,6 +439,12 @@ JSON
 
 # Summarize the stored evidence for one execution session.
 uv run policynim evidence report --session-id <session-id-from-runtime-execute>
+
+# Write an operator-friendly Markdown artifact.
+uv run policynim evidence report \
+  --session-id <id> \
+  --format markdown \
+  --output reports/<id>.md
 ```
 
 Contract notes:
@@ -458,6 +466,9 @@ Contract notes:
 - `runtime execute` exits `1` for `blocked`, `refused`, and `failed`
 - `evidence report` is summary-only: it aggregates one session from the SQLite
   runtime evidence store rather than dumping raw rows
+- `evidence report --format markdown --output <path>` writes a durable
+  release artifact; parent directories are created automatically and existing
+  files are replaced atomically
 
 SQLite runtime evidence notes:
 
@@ -466,6 +477,19 @@ SQLite runtime evidence notes:
 - persisted events live in the `runtime_execution_events` table
 - `evidence report` is the supported operator surface for session summaries
 - raw SQLite inspection is a debugging aid, not a formal public API
+
+Hosted beta operator audit:
+
+```bash
+uv run policynim beta-admin audit-log --limit 20
+uv run policynim beta-admin audit-log --github-login octocat
+uv run policynim beta-admin audit-log --event-type api_key_rotated --limit 10
+```
+
+`beta-admin audit-log` reads the hosted auth SQLite `audit_events` table,
+returns newest events first, and redacts secret-bearing detail keys. API key
+prefixes are safe to display because they are already stored as recovery
+metadata; full API keys, bearer tokens, and hashes are not exposed.
 
 Useful inspection commands:
 

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
+from datetime import datetime
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Annotated, Literal, NoReturn
 
 import typer
@@ -15,6 +18,7 @@ from pydantic import TypeAdapter, ValidationError
 import policynim.config_discovery as config_discovery
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
+from policynim.runtime_paths import resolve_runtime_path
 from policynim.services import (
     create_beta_auth_service,
     create_eval_service,
@@ -43,6 +47,7 @@ from policynim.types import (
     RouteRequest,
     RuntimeActionRequest,
     RuntimeDecisionResult,
+    RuntimeEvidenceSessionSummary,
     RuntimeExecutionOutcome,
     SearchRequest,
     TaskType,
@@ -503,18 +508,40 @@ def evidence_report(
             help="Runtime evidence session id to summarize.",
         ),
     ],
+    output_format: Annotated[
+        Literal["json", "markdown"],
+        typer.Option(
+            "--format",
+            help="Report format. Supported values: json, markdown.",
+        ),
+    ] = "json",
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            help="Optional file path to write the rendered report.",
+        ),
+    ] = None,
 ) -> None:
     """Summarize one runtime evidence session from SQLite-backed storage."""
     service = None
+    rendered: str | None = None
+    written_path: Path | None = None
     try:
         service = create_runtime_evidence_report_service(_load_setup_dependent_settings())
         result = service.report_session(session_id)
+        rendered = _render_runtime_evidence_report(result, output_format=output_format)
+        if output is not None:
+            written_path = _write_cli_artifact_text(output, rendered)
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     finally:
         _close_service(service)
 
-    typer.echo(result.model_dump_json(indent=2))
+    if output is not None and written_path is not None:
+        typer.echo(f"Wrote runtime evidence report to {written_path}.")
+        return
+    typer.echo(rendered)
 
 
 @app.command()
@@ -688,6 +715,38 @@ def beta_admin_revoke_key(
     typer.echo(account.model_dump_json(indent=2))
 
 
+@beta_admin_app.command("audit-log")
+def beta_admin_audit_log(
+    github_login: Annotated[
+        str | None,
+        typer.Option("--github-login", help="Filter audit events by GitHub login."),
+    ] = None,
+    event_type: Annotated[
+        str | None,
+        typer.Option("--event-type", help="Filter audit events by event type."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", min=1, help="Maximum audit events to return."),
+    ] = 50,
+) -> None:
+    """Print hosted beta audit events as JSON."""
+    service = None
+    try:
+        service = create_beta_auth_service(get_settings())
+        events = service.list_audit_events(
+            github_login=github_login,
+            event_type=event_type,
+            limit=limit,
+        )
+    except PolicyNIMError as exc:
+        _exit_with_error(str(exc))
+    finally:
+        _close_service(service)
+
+    typer.echo(json.dumps([event.model_dump(mode="json") for event in events], indent=2))
+
+
 def main() -> None:
     """Run the PolicyNIM CLI."""
     app()
@@ -706,6 +765,114 @@ def _version_option_callback(value: bool) -> None:
 def _exit_with_error(message: str) -> NoReturn:
     typer.secho(message, fg=typer.colors.RED, err=True)
     raise typer.Exit(code=1)
+
+
+def _render_runtime_evidence_report(
+    summary: RuntimeEvidenceSessionSummary,
+    *,
+    output_format: Literal["json", "markdown"],
+) -> str:
+    if output_format == "json":
+        return summary.model_dump_json(indent=2)
+    return _runtime_evidence_report_markdown(summary)
+
+
+def _runtime_evidence_report_markdown(summary: RuntimeEvidenceSessionSummary) -> str:
+    lines = [
+        f"# Runtime Evidence Report: {summary.session_id}",
+        "",
+        f"- Started: {summary.started_at.isoformat()}",
+        f"- Completed: {_optional_iso(summary.completed_at)}",
+        f"- Events: {summary.event_count}",
+        f"- Executions: {summary.execution_count}",
+        (
+            "- Outcomes: "
+            f"allowed={summary.allowed_count}, "
+            f"confirmed={summary.confirmed_count}, "
+            f"blocked={summary.blocked_count}, "
+            f"refused={summary.refused_count}, "
+            f"failed={summary.failed_count}, "
+            f"incomplete={summary.incomplete_count}"
+        ),
+        "",
+        "## Executions",
+        "",
+    ]
+    if not summary.executions:
+        lines.append("No executions recorded.")
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            (
+                "| Execution | Action | Decision | Outcome | Confirmation | "
+                "Started | Completed | Failure |"
+            ),
+            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for execution in summary.executions:
+        lines.append(
+            " | ".join(
+                [
+                    f"| {_markdown_cell(execution.execution_id)}",
+                    _markdown_cell(execution.action_kind),
+                    _markdown_cell(execution.decision),
+                    _markdown_cell(execution.execution_outcome or "incomplete"),
+                    _markdown_cell(execution.confirmation_outcome),
+                    _markdown_cell(execution.started_at.isoformat()),
+                    _markdown_cell(_optional_iso(execution.completed_at)),
+                    f"{_markdown_cell(execution.failure_class or '')} |",
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def _optional_iso(value: datetime | None) -> str:
+    if value is None:
+        return "N/A"
+    return value.isoformat()
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
+def _write_cli_artifact_text(output: str, content: str) -> Path:
+    output_value = output.strip()
+    if not output_value:
+        raise PolicyNIMError("Runtime evidence report output path must not be empty.")
+
+    target = resolve_runtime_path(Path(output_value))
+    if target.exists() and target.is_dir():
+        raise PolicyNIMError(f"Runtime evidence report output must be a file path: {target}.")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: str | None = None
+    try:
+        with NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = temp_file.name
+            temp_file.write(content)
+            temp_file.write("\n")
+        os.replace(temp_path, target)
+    except OSError as exc:
+        if temp_path is not None:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise PolicyNIMError(
+            f"Could not write runtime evidence report to {target}: {exc}."
+        ) from exc
+    return target
 
 
 def _format_validation_error(label: str, exc: ValidationError) -> str:

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -772,12 +772,14 @@ def _render_runtime_evidence_report(
     *,
     output_format: Literal["json", "markdown"],
 ) -> str:
+    """Render one runtime evidence summary in the requested CLI format."""
     if output_format == "json":
         return summary.model_dump_json(indent=2)
     return _runtime_evidence_report_markdown(summary)
 
 
 def _runtime_evidence_report_markdown(summary: RuntimeEvidenceSessionSummary) -> str:
+    """Render one runtime evidence session summary as Markdown."""
     lines = [
         f"# Runtime Evidence Report: {summary.session_id}",
         "",
@@ -830,16 +832,19 @@ def _runtime_evidence_report_markdown(summary: RuntimeEvidenceSessionSummary) ->
 
 
 def _optional_iso(value: datetime | None) -> str:
+    """Return an ISO timestamp or the CLI placeholder for missing timestamps."""
     if value is None:
         return "N/A"
     return value.isoformat()
 
 
 def _markdown_cell(value: object) -> str:
+    """Escape a value for use inside a Markdown table cell."""
     return str(value).replace("\n", " ").replace("|", "\\|")
 
 
 def _write_cli_artifact_text(output: str, content: str) -> Path:
+    """Write rendered CLI artifact text to a user-provided path atomically."""
     output_value = output.strip()
     if not output_value:
         raise PolicyNIMError("Runtime evidence report output path must not be empty.")

--- a/src/policynim/services/beta_auth.py
+++ b/src/policynim/services/beta_auth.py
@@ -15,7 +15,13 @@ from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import AuthStore
-from policynim.types import BetaAccount, BetaAuthDecision, BetaIssuedApiKey, BetaUsageSnapshot
+from policynim.types import (
+    BetaAccount,
+    BetaAuditEvent,
+    BetaAuthDecision,
+    BetaIssuedApiKey,
+    BetaUsageSnapshot,
+)
 
 _GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 _GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
@@ -66,6 +72,22 @@ class BetaAuthService:
     def list_accounts(self) -> list[BetaAccount]:
         """Return all hosted beta accounts."""
         return self._store.list_accounts()
+
+    def list_audit_events(
+        self,
+        *,
+        github_login: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+    ) -> list[BetaAuditEvent]:
+        """Return operator-visible hosted beta audit events."""
+        if github_login is not None:
+            self._require_account_by_login(github_login)
+        return self._store.list_audit_events(
+            github_login=github_login,
+            event_type=event_type,
+            limit=limit,
+        )
 
     def get_account(self, account_id: int) -> BetaAccount | None:
         """Return one hosted beta account by id."""

--- a/src/policynim/storage/auth_store.py
+++ b/src/policynim/storage/auth_store.py
@@ -554,11 +554,15 @@ def _account_from_row(row: sqlite3.Row) -> BetaAccount:
 
 
 def _audit_event_from_row(row: sqlite3.Row) -> BetaAuditEvent:
+    """Convert one SQLite audit row into the operator-visible typed model."""
     created_at = _parse_datetime(row["created_at"])
     if created_at is None:
         raise PolicyNIMError("Audit event row is missing a created_at timestamp.")
 
-    raw_details = json.loads(str(row["details_json"]))
+    try:
+        raw_details = json.loads(str(row["details_json"]))
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise PolicyNIMError(f"Audit event {row['event_id']} has malformed details JSON.") from exc
     details = _redact_audit_detail(raw_details)
     if not isinstance(details, dict):
         details = {}
@@ -584,6 +588,7 @@ def _audit_event_from_row(row: sqlite3.Row) -> BetaAuditEvent:
 
 
 def _redact_audit_detail(value: object) -> object:
+    """Recursively redact secret-bearing values from audit event details."""
     if isinstance(value, dict):
         redacted: dict[str, object] = {}
         for key, item in value.items():
@@ -599,6 +604,7 @@ def _redact_audit_detail(value: object) -> object:
 
 
 def _is_sensitive_audit_detail_key(key: str) -> bool:
+    """Return whether an audit details key should be redacted for operators."""
     normalized = key.lower()
     if normalized == "key_prefix":
         return False

--- a/src/policynim/storage/auth_store.py
+++ b/src/policynim/storage/auth_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from policynim.errors import PolicyNIMError
-from policynim.types import BetaAccount, BetaAccountStatus, BetaUsageSnapshot
+from policynim.types import BetaAccount, BetaAccountStatus, BetaAuditEvent, BetaUsageSnapshot
 
 _ACTIVE_STATUS = "active"
 _SUSPENDED_STATUS = "suspended"
@@ -73,6 +73,54 @@ class AuthStore:
         with closing(self._connect()) as conn:
             rows = conn.execute(_ACCOUNT_SELECT + " ORDER BY a.created_at ASC").fetchall()
             return [_account_from_row(row) for row in rows]
+
+    def list_audit_events(
+        self,
+        *,
+        github_login: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+    ) -> list[BetaAuditEvent]:
+        """Return hosted beta audit events newest first."""
+        if limit < 1:
+            raise PolicyNIMError("Audit event limit must be greater than zero.")
+
+        where_clauses: list[str] = []
+        parameters: list[object] = []
+        if github_login is not None:
+            where_clauses.append("a.github_login = ?")
+            parameters.append(github_login)
+        if event_type is not None:
+            where_clauses.append("e.event_type = ?")
+            parameters.append(event_type)
+
+        where_sql = ""
+        if where_clauses:
+            where_sql = " WHERE " + " AND ".join(where_clauses)
+
+        query = (
+            """
+            SELECT
+                e.id AS event_id,
+                e.account_id,
+                a.github_login,
+                a.status AS account_status,
+                e.event_type,
+                e.details_json,
+                e.created_at
+            FROM audit_events e
+            LEFT JOIN accounts a ON a.id = e.account_id
+            """
+            + where_sql
+            + """
+            ORDER BY e.created_at DESC, e.id DESC
+            LIMIT ?
+            """
+        )
+        parameters.append(limit)
+        with closing(self._connect()) as conn:
+            rows = conn.execute(query, tuple(parameters)).fetchall()
+        return [_audit_event_from_row(row) for row in rows]
 
     def get_account_by_id(self, account_id: int) -> BetaAccount | None:
         """Return one hosted beta account by internal id."""
@@ -503,6 +551,60 @@ def _account_from_row(row: sqlite3.Row) -> BetaAccount:
         api_key_prefix=str(row["api_key_prefix"]) if row["api_key_prefix"] is not None else None,
         api_key_created_at=_parse_datetime(row["api_key_created_at"]),
     )
+
+
+def _audit_event_from_row(row: sqlite3.Row) -> BetaAuditEvent:
+    created_at = _parse_datetime(row["created_at"])
+    if created_at is None:
+        raise PolicyNIMError("Audit event row is missing a created_at timestamp.")
+
+    raw_details = json.loads(str(row["details_json"]))
+    details = _redact_audit_detail(raw_details)
+    if not isinstance(details, dict):
+        details = {}
+
+    account_status = row["account_status"]
+    if account_status is not None and str(account_status) not in {
+        _ACTIVE_STATUS,
+        _SUSPENDED_STATUS,
+    }:
+        raise PolicyNIMError(f"Unsupported beta account status: {account_status}")
+
+    return BetaAuditEvent(
+        event_id=int(row["event_id"]),
+        account_id=int(row["account_id"]) if row["account_id"] is not None else None,
+        github_login=str(row["github_login"]) if row["github_login"] is not None else None,
+        account_status=(
+            cast(BetaAccountStatus, str(account_status)) if account_status is not None else None
+        ),
+        event_type=str(row["event_type"]),
+        details=cast(dict[str, object], details),
+        created_at=created_at,
+    )
+
+
+def _redact_audit_detail(value: object) -> object:
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if _is_sensitive_audit_detail_key(key_text):
+                redacted[key_text] = "[redacted]"
+            else:
+                redacted[key_text] = _redact_audit_detail(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_audit_detail(item) for item in value]
+    return value
+
+
+def _is_sensitive_audit_detail_key(key: str) -> bool:
+    normalized = key.lower()
+    if normalized == "key_prefix":
+        return False
+    if normalized == "key" or normalized.endswith("_key"):
+        return True
+    return any(marker in normalized for marker in ("secret", "token", "key_hash", "api_key"))
 
 
 def _usage_snapshot(

--- a/src/policynim/types.py
+++ b/src/policynim/types.py
@@ -652,6 +652,18 @@ class BetaAccount(StrictModel):
     api_key_created_at: datetime | None = None
 
 
+class BetaAuditEvent(StrictModel):
+    """One operator-visible hosted beta audit event."""
+
+    event_id: int = Field(ge=1)
+    account_id: int | None = Field(default=None, ge=1)
+    github_login: str | None = None
+    account_status: BetaAccountStatus | None = None
+    event_type: str = Field(min_length=1)
+    details: dict[str, object] = Field(default_factory=dict)
+    created_at: datetime
+
+
 class BetaUsageSnapshot(StrictModel):
     """Current daily hosted-usage state for one beta account."""
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,8 +47,9 @@ Current automated coverage includes:
   guidance
 - CLI output for `eval`
 - CLI output for `eval --backend default|nemo|nemo_evaluator|nat`
-- CLI output for `runtime decide`, `runtime execute`, and `evidence report`
-- CLI output for `beta-admin` hosted operator commands
+- CLI output for `runtime decide`, `runtime execute`, and `evidence report`,
+  including Markdown/file artifact exports
+- CLI output for `beta-admin` hosted operator commands, including audit-log filtering
 - MCP tool parity for `policy_preflight` and `policy_search`
 - MCP startup wiring for `stdio` and `streamable-http`
 - Hosted HTTP `/healthz` readiness checks and the optional bearer-auth wrapper

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -115,6 +115,79 @@ def test_auth_store_consumes_quota_atomically_until_limit(tmp_path) -> None:
     assert third.remaining == 0
 
 
+def test_auth_store_lists_audit_events_newest_first_with_account_metadata(tmp_path) -> None:
+    store = AuthStore(path=tmp_path / "auth.sqlite3")
+    first_time = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+    second_time = datetime(2026, 4, 5, 12, 5, tzinfo=UTC)
+    account = store.upsert_account_from_github(
+        github_user_id=123,
+        github_login="octocat",
+        email="octocat@example.com",
+        now=first_time,
+    )
+    store.rotate_api_key(
+        account_id=account.account_id,
+        key_prefix="pnm_first",
+        key_hash=_hash_api_key("pnm_first_secret"),
+        now=second_time,
+    )
+
+    events = store.list_audit_events(limit=10)
+
+    assert [event.event_type for event in events] == ["api_key_rotated", "account_signup"]
+    assert events[0].github_login == "octocat"
+    assert events[0].account_status == "active"
+    assert events[0].details == {"key_prefix": "pnm_first"}
+    assert events[0].created_at == second_time
+
+
+def test_auth_store_filters_audit_events_and_redacts_secret_details(tmp_path) -> None:
+    store = AuthStore(path=tmp_path / "auth.sqlite3")
+    now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+    account = store.upsert_account_from_github(
+        github_user_id=123,
+        github_login="octocat",
+        email="octocat@example.com",
+        now=now,
+    )
+    other = store.upsert_account_from_github(
+        github_user_id=456,
+        github_login="hubot",
+        email="hubot@example.com",
+        now=now,
+    )
+    store.rotate_api_key(
+        account_id=account.account_id,
+        key_prefix="pnm_first",
+        key_hash=_hash_api_key("pnm_first_secret"),
+        now=now,
+    )
+    with store._connect() as conn:
+        store._insert_audit_event(
+            conn,
+            account_id=other.account_id,
+            event_type="operator_note",
+            details={
+                "api_key": "pnm_full_secret",
+                "key_hash": _hash_api_key("pnm_full_secret"),
+                "key_prefix": "pnm_safe_prefix",
+                "nested": {"session_token": "token-secret"},
+            },
+            now=now,
+        )
+
+    events = store.list_audit_events(github_login="hubot", event_type="operator_note", limit=1)
+
+    assert len(events) == 1
+    assert events[0].github_login == "hubot"
+    assert events[0].details == {
+        "api_key": "[redacted]",
+        "key_hash": "[redacted]",
+        "key_prefix": "pnm_safe_prefix",
+        "nested": {"session_token": "[redacted]"},
+    }
+
+
 def test_auth_store_reset_for_tests_clears_existing_state(tmp_path) -> None:
     store = AuthStore(path=tmp_path / "auth.sqlite3")
     store.upsert_account_from_github(

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 from datetime import UTC, date, datetime
 
+from policynim.errors import PolicyNIMError
 from policynim.storage import AuthStore
 
 
@@ -116,6 +117,7 @@ def test_auth_store_consumes_quota_atomically_until_limit(tmp_path) -> None:
 
 
 def test_auth_store_lists_audit_events_newest_first_with_account_metadata(tmp_path) -> None:
+    """Return hosted beta audit events newest first with account metadata."""
     store = AuthStore(path=tmp_path / "auth.sqlite3")
     first_time = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
     second_time = datetime(2026, 4, 5, 12, 5, tzinfo=UTC)
@@ -142,6 +144,7 @@ def test_auth_store_lists_audit_events_newest_first_with_account_metadata(tmp_pa
 
 
 def test_auth_store_filters_audit_events_and_redacts_secret_details(tmp_path) -> None:
+    """Filter hosted beta audit events and redact secret-bearing details."""
     store = AuthStore(path=tmp_path / "auth.sqlite3")
     now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
     account = store.upsert_account_from_github(
@@ -186,6 +189,33 @@ def test_auth_store_filters_audit_events_and_redacts_secret_details(tmp_path) ->
         "key_prefix": "pnm_safe_prefix",
         "nested": {"session_token": "[redacted]"},
     }
+
+
+def test_auth_store_rejects_malformed_audit_event_details(tmp_path) -> None:
+    """Raise a controlled error when stored audit event details are malformed."""
+    store = AuthStore(path=tmp_path / "auth.sqlite3")
+    now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+    account = store.upsert_account_from_github(
+        github_user_id=123,
+        github_login="octocat",
+        email="octocat@example.com",
+        now=now,
+    )
+    with store._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO audit_events (account_id, event_type, details_json, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (account.account_id, "operator_note", "{not-json", now.isoformat()),
+        )
+
+    try:
+        store.list_audit_events(event_type="operator_note")
+    except PolicyNIMError as exc:
+        assert "malformed details JSON" in str(exc)
+    else:
+        raise AssertionError("Expected malformed audit event details to fail.")
 
 
 def test_auth_store_reset_for_tests_clears_existing_state(tmp_path) -> None:

--- a/tests/test_beta_auth.py
+++ b/tests/test_beta_auth.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from policynim.errors import ProviderError
+from policynim.errors import PolicyNIMError, ProviderError
 from policynim.services.beta_auth import BetaAuthService
 from policynim.settings import Settings
 from policynim.storage import AuthStore
@@ -115,3 +115,33 @@ def test_fetch_github_identity_rejects_missing_required_fields(
 
     with pytest.raises(ProviderError, match="valid user id"):
         service._fetch_github_identity("github-access-token")
+
+
+def test_beta_auth_service_lists_filtered_audit_events(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    account = service._store.upsert_account_from_github(
+        github_user_id=123,
+        github_login="octocat",
+        email="octocat@example.com",
+        now=service._utc_now(),
+    )
+    service._store.rotate_api_key(
+        account_id=account.account_id,
+        key_prefix="pnm_first",
+        key_hash="stored-hash",
+        now=service._utc_now(),
+    )
+
+    events = service.list_audit_events(github_login="octocat", event_type="api_key_rotated")
+
+    assert len(events) == 1
+    assert events[0].event_type == "api_key_rotated"
+    assert events[0].github_login == "octocat"
+    assert events[0].details == {"key_prefix": "pnm_first"}
+
+
+def test_beta_auth_service_rejects_audit_filter_for_unknown_account(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(PolicyNIMError, match="does not exist"):
+        service.list_audit_events(github_login="missing-user")

--- a/tests/test_beta_auth.py
+++ b/tests/test_beta_auth.py
@@ -118,6 +118,7 @@ def test_fetch_github_identity_rejects_missing_required_fields(
 
 
 def test_beta_auth_service_lists_filtered_audit_events(tmp_path: Path) -> None:
+    """Return filtered hosted beta audit events through the service layer."""
     service = _service(tmp_path)
     account = service._store.upsert_account_from_github(
         github_user_id=123,
@@ -141,6 +142,7 @@ def test_beta_auth_service_lists_filtered_audit_events(tmp_path: Path) -> None:
 
 
 def test_beta_auth_service_rejects_audit_filter_for_unknown_account(tmp_path: Path) -> None:
+    """Reject audit-log account filters that do not match a hosted beta account."""
     service = _service(tmp_path)
 
     with pytest.raises(PolicyNIMError, match="does not exist"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from policynim.settings import Settings, get_settings
 from policynim.storage import RuntimeEvidenceStore
 from policynim.types import (
     BetaAccount,
+    BetaAuditEvent,
     Citation,
     CompiledPolicyConstraint,
     CompiledPolicyPacket,
@@ -53,6 +54,8 @@ from policynim.types import (
     RouteResult,
     RuntimeDecision,
     RuntimeDecisionResult,
+    RuntimeEvidenceExecutionSummary,
+    RuntimeEvidenceSessionSummary,
     RuntimeExecutionResult,
     ScoredChunk,
     SearchRequest,
@@ -605,13 +608,15 @@ class _MockJSONModel:
 class MockRuntimeEvidenceReportService:
     """Static evidence report service for CLI tests."""
 
-    def __init__(self, payload: dict[str, object]) -> None:
+    def __init__(self, payload: dict[str, object] | RuntimeEvidenceSessionSummary) -> None:
         self._payload = payload
         self.closed = False
         self.last_session_id: str | None = None
 
-    def report_session(self, session_id: str) -> _MockJSONModel:
+    def report_session(self, session_id: str) -> _MockJSONModel | RuntimeEvidenceSessionSummary:
         self.last_session_id = session_id
+        if isinstance(self._payload, RuntimeEvidenceSessionSummary):
+            return self._payload
         return _MockJSONModel(self._payload)
 
     def close(self) -> None:
@@ -760,6 +765,43 @@ class MockBetaAuthService:
 
     def list_accounts(self) -> list[BetaAccount]:
         return [self._account]
+
+    def list_audit_events(
+        self,
+        *,
+        github_login: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+    ) -> list[BetaAuditEvent]:
+        if github_login == "missing-user":
+            raise PolicyNIMError(
+                "Hosted beta account with GitHub login 'missing-user' does not exist."
+            )
+        events = [
+            BetaAuditEvent(
+                event_id=2,
+                account_id=1,
+                github_login="octocat",
+                account_status="active",
+                event_type="api_key_rotated",
+                details={"key_prefix": "pnm_current"},
+                created_at=datetime(2026, 4, 5, 12, 5, tzinfo=UTC),
+            ),
+            BetaAuditEvent(
+                event_id=1,
+                account_id=1,
+                github_login="octocat",
+                account_status="active",
+                event_type="account_signup",
+                details={"github_login": "octocat", "email": "octocat@example.com"},
+                created_at=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+            ),
+        ]
+        if github_login is not None:
+            events = [event for event in events if event.github_login == github_login]
+        if event_type is not None:
+            events = [event for event in events if event.event_type == event_type]
+        return events[:limit]
 
     def suspend_account(self, *, github_login: str) -> BetaAccount:
         assert github_login == "octocat"
@@ -1907,11 +1949,64 @@ def test_beta_admin_revoke_key_prints_json(monkeypatch) -> None:
     assert json.loads(result.stdout)["api_key_prefix"] is None
 
 
+def test_beta_admin_audit_log_prints_filtered_json(monkeypatch) -> None:
+    service = MockBetaAuthService()
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_beta_auth_service",
+        lambda settings: service,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "beta-admin",
+            "audit-log",
+            "--github-login",
+            "octocat",
+            "--event-type",
+            "api_key_rotated",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["event_id"] == 2
+    assert payload[0]["github_login"] == "octocat"
+    assert payload[0]["event_type"] == "api_key_rotated"
+    assert payload[0]["details"] == {"key_prefix": "pnm_current"}
+
+
+def test_beta_admin_audit_log_rejects_invalid_limit() -> None:
+    result = runner.invoke(app, ["beta-admin", "audit-log", "--limit", "0"])
+
+    assert result.exit_code == 2
+    assert "Invalid value" in result.stderr
+
+
+def test_beta_admin_audit_log_surfaces_missing_account(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_beta_auth_service",
+        lambda settings: MockBetaAuthService(),
+    )
+
+    result = runner.invoke(
+        app,
+        ["beta-admin", "audit-log", "--github-login", "missing-user"],
+    )
+
+    assert result.exit_code == 1
+    assert "missing-user" in result.stderr
+
+
 def test_beta_admin_help_mentions_operator_commands() -> None:
     result = runner.invoke(app, ["beta-admin", "--help"])
 
     assert result.exit_code == 0
     assert "list-accounts" in result.stdout
+    assert "audit-log" in result.stdout
     assert "revoke-key" in result.stdout
 
 
@@ -2424,6 +2519,121 @@ def test_evidence_report_command_prints_session_summary_json(monkeypatch) -> Non
     assert payload["session_id"] == "session-1"
     assert payload["execution_count"] == 1
     assert service.closed is True
+
+
+def _cli_evidence_summary() -> RuntimeEvidenceSessionSummary:
+    started_at = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+    completed_at = datetime(2026, 4, 5, 12, 0, 10, tzinfo=UTC)
+    return RuntimeEvidenceSessionSummary(
+        session_id="session-1",
+        started_at=started_at,
+        completed_at=completed_at,
+        event_count=2,
+        execution_count=1,
+        allowed_count=1,
+        confirmed_count=0,
+        blocked_count=0,
+        refused_count=0,
+        failed_count=0,
+        incomplete_count=0,
+        executions=[
+            RuntimeEvidenceExecutionSummary(
+                execution_id="exec-1",
+                action_kind="shell_command",
+                task="Run release checks.",
+                decision="allow",
+                summary="Release checks may run.",
+                confirmation_outcome="not_required",
+                execution_outcome="allowed",
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+        ],
+    )
+
+
+def test_evidence_report_command_prints_markdown(monkeypatch) -> None:
+    service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_runtime_evidence_report_service",
+        lambda settings: service,
+        raising=False,
+    )
+
+    result = runner.invoke(
+        app,
+        ["evidence", "report", "--session-id", "session-1", "--format", "markdown"],
+    )
+
+    assert result.exit_code == 0
+    assert "# Runtime Evidence Report" in result.stdout
+    assert "session-1" in result.stdout
+    assert "| exec-1 | shell_command | allow | allowed |" in result.stdout
+    assert service.closed is True
+
+
+def test_evidence_report_command_writes_json_output_atomically(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_runtime_evidence_report_service",
+        lambda settings: service,
+        raising=False,
+    )
+    monkeypatch.chdir(tmp_path)
+    output_path = Path("reports") / "session-1.json"
+
+    result = runner.invoke(
+        app,
+        ["evidence", "report", "--session-id", "session-1", "--output", str(output_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Wrote runtime evidence report to" in result.stdout
+    payload = json.loads((tmp_path / output_path).read_text(encoding="utf-8"))
+    assert payload["session_id"] == "session-1"
+    assert service.closed is True
+
+
+def test_evidence_report_command_rejects_directory_output(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_runtime_evidence_report_service",
+        lambda settings: service,
+        raising=False,
+    )
+
+    result = runner.invoke(
+        app,
+        ["evidence", "report", "--session-id", "session-1", "--output", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "must be a file path" in result.stderr
+
+
+def test_evidence_report_command_rejects_empty_output(
+    monkeypatch,
+) -> None:
+    service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_runtime_evidence_report_service",
+        lambda settings: service,
+        raising=False,
+    )
+
+    result = runner.invoke(
+        app,
+        ["evidence", "report", "--session-id", "session-1", "--output", " "],
+    )
+
+    assert result.exit_code == 1
+    assert "must not be empty" in result.stderr
 
 
 def test_evidence_report_command_surfaces_missing_session_errors(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -773,6 +773,7 @@ class MockBetaAuthService:
         event_type: str | None = None,
         limit: int = 50,
     ) -> list[BetaAuditEvent]:
+        """Return static hosted beta audit events for CLI assertions."""
         if github_login == "missing-user":
             raise PolicyNIMError(
                 "Hosted beta account with GitHub login 'missing-user' does not exist."
@@ -1950,6 +1951,7 @@ def test_beta_admin_revoke_key_prints_json(monkeypatch) -> None:
 
 
 def test_beta_admin_audit_log_prints_filtered_json(monkeypatch) -> None:
+    """Print filtered hosted beta audit events as JSON."""
     service = MockBetaAuthService()
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_beta_auth_service",
@@ -1980,6 +1982,7 @@ def test_beta_admin_audit_log_prints_filtered_json(monkeypatch) -> None:
 
 
 def test_beta_admin_audit_log_rejects_invalid_limit() -> None:
+    """Reject non-positive audit-log limits at the Typer boundary."""
     result = runner.invoke(app, ["beta-admin", "audit-log", "--limit", "0"])
 
     assert result.exit_code == 2
@@ -1987,6 +1990,7 @@ def test_beta_admin_audit_log_rejects_invalid_limit() -> None:
 
 
 def test_beta_admin_audit_log_surfaces_missing_account(monkeypatch) -> None:
+    """Surface missing account filters as operator-facing CLI errors."""
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_beta_auth_service",
         lambda settings: MockBetaAuthService(),
@@ -2522,6 +2526,7 @@ def test_evidence_report_command_prints_session_summary_json(monkeypatch) -> Non
 
 
 def _cli_evidence_summary() -> RuntimeEvidenceSessionSummary:
+    """Return one typed evidence summary for report-format CLI tests."""
     started_at = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
     completed_at = datetime(2026, 4, 5, 12, 0, 10, tzinfo=UTC)
     return RuntimeEvidenceSessionSummary(
@@ -2553,6 +2558,7 @@ def _cli_evidence_summary() -> RuntimeEvidenceSessionSummary:
 
 
 def test_evidence_report_command_prints_markdown(monkeypatch) -> None:
+    """Render runtime evidence reports as Markdown on stdout."""
     service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_runtime_evidence_report_service",
@@ -2576,6 +2582,7 @@ def test_evidence_report_command_writes_json_output_atomically(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
+    """Write rendered JSON evidence reports to a nested output path."""
     service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_runtime_evidence_report_service",
@@ -2601,6 +2608,7 @@ def test_evidence_report_command_rejects_directory_output(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
+    """Reject output paths that already point at directories."""
     service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_runtime_evidence_report_service",
@@ -2620,6 +2628,7 @@ def test_evidence_report_command_rejects_directory_output(
 def test_evidence_report_command_rejects_empty_output(
     monkeypatch,
 ) -> None:
+    """Reject empty output path strings before filesystem writes."""
     service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
     monkeypatch.setattr(
         "policynim.interfaces.cli.create_runtime_evidence_report_service",

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -113,6 +113,7 @@ def test_tests_readme_mentions_runtime_and_docs_parity_coverage() -> None:
 
 
 def test_hosted_operations_documents_operator_beta_release_gate() -> None:
+    """Document the deterministic and opt-in hosted beta release checks."""
     text = _read_text(REPO_ROOT / "docs" / "hosted-beta-operations.md")
 
     for token in (

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -29,6 +29,7 @@ def test_workflows_guide_documents_runtime_request_shapes_and_sqlite_usage() -> 
         "policynim runtime decide --input <path|->",
         "policynim runtime execute --input <path|->",
         "policynim evidence report --session-id <id>",
+        "policynim evidence report --session-id <id> --format markdown --output reports/<id>.md",
         '"kind": "shell_command"',
         '"kind": "file_write"',
         '"kind": "http_request"',
@@ -107,5 +108,20 @@ def test_tests_readme_mentions_runtime_and_docs_parity_coverage() -> None:
     for token in (
         "Real SQLite-backed CLI runtime execution plus `evidence report` coverage",
         "Runtime docs parity",
+    ):
+        assert token in text
+
+
+def test_hosted_operations_documents_operator_beta_release_gate() -> None:
+    text = _read_text(REPO_ROOT / "docs" / "hosted-beta-operations.md")
+
+    for token in (
+        "90-Day Operator Beta Release Gate",
+        "uv run ruff check .",
+        "uv run pyright",
+        'uv run pytest -q -m "not live and not docker_live"',
+        "uv run --group test pytest -q -m live tests/test_hosted_mcp_live.py",
+        "POLICYNIM_RUN_DOCKER_TESTS=1 uv run --group test pytest -q -m docker_live",
+        "policynim beta-admin audit-log",
     ):
         assert token in text


### PR DESCRIPTION
## Summary
- add typed hosted beta audit events and a beta-admin audit-log CLI with account/event filters
- extend evidence report with JSON/Markdown rendering and atomic file output support
- document the 90-day operator beta release gate and new operator commands

## Verification
- uv run ruff check .
- uv run pyright
- uv run pytest -q -m "not live and not docker_live"
- git diff --check

Optional hosted/Docker smoke checks were not run because the required hosted/Docker opt-in env vars are unset.