### PR TITLE
[codex] Add sqlite-vec day one contracts

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -2,8 +2,7 @@
 # Copy this file to .env for local CLI, eval, and stdio MCP work.
 NVIDIA_API_KEY=
 POLICYNIM_ENV=development
-POLICYNIM_LANCEDB_URI=data/lancedb
-POLICYNIM_LANCEDB_TABLE=policy_chunks
+POLICYNIM_INDEX_DB_PATH=data/index.sqlite3
 POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH=data/runtime/runtime_rules.json
 POLICYNIM_RUNTIME_EVIDENCE_DB_PATH=data/runtime/runtime_evidence.sqlite3
 POLICYNIM_RUNTIME_SHELL_TIMEOUT_SECONDS=300

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,7 @@
 # .env.production.example when preparing hosted Railway variables.
 NVIDIA_API_KEY=
 POLICYNIM_ENV=development
-POLICYNIM_LANCEDB_URI=data/lancedb
-POLICYNIM_LANCEDB_TABLE=policy_chunks
+POLICYNIM_INDEX_DB_PATH=data/index.sqlite3
 POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH=data/runtime/runtime_rules.json
 POLICYNIM_RUNTIME_EVIDENCE_DB_PATH=data/runtime/runtime_evidence.sqlite3
 POLICYNIM_RUNTIME_SHELL_TIMEOUT_SECONDS=300

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ COPY src ./src
 COPY policies ./policies
 COPY evals ./evals
 
-RUN uv sync --frozen
+# Hosted services still use the legacy LanceDB store until service wiring moves
+# to SQLiteVecIndexStore; default package installs stay portable.
+RUN uv sync --frozen --extra hosted-legacy-index
 RUN --mount=type=secret,id=nvidia_api_key,required=true \
     sh -c 'NVIDIA_API_KEY="$(cat /run/secrets/nvidia_api_key)" uv run policynim ingest'
 

--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -19,7 +19,9 @@ COPY evals ./evals
 # Dockerfile still has to source the bake-time key from a build arg.
 ARG NVIDIA_API_KEY
 
-RUN uv sync --frozen
+# Hosted services still use the legacy LanceDB store until service wiring moves
+# to SQLiteVecIndexStore; default package installs stay portable.
+RUN uv sync --frozen --extra hosted-legacy-index
 RUN NVIDIA_API_KEY="${NVIDIA_API_KEY}" uv run policynim ingest
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ policynim init
 policynim ingest
 ```
 
+If your default Python is already supported, the shorter
+`pipx install policynim` and `uv tool install policynim` forms are also valid.
+
 Use `--python 3.12` instead when Python 3.12 is your managed runtime. If your
 machine does not expose `3.11` or `3.12` by name, pass the full path to that
 Python executable.

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -55,7 +55,7 @@ policynim init
 
 That command prompts for `NVIDIA_API_KEY` and an optional custom corpus
 directory, then writes the standalone `config.env` file under your platform
-config directory with user-owned defaults for `POLICYNIM_LANCEDB_URI`,
+config directory with user-owned defaults for `POLICYNIM_INDEX_DB_PATH`,
 `POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH`, `POLICYNIM_RUNTIME_EVIDENCE_DB_PATH`,
 and `POLICYNIM_EVAL_WORKSPACE_DIR`.
 
@@ -74,6 +74,9 @@ policynim --help
 policynim init
 policynim ingest
 ```
+
+If your default Python is already supported, the shorter
+`pipx install policynim` and `uv tool install policynim` forms are also valid.
 
 Use `--python 3.12` instead when Python 3.12 is your managed runtime. If your
 machine does not expose `3.11` or `3.12` by name, pass the full path to that
@@ -110,8 +113,7 @@ Core retrieval and grounding:
 
 - `NVIDIA_API_KEY`
 - `POLICYNIM_CORPUS_DIR`
-- `POLICYNIM_LANCEDB_URI`
-- `POLICYNIM_LANCEDB_TABLE`
+- `POLICYNIM_INDEX_DB_PATH`
 - `POLICYNIM_DEFAULT_TOP_K`
 - `POLICYNIM_NVIDIA_CHAT_MODEL`
 - `POLICYNIM_NVIDIA_BASE_URL`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ dependencies = [
   "httpx==0.27.2",
   "itsdangerous==2.2.0",
   "jinja2==3.1.6",
-  "lance-namespace==0.6.1",
-  "lance-namespace-urllib3-client==0.6.1",
-  "lancedb==0.27.1",
   "markdown-it-py==4.0.0",
   "mcp[cli]==1.26.0",
   "openai==2.29.0",
@@ -35,6 +32,7 @@ dependencies = [
   "platformdirs==4.5.0",
   "pydantic==2.12.5",
   "pydantic-settings==2.13.1",
+  "sqlite-vec==0.1.9",
   "typer==0.24.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ Issues = "https://github.com/nnennandukwe/policyNIM/issues"
 Repository = "https://github.com/nnennandukwe/policyNIM"
 
 [project.optional-dependencies]
+hosted-legacy-index = [
+  "lance-namespace==0.6.1",
+  "lance-namespace-urllib3-client==0.6.1",
+  "lancedb==0.27.1",
+]
 nvidia-guardrails = [
   "nemoguardrails[nvidia]==0.21.0",
 ]

--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -21,6 +21,7 @@ class StandalonePaths:
 
     config_file: Path
     data_root: Path
+    index_db_path: Path
     lancedb_uri: Path
     runtime_rules_artifact_path: Path
     runtime_evidence_db_path: Path
@@ -44,6 +45,7 @@ def standalone_paths() -> StandalonePaths:
     return StandalonePaths(
         config_file=config_root / "config.env",
         data_root=data_root,
+        index_db_path=data_root / "index.sqlite3",
         lancedb_uri=data_root / "lancedb",
         runtime_rules_artifact_path=data_root / "runtime" / "runtime_rules.json",
         runtime_evidence_db_path=data_root / "runtime" / "runtime_evidence.sqlite3",
@@ -154,7 +156,7 @@ def build_init_config_contents(
     if include_data_paths:
         lines.extend(
             [
-                _env_assignment("POLICYNIM_LANCEDB_URI", standalone.lancedb_uri.as_posix()),
+                _env_assignment("POLICYNIM_INDEX_DB_PATH", standalone.index_db_path.as_posix()),
                 _env_assignment(
                     "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
                     standalone.runtime_rules_artifact_path.as_posix(),

--- a/src/policynim/services/dump.py
+++ b/src/policynim/services/dump.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from policynim.contracts import IndexStore
-from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import PolicyChunk
 
 
@@ -23,9 +22,4 @@ class IndexDumpService:
 def create_index_dump_service(settings: Settings | None = None) -> IndexDumpService:
     """Build the default index dump service from application settings."""
     active_settings = settings or get_settings()
-    return IndexDumpService(
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        )
-    )
+    return IndexDumpService(index_store=create_legacy_index_store(active_settings))

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -28,7 +28,7 @@ from policynim.services.preflight import PreflightService
 from policynim.services.regeneration import PolicyRegenerationService
 from policynim.services.search import SearchService
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import (
     CompiledPolicyConstraint,
     CompiledPolicyPacket,
@@ -1259,10 +1259,7 @@ def _create_live_search_service(settings: Settings, *, rerank_enabled: bool) -> 
 
     return SearchService(
         embedder=NVIDIAEmbedder.from_settings(settings),
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(settings.lancedb_uri),
-            table_name=settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(settings),
         reranker=NVIDIAReranker.from_settings(settings) if rerank_enabled else None,
     )
 
@@ -1281,10 +1278,7 @@ def _create_live_preflight_service(
 
     return PreflightService(
         embedder=NVIDIAEmbedder.from_settings(settings),
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(settings.lancedb_uri),
-            table_name=settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(settings),
         reranker=(
             NVIDIAReranker.from_settings(settings) if rerank_enabled else _PassThroughReranker()
         ),
@@ -1336,10 +1330,7 @@ def _create_live_regeneration_service(
     try:
         compiler_service = PolicyCompilerService(
             embedder=NVIDIAEmbedder.from_settings(settings),
-            index_store=LanceDBIndexStore(
-                uri=resolve_runtime_path(settings.lancedb_uri),
-                table_name=settings.lancedb_table,
-            ),
+            index_store=create_legacy_index_store(settings),
             reranker=(
                 NVIDIAReranker.from_settings(settings) if rerank_enabled else _PassThroughReranker()
             ),

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -10,7 +10,7 @@ from policynim.errors import ConfigurationError
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services.ingest import create_ingest_service
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import HealthCheckResult
 
 LOGGER = logging.getLogger(__name__)
@@ -68,12 +68,8 @@ class RuntimeHealthService:
 def create_runtime_health_service(settings: Settings | None = None) -> RuntimeHealthService:
     """Build the default runtime health service from application settings."""
     active_settings = settings or get_settings()
-    index_uri = resolve_runtime_path(active_settings.lancedb_uri)
     return RuntimeHealthService(
-        index_store=LanceDBIndexStore(
-            uri=index_uri,
-            table_name=active_settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(active_settings),
         table_name=active_settings.lancedb_table,
         mcp_url=_derive_mcp_url(active_settings),
     )

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -13,7 +13,7 @@ from policynim.contracts import Embedder
 from policynim.ingest import chunk_policy_documents, load_policy_documents
 from policynim.runtime_paths import resolve_corpus_root, resolve_runtime_path
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import (
     CompiledRuntimeRule,
     EmbeddedChunk,
@@ -115,10 +115,7 @@ def create_ingest_service(settings: Settings | None = None) -> IngestService:
     active_settings = settings or get_settings()
     return IngestService(
         embedder=_create_default_embedder(active_settings),
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(active_settings),
         corpus_root=resolve_corpus_root(active_settings.corpus_dir),
         embedding_model=active_settings.nvidia_embed_model,
         runtime_rules_artifact_path=resolve_runtime_path(

--- a/src/policynim/services/router.py
+++ b/src/policynim/services/router.py
@@ -9,9 +9,8 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
-from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import (
     PolicyMetadata,
     PolicySelectionPacket,
@@ -157,10 +156,7 @@ def create_policy_router_service(settings: Settings | None = None) -> PolicyRout
     embedder, reranker = _create_default_router_components(active_settings)
     return PolicyRouterService(
         embedder=embedder,
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(active_settings),
         reranker=reranker,
     )
 

--- a/src/policynim/services/runtime_decision.py
+++ b/src/policynim/services/runtime_decision.py
@@ -21,7 +21,7 @@ from policynim.errors import (
 )
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import (
     Citation,
     CompiledRuntimeRule,
@@ -122,10 +122,7 @@ def create_runtime_decision_service(settings: Settings | None = None) -> Runtime
     """Build the default runtime decision service from application settings."""
     active_settings = settings or get_settings()
     return RuntimeDecisionService(
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(active_settings),
         runtime_rules_artifact_path=resolve_runtime_path(
             active_settings.runtime_rules_artifact_path
         ),

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -6,9 +6,8 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
-from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
-from policynim.storage import LanceDBIndexStore
+from policynim.storage import create_legacy_index_store
 from policynim.types import SearchRequest, SearchResult
 
 _DEFAULT_RERANK_CANDIDATE_POOL = 15
@@ -82,10 +81,7 @@ def create_search_service(settings: Settings | None = None) -> SearchService:
     embedder, reranker = _create_default_search_components(active_settings)
     return SearchService(
         embedder=embedder,
-        index_store=LanceDBIndexStore(
-            uri=resolve_runtime_path(active_settings.lancedb_uri),
-            table_name=active_settings.lancedb_table,
-        ),
+        index_store=create_legacy_index_store(active_settings),
         reranker=reranker,
     )
 

--- a/src/policynim/settings.py
+++ b/src/policynim/settings.py
@@ -36,6 +36,7 @@ class StandaloneDefaultPathsSource(PydanticBaseSettingsSource):
         return None, field_name, False
 
     def __call__(self) -> dict[str, Any]:
+        """Return standalone path defaults outside source checkouts."""
         if _should_use_repo_relative_defaults():
             return {}
 

--- a/src/policynim/settings.py
+++ b/src/policynim/settings.py
@@ -41,6 +41,7 @@ class StandaloneDefaultPathsSource(PydanticBaseSettingsSource):
 
         standalone = config_discovery.standalone_paths()
         return {
+            "index_db_path": standalone.index_db_path,
             "lancedb_uri": standalone.lancedb_uri,
             "runtime_rules_artifact_path": standalone.runtime_rules_artifact_path,
             "runtime_evidence_db_path": standalone.runtime_evidence_db_path,
@@ -64,6 +65,10 @@ class Settings(BaseSettings):
     nvidia_api_key: str | None = Field(default=None, validation_alias="NVIDIA_API_KEY")
     policynim_env: str = Field(default="development", validation_alias="POLICYNIM_ENV")
     corpus_dir: Path | None = None
+    index_db_path: Path = Field(
+        default=Path("data/index.sqlite3"),
+        validation_alias=AliasChoices("POLICYNIM_INDEX_DB_PATH", "POLICYNIM_LANCEDB_URI"),
+    )
     lancedb_uri: Path = Path("data/lancedb")
     lancedb_table: str = "policy_chunks"
     runtime_rules_artifact_path: Path = Path("data/runtime/runtime_rules.json")
@@ -171,6 +176,14 @@ class Settings(BaseSettings):
     def normalize_empty_corpus_dir(cls, value: Any) -> Any:
         """Treat empty configured corpus values as unset."""
         return _normalize_optional_setting(value)
+
+    @field_validator("index_db_path", mode="before")
+    @classmethod
+    def validate_index_db_path(cls, value: Any) -> Any:
+        """Reject empty configured local index paths before Path coercion."""
+        if isinstance(value, str) and not value.strip():
+            raise ValueError("POLICYNIM_INDEX_DB_PATH must not be empty.")
+        return value
 
     @field_validator("mcp_bearer_tokens", mode="before")
     @classmethod

--- a/src/policynim/storage/__init__.py
+++ b/src/policynim/storage/__init__.py
@@ -1,7 +1,13 @@
 """Storage adapters for PolicyNIM."""
 
 from policynim.storage.auth_store import AuthStore
+from policynim.storage.index_store import create_legacy_index_store
 from policynim.storage.lancedb import LanceDBIndexStore
 from policynim.storage.runtime_evidence import RuntimeEvidenceStore
 
-__all__ = ["AuthStore", "LanceDBIndexStore", "RuntimeEvidenceStore"]
+__all__ = [
+    "AuthStore",
+    "LanceDBIndexStore",
+    "RuntimeEvidenceStore",
+    "create_legacy_index_store",
+]

--- a/src/policynim/storage/index_store.py
+++ b/src/policynim/storage/index_store.py
@@ -1,0 +1,42 @@
+"""Index-store factory helpers for transition-era storage wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from policynim.errors import ConfigurationError
+from policynim.runtime_paths import resolve_runtime_path
+from policynim.settings import Settings
+from policynim.storage.lancedb import LanceDBIndexStore
+
+
+def create_legacy_index_store(settings: Settings) -> LanceDBIndexStore:
+    """Build the temporary LanceDB-backed index store with a controlled failure path."""
+    index_uri = resolve_runtime_path(settings.lancedb_uri)
+    try:
+        return LanceDBIndexStore(
+            uri=index_uri,
+            table_name=settings.lancedb_table,
+        )
+    except ModuleNotFoundError as exc:
+        if _is_missing_lancedb_backend(exc):
+            raise ConfigurationError(
+                _missing_legacy_backend_message(index_uri=index_uri),
+                failure_class="missing_index_backend",
+            ) from exc
+        raise
+
+
+def _is_missing_lancedb_backend(exc: ModuleNotFoundError) -> bool:
+    """Return whether a missing-module error came from the LanceDB backend."""
+    missing_name = exc.name or str(exc)
+    return missing_name == "lancedb" or missing_name.startswith("lancedb.")
+
+
+def _missing_legacy_backend_message(*, index_uri: Path) -> str:
+    """Return install guidance for the temporary hosted legacy index backend."""
+    return (
+        "The current service wiring still uses the temporary LanceDB index backend at "
+        f"{index_uri}. Install the `hosted-legacy-index` extra for this transition path "
+        "or use a build that wires `POLICYNIM_INDEX_DB_PATH` to SQLiteVecIndexStore."
+    )

--- a/src/policynim/storage/lancedb.py
+++ b/src/policynim/storage/lancedb.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from importlib import import_module
 from pathlib import Path
 from typing import Any, cast
-
-import lancedb
 
 from policynim.contracts import IndexStore
 from policynim.errors import MissingIndexError
@@ -20,6 +19,7 @@ class LanceDBIndexStore(IndexStore):
         self._uri = uri
         self._table_name = table_name
         self._uri.mkdir(parents=True, exist_ok=True)
+        lancedb = import_module("lancedb")
         connect = cast(Any, getattr(lancedb, "connect"))
         self._db = connect(self._uri.as_posix())
 

--- a/src/policynim/storage/lancedb.py
+++ b/src/policynim/storage/lancedb.py
@@ -16,6 +16,7 @@ class LanceDBIndexStore(IndexStore):
     """Stores embedded policy chunks in a local LanceDB table."""
 
     def __init__(self, *, uri: Path, table_name: str) -> None:
+        """Connect to the configured LanceDB table location."""
         self._uri = uri
         self._table_name = table_name
         self._uri.mkdir(parents=True, exist_ok=True)

--- a/src/policynim/storage/sqlite_vec.py
+++ b/src/policynim/storage/sqlite_vec.py
@@ -1,0 +1,47 @@
+"""Planned sqlite-vec local vector storage for PolicyNIM."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from policynim.contracts import IndexStore
+from policynim.types import EmbeddedChunk, PolicyChunk, ScoredChunk
+
+
+class SQLiteVecIndexStore(IndexStore):
+    """Day 1 skeleton for the future sqlite-vec-backed index store."""
+
+    def __init__(self, *, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        """Return the configured SQLite index file path."""
+        return self._path
+
+    def replace(self, chunks: Sequence[EmbeddedChunk]) -> None:
+        """Replace the local index contents with embedded chunks."""
+        raise NotImplementedError("SQLiteVecIndexStore is implemented on Day 2.")
+
+    def exists(self) -> bool:
+        """Return whether the local index exists."""
+        raise NotImplementedError("SQLiteVecIndexStore is implemented on Day 2.")
+
+    def count(self) -> int:
+        """Return the number of rows in the local index."""
+        raise NotImplementedError("SQLiteVecIndexStore is implemented on Day 2.")
+
+    def list_chunks(self) -> list[PolicyChunk]:
+        """Return all indexed chunks without embeddings."""
+        raise NotImplementedError("SQLiteVecIndexStore is implemented on Day 2.")
+
+    def search(
+        self,
+        query_embedding: Sequence[float],
+        *,
+        top_k: int,
+        domain: str | None = None,
+    ) -> list[ScoredChunk]:
+        """Search the local index and return scored chunks."""
+        raise NotImplementedError("SQLiteVecIndexStore is implemented on Day 2.")

--- a/src/policynim/storage/sqlite_vec.py
+++ b/src/policynim/storage/sqlite_vec.py
@@ -13,6 +13,7 @@ class SQLiteVecIndexStore(IndexStore):
     """Day 1 skeleton for the future sqlite-vec-backed index store."""
 
     def __init__(self, *, path: Path) -> None:
+        """Record the SQLite index database path for future store operations."""
         self._path = path
 
     @property

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1582,7 +1582,7 @@ def test_init_command_writes_config_and_prints_next_step(
     assert config_path.read_text(encoding="utf-8") == (
         "NVIDIA_API_KEY='nvapi-test-key'\n"
         f"POLICYNIM_CORPUS_DIR='{custom_corpus}'\n"
-        f"POLICYNIM_LANCEDB_URI='{data_root / 'lancedb'}'\n"
+        f"POLICYNIM_INDEX_DB_PATH='{data_root / 'index.sqlite3'}'\n"
         f"POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH='{data_root / 'runtime' / 'runtime_rules.json'}'\n"
         "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH="
         f"'{data_root / 'runtime' / 'runtime_evidence.sqlite3'}'\n"

--- a/tests/test_dockerfile_contract.py
+++ b/tests/test_dockerfile_contract.py
@@ -50,6 +50,14 @@ def test_container_builds_include_project_metadata_files() -> None:
         assert "COPY pyproject.toml uv.lock README.md LICENSE ./" in text
 
 
+def test_hosted_container_builds_sync_legacy_index_extra() -> None:
+    """Keep hosted deploys alive while the default package removes LanceDB."""
+    for path in (DOCKERFILE, RAILWAY_DOCKERFILE):
+        text = _read_text(path)
+
+        assert "uv sync --frozen --extra hosted-legacy-index" in text
+
+
 def test_hosted_operations_doc_explains_railway_dockerfile_split() -> None:
     text = " ".join(_read_text(HOSTED_OPERATIONS).split())
 

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -64,6 +64,7 @@ class RecordingIndexStore:
 
 
 def test_ingest_service_builds_and_rebuilds_local_index(tmp_path: Path) -> None:
+    pytest.importorskip("lancedb")
     policies_dir = tmp_path / "policies"
     artifact_path = tmp_path / "runtime" / "runtime_rules.json"
     write_policy(

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -64,6 +64,7 @@ class RecordingIndexStore:
 
 
 def test_ingest_service_builds_and_rebuilds_local_index(tmp_path: Path) -> None:
+    """Build and rebuild the legacy LanceDB index when that backend is installed."""
     pytest.importorskip("lancedb")
     policies_dir = tmp_path / "policies"
     artifact_path = tmp_path / "runtime" / "runtime_rules.json"

--- a/tests/test_package_release.py
+++ b/tests/test_package_release.py
@@ -15,12 +15,23 @@ def _project() -> dict[str, Any]:
     return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
 
 
-def test_runtime_dependencies_pin_lance_namespace_for_clean_wheel_installs() -> None:
-    """Prevent pip/pipx from resolving a lancedb-incompatible namespace client."""
+def test_runtime_dependencies_pin_sqlite_vec_for_portable_local_index() -> None:
+    """Keep the local index backend compatible with standalone release targets."""
     dependencies = set(_project()["project"]["dependencies"])
 
-    assert "lance-namespace==0.6.1" in dependencies
-    assert "lance-namespace-urllib3-client==0.6.1" in dependencies
+    assert "sqlite-vec==0.1.9" in dependencies
+
+
+def test_runtime_dependencies_do_not_ship_lancedb_backend() -> None:
+    """Prevent standalone releases from depending on missing macOS x86_64 wheels."""
+    dependencies = {
+        dependency.split("==", maxsplit=1)[0].lower()
+        for dependency in _project()["project"]["dependencies"]
+    }
+
+    assert "lancedb" not in dependencies
+    assert "lance-namespace" not in dependencies
+    assert "lance-namespace-urllib3-client" not in dependencies
 
 
 def test_package_metadata_is_ready_for_public_install_channels() -> None:

--- a/tests/test_package_release.py
+++ b/tests/test_package_release.py
@@ -34,6 +34,17 @@ def test_runtime_dependencies_do_not_ship_lancedb_backend() -> None:
     assert "lance-namespace-urllib3-client" not in dependencies
 
 
+def test_hosted_legacy_index_extra_pins_temporary_lancedb_backend() -> None:
+    """Let hosted Linux builds keep working until service wiring moves to SQLite."""
+    optional_dependencies = _project()["project"]["optional-dependencies"]
+
+    assert optional_dependencies["hosted-legacy-index"] == [
+        "lance-namespace==0.6.1",
+        "lance-namespace-urllib3-client==0.6.1",
+        "lancedb==0.27.1",
+    ]
+
+
 def test_package_metadata_is_ready_for_public_install_channels() -> None:
     """Keep PyPI and GitHub release metadata useful for first-time installers."""
     project = _project()["project"]

--- a/tests/test_service_factories.py
+++ b/tests/test_service_factories.py
@@ -71,6 +71,41 @@ import policynim.services.runtime_execution
     assert result.returncode == 0, result.stderr
 
 
+def test_service_modules_import_without_legacy_lancedb_backend() -> None:
+    script = f"""
+import importlib.abc
+import sys
+
+sys.path.insert(0, {str(PROJECT_ROOT / "src")!r})
+
+class BlockLegacyLanceDB(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "lancedb" or fullname.startswith("lancedb."):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+sys.meta_path.insert(0, BlockLegacyLanceDB())
+
+import policynim.services
+import policynim.services.ingest
+import policynim.services.eval
+import policynim.services.search
+import policynim.services.preflight
+import policynim.services.router
+import policynim.services.compiler
+import policynim.services.runtime_decision
+import policynim.storage
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_create_ingest_service_builds_default_components(monkeypatch, tmp_path: Path) -> None:
     mock_embedder = object()
     monkeypatch.setattr(ingest_module, "_create_default_embedder", lambda settings: mock_embedder)

--- a/tests/test_service_factories.py
+++ b/tests/test_service_factories.py
@@ -15,6 +15,7 @@ import policynim.services.runtime_decision as runtime_decision_module
 import policynim.services.runtime_evidence_report as runtime_evidence_report_module
 import policynim.services.runtime_execution as runtime_execution_module
 import policynim.services.search as search_module
+from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -33,6 +34,14 @@ class MockRuntimeEvidenceStore:
 
     def __init__(self, *, path: Path) -> None:
         self.path = path
+
+
+def mock_index_store_from_settings(settings: Settings) -> MockIndexStore:
+    """Build a mock index store from settings using runtime path semantics."""
+    return MockIndexStore(
+        uri=resolve_runtime_path(settings.lancedb_uri),
+        table_name=settings.lancedb_table,
+    )
 
 
 def test_service_modules_import_without_provider_package() -> None:
@@ -72,6 +81,7 @@ import policynim.services.runtime_execution
 
 
 def test_service_modules_import_without_legacy_lancedb_backend() -> None:
+    """Import service modules when the transition-era LanceDB backend is absent."""
     script = f"""
 import importlib.abc
 import sys
@@ -106,10 +116,48 @@ import policynim.storage
     assert result.returncode == 0, result.stderr
 
 
+def test_legacy_index_factory_reports_missing_backend() -> None:
+    """Fail with ConfigurationError instead of raw ModuleNotFoundError."""
+    script = f"""
+import importlib.abc
+import sys
+
+sys.path.insert(0, {str(PROJECT_ROOT / "src")!r})
+
+class BlockLegacyLanceDB(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "lancedb" or fullname.startswith("lancedb."):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+sys.meta_path.insert(0, BlockLegacyLanceDB())
+
+from policynim.errors import ConfigurationError
+from policynim.settings import Settings
+from policynim.storage import create_legacy_index_store
+
+try:
+    create_legacy_index_store(Settings())
+except ConfigurationError as exc:
+    assert exc.failure_class == "missing_index_backend"
+    assert "hosted-legacy-index" in str(exc)
+else:
+    raise AssertionError("expected ConfigurationError")
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_create_ingest_service_builds_default_components(monkeypatch, tmp_path: Path) -> None:
     mock_embedder = object()
     monkeypatch.setattr(ingest_module, "_create_default_embedder", lambda settings: mock_embedder)
-    monkeypatch.setattr(ingest_module, "LanceDBIndexStore", MockIndexStore)
+    monkeypatch.setattr(ingest_module, "create_legacy_index_store", mock_index_store_from_settings)
 
     settings = Settings(
         corpus_dir=tmp_path / "policies",
@@ -139,7 +187,7 @@ def test_create_search_service_builds_default_components(monkeypatch, tmp_path: 
         "_create_default_search_components",
         lambda settings: (mock_embedder, mock_reranker),
     )
-    monkeypatch.setattr(search_module, "LanceDBIndexStore", MockIndexStore)
+    monkeypatch.setattr(search_module, "create_legacy_index_store", mock_index_store_from_settings)
 
     settings = Settings(lancedb_uri=tmp_path / "search-index")
 
@@ -163,7 +211,7 @@ def test_create_policy_router_service_builds_default_components(
         "_create_default_router_components",
         lambda settings: (mock_embedder, mock_reranker),
     )
-    monkeypatch.setattr(router_module, "LanceDBIndexStore", MockIndexStore)
+    monkeypatch.setattr(router_module, "create_legacy_index_store", mock_index_store_from_settings)
 
     settings = Settings(lancedb_uri=tmp_path / "router-index")
 
@@ -264,7 +312,11 @@ def test_create_runtime_decision_service_uses_runtime_paths(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(runtime_decision_module, "LanceDBIndexStore", MockIndexStore)
+    monkeypatch.setattr(
+        runtime_decision_module,
+        "create_legacy_index_store",
+        mock_index_store_from_settings,
+    )
 
     settings = Settings(
         lancedb_uri=tmp_path / "runtime-index",

--- a/tests/test_settings_and_types.py
+++ b/tests/test_settings_and_types.py
@@ -45,6 +45,7 @@ def clear_config_precedence_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in (
         "POLICYNIM_CONFIG_FILE",
         "POLICYNIM_DEFAULT_TOP_K",
+        "POLICYNIM_INDEX_DB_PATH",
         "POLICYNIM_LANCEDB_URI",
         "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
         "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
@@ -180,8 +181,51 @@ def test_settings_uses_user_config_and_standalone_defaults_when_no_local_dotenv(
     settings = Settings()
 
     assert settings.default_top_k == 8
+    assert settings.index_db_path == data_root / "index.sqlite3"
     assert settings.lancedb_uri == data_root / "lancedb"
     assert settings.eval_workspace_dir == data_root / "evals" / "workspace"
+
+
+def test_settings_uses_index_db_path_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("POLICYNIM_INDEX_DB_PATH", str(tmp_path / "index.sqlite3"))
+
+    settings = load_settings_without_env_file()
+
+    assert settings.index_db_path == tmp_path / "index.sqlite3"
+
+
+def test_settings_maps_deprecated_lancedb_uri_to_index_db_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("POLICYNIM_LANCEDB_URI", str(tmp_path / "legacy-index"))
+
+    settings = load_settings_without_env_file()
+
+    assert settings.index_db_path == tmp_path / "legacy-index"
+
+
+def test_settings_prefers_index_db_path_over_deprecated_lancedb_uri(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("POLICYNIM_INDEX_DB_PATH", str(tmp_path / "index.sqlite3"))
+    monkeypatch.setenv("POLICYNIM_LANCEDB_URI", str(tmp_path / "legacy-index"))
+
+    settings = load_settings_without_env_file()
+
+    assert settings.index_db_path == tmp_path / "index.sqlite3"
+
+
+def test_settings_allows_constructor_index_db_path(tmp_path: Path) -> None:
+    settings = load_settings_without_env_file(index_db_path=tmp_path / "index.sqlite3")
+
+    assert settings.index_db_path == tmp_path / "index.sqlite3"
+
+
+def test_settings_rejects_empty_index_db_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLICYNIM_INDEX_DB_PATH", "")
+
+    with pytest.raises(ValidationError, match="POLICYNIM_INDEX_DB_PATH must not be empty"):
+        load_settings_without_env_file()
 
 
 def test_settings_prefers_explicit_config_file_over_cwd_dotenv_and_user_config(
@@ -257,6 +301,7 @@ def test_settings_ignores_config_file_from_discovered_user_config(
 
     assert settings.default_top_k == 8
     assert settings.config_file is None
+    assert settings.index_db_path == data_root / "index.sqlite3"
     assert settings.lancedb_uri == data_root / "lancedb"
 
 
@@ -341,6 +386,11 @@ def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces
     custom_corpus = tmp_path / "Custom Policies"
     custom_corpus.mkdir(parents=True)
     config_path = config_root / "config.env"
+    workspace = tmp_path / "Installed App Workspace"
+    workspace.mkdir()
+    package_root = tmp_path / "site-packages" / "policynim"
+    package_root.mkdir(parents=True)
+    monkeypatch.chdir(workspace)
 
     monkeypatch.setattr(
         "policynim.config_discovery.user_config_path",
@@ -350,18 +400,26 @@ def test_settings_loads_quoted_init_config_values_with_paths_that_contain_spaces
         "policynim.config_discovery.user_data_path",
         lambda *args, **kwargs: data_root,
     )
+    monkeypatch.setattr(
+        "policynim.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
 
     config_discovery.write_init_config_file(
         destination=config_path,
         api_key="quoted-key",
         corpus_dir=custom_corpus,
     )
+    config_text = config_path.read_text(encoding="utf-8")
+    assert "POLICYNIM_INDEX_DB_PATH" in config_text
+    assert "POLICYNIM_LANCEDB_URI" not in config_text
 
     settings_type = cast(Any, Settings)
     settings = settings_type(_env_file=config_path)
 
     assert settings.nvidia_api_key == "quoted-key"
     assert settings.corpus_dir == custom_corpus.resolve(strict=False)
+    assert settings.index_db_path == data_root / "index.sqlite3"
     assert settings.lancedb_uri == data_root / "lancedb"
     assert settings.runtime_rules_artifact_path == data_root / "runtime" / "runtime_rules.json"
     assert settings.runtime_evidence_db_path == data_root / "runtime" / "runtime_evidence.sqlite3"

--- a/tests/test_sqlite_vec.py
+++ b/tests/test_sqlite_vec.py
@@ -1,0 +1,137 @@
+"""Contract tests for the planned sqlite-vec local index backend."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from policynim.errors import MissingIndexError
+from policynim.types import EmbeddedChunk, PolicyMetadata
+
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="Day 2 implements SQLiteVecIndexStore against this contract.",
+)
+
+
+def test_sqlite_vec_store_replaces_and_searches_chunks(tmp_path: Path) -> None:
+    """Store, count, list, and search embedded chunks from one SQLite file."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    store = SQLiteVecIndexStore(path=tmp_path / "index.sqlite3")
+    chunks = [
+        make_chunk("BACKEND-1", domain="backend", vector=[1.0, 0.0]),
+        make_chunk("SECURITY-1", domain="security", vector=[0.0, 1.0]),
+    ]
+
+    store.replace(chunks)
+
+    assert store.path == tmp_path / "index.sqlite3"
+    assert store.exists() is True
+    assert store.count() == 2
+    assert [chunk.chunk_id for chunk in store.list_chunks()] == ["BACKEND-1", "SECURITY-1"]
+    assert [chunk.chunk_id for chunk in store.search([1.0, 0.0], top_k=1)] == ["BACKEND-1"]
+
+
+def test_sqlite_vec_store_filters_search_by_domain(tmp_path: Path) -> None:
+    """Keep the existing optional domain filter behavior."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    store = SQLiteVecIndexStore(path=tmp_path / "index.sqlite3")
+    store.replace(
+        [
+            make_chunk("BACKEND-1", domain="backend", vector=[1.0, 0.0]),
+            make_chunk("SECURITY-1", domain="security", vector=[0.9, 0.1]),
+        ]
+    )
+
+    results = store.search([1.0, 0.0], top_k=2, domain="security")
+
+    assert [chunk.chunk_id for chunk in results] == ["SECURITY-1"]
+
+
+def test_sqlite_vec_store_round_trips_json_metadata(tmp_path: Path) -> None:
+    """Preserve list metadata through SQLite JSON serialization."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    store = SQLiteVecIndexStore(path=tmp_path / "index.sqlite3")
+    store.replace(
+        [
+            make_chunk(
+                "BACKEND-1",
+                domain="backend",
+                vector=[1.0, 0.0],
+                tags=["observability", "backend"],
+                grounded_in=["https://example.com/policy"],
+            )
+        ]
+    )
+
+    [chunk] = store.list_chunks()
+
+    assert chunk.policy.tags == ["observability", "backend"]
+    assert chunk.policy.grounded_in == ["https://example.com/policy"]
+
+
+def test_sqlite_vec_store_rejects_empty_or_inconsistent_vectors(tmp_path: Path) -> None:
+    """Fail closed before creating a usable index for malformed embeddings."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    store = SQLiteVecIndexStore(path=tmp_path / "index.sqlite3")
+
+    with pytest.raises(MissingIndexError):
+        store.replace([])
+    with pytest.raises(MissingIndexError):
+        store.replace([make_chunk("BACKEND-1", vector=[])])
+    with pytest.raises(MissingIndexError):
+        store.replace(
+            [
+                make_chunk("BACKEND-1", vector=[1.0, 0.0]),
+                make_chunk("BACKEND-2", vector=[1.0, 0.0, 0.0]),
+            ]
+        )
+    assert store.exists() is False
+
+
+def test_sqlite_vec_store_failed_replace_preserves_existing_index(tmp_path: Path) -> None:
+    """A failed rebuild must not destroy the previous usable index."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    store = SQLiteVecIndexStore(path=tmp_path / "index.sqlite3")
+    store.replace([make_chunk("BACKEND-1", vector=[1.0, 0.0])])
+
+    with pytest.raises(MissingIndexError):
+        store.replace([make_chunk("BROKEN-1", vector=[])])
+
+    assert store.exists() is True
+    assert store.count() == 1
+    assert [chunk.chunk_id for chunk in store.list_chunks()] == ["BACKEND-1"]
+
+
+def make_chunk(
+    chunk_id: str,
+    *,
+    domain: str = "backend",
+    vector: Sequence[float],
+    tags: Sequence[str] = ("observability",),
+    grounded_in: Sequence[str] = ("https://example.com/policy",),
+) -> EmbeddedChunk:
+    """Build one embedded policy chunk for storage-contract tests."""
+    return EmbeddedChunk(
+        chunk_id=chunk_id,
+        path=f"policies/{domain}/{chunk_id.lower()}.md",
+        section="Rules",
+        lines="1-4",
+        text=f"{domain} guidance for {chunk_id}",
+        policy=PolicyMetadata(
+            policy_id=f"{domain.upper()}-POLICY-001",
+            title=f"{domain.title()} Policy",
+            doc_type="guidance",
+            domain=domain,
+            tags=list(tags),
+            grounded_in=list(grounded_in),
+        ),
+        vector=[float(value) for value in vector],
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -707,6 +707,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1391,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lance-namespace"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/35/135ee7e3de58389074ad49b389adb8f431dc3f0034afbed1a9122c223c68/lancedb-0.27.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8aea87c3002850e98e4ac095c165dd819edd69f7c50e418f13f5917d1b9e0dcb", size = 43540316, upload-time = "2026-01-26T23:56:19.228Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cf/ea458fa50ef29c1a0653e1af6ea0599e532180267f49ca0bcf0049b0d8e3/lancedb-0.27.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:382666cddfb8b87d1efef4797bbc92cb1c3263b9b40894e5194ed5ed4e4486d4", size = 45409178, upload-time = "2026-01-27T03:25:09.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cd/30714b878ec876eda3ce88637d6ef8da44484a065ec050dcfba3ad888465/lancedb-0.27.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7835e84d92631ddc7e269c8a18691ec16f24fe32f0fd14138d76951f530c28b9", size = 48484253, upload-time = "2026-01-27T03:28:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/19c1b8b7b36a0445e31fa532619bb75c4e76a91fff0514439dea2c4194d6/lancedb-0.27.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5996f7e36ae4cf580693fae33f560a21f29640b1ae0e923dcd8efea65ee8a78e", size = 45427415, upload-time = "2026-01-27T03:23:26.822Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f1/794e9bc8d2adc9130c55695979afb66b0121c9d2abacdd19ce112e201879/lancedb-0.27.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:37e80565729555f6fc390a623da4f26392c463ba35e7634b2e706c1f9ac77e47", size = 48531937, upload-time = "2026-01-27T03:27:57.455Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/96/fa3cb37a6ffe7b81073d8c74f7cb95204d0922ac1668b264685aa34add20/lancedb-0.27.1-cp39-abi3-win_amd64.whl", hash = "sha256:f2150a66758ce6fe3cff226ac1ffcac2d5f5e2c9b35bc4c2d5923abcebef98cc", size = 53374010, upload-time = "2026-01-27T03:57:13.434Z" },
 ]
 
 [[package]]
@@ -2594,6 +2656,15 @@ wheels = [
 ]
 
 [[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2756,6 +2827,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+hosted-legacy-index = [
+    { name = "lance-namespace" },
+    { name = "lance-namespace-urllib3-client" },
+    { name = "lancedb" },
+]
 nvidia-eval = [
     { name = "nemo-evaluator" },
     { name = "nvidia-nat-eval" },
@@ -2789,6 +2865,9 @@ requires-dist = [
     { name = "httpx", specifier = "==0.27.2" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "lance-namespace", marker = "extra == 'hosted-legacy-index'", specifier = "==0.6.1" },
+    { name = "lance-namespace-urllib3-client", marker = "extra == 'hosted-legacy-index'", specifier = "==0.6.1" },
+    { name = "lancedb", marker = "extra == 'hosted-legacy-index'", specifier = "==0.27.1" },
     { name = "markdown-it-py", specifier = "==4.0.0" },
     { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
     { name = "nemo-evaluator", marker = "extra == 'nvidia-eval'", specifier = "==0.2.5" },
@@ -2805,7 +2884,7 @@ requires-dist = [
     { name = "sqlite-vec", specifier = "==0.1.9" },
     { name = "typer", specifier = "==0.24.1" },
 ]
-provides-extras = ["nvidia-guardrails", "nvidia-eval", "nvidia-eval-launcher"]
+provides-extras = ["hosted-legacy-index", "nvidia-guardrails", "nvidia-eval", "nvidia-eval-launcher"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -707,18 +707,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecation"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1391,56 +1379,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "lance-namespace"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lance-namespace-urllib3-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
-]
-
-[[package]]
-name = "lance-namespace-urllib3-client"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
-]
-
-[[package]]
-name = "lancedb"
-version = "0.27.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecation" },
-    { name = "lance-namespace" },
-    { name = "numpy" },
-    { name = "overrides", marker = "python_full_version < '3.12'" },
-    { name = "packaging" },
-    { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "tqdm" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/35/135ee7e3de58389074ad49b389adb8f431dc3f0034afbed1a9122c223c68/lancedb-0.27.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8aea87c3002850e98e4ac095c165dd819edd69f7c50e418f13f5917d1b9e0dcb", size = 43540316, upload-time = "2026-01-26T23:56:19.228Z" },
-    { url = "https://files.pythonhosted.org/packages/16/cf/ea458fa50ef29c1a0653e1af6ea0599e532180267f49ca0bcf0049b0d8e3/lancedb-0.27.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:382666cddfb8b87d1efef4797bbc92cb1c3263b9b40894e5194ed5ed4e4486d4", size = 45409178, upload-time = "2026-01-27T03:25:09.932Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/cd/30714b878ec876eda3ce88637d6ef8da44484a065ec050dcfba3ad888465/lancedb-0.27.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7835e84d92631ddc7e269c8a18691ec16f24fe32f0fd14138d76951f530c28b9", size = 48484253, upload-time = "2026-01-27T03:28:16.048Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c2/19c1b8b7b36a0445e31fa532619bb75c4e76a91fff0514439dea2c4194d6/lancedb-0.27.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5996f7e36ae4cf580693fae33f560a21f29640b1ae0e923dcd8efea65ee8a78e", size = 45427415, upload-time = "2026-01-27T03:23:26.822Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/f1/794e9bc8d2adc9130c55695979afb66b0121c9d2abacdd19ce112e201879/lancedb-0.27.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:37e80565729555f6fc390a623da4f26392c463ba35e7634b2e706c1f9ac77e47", size = 48531937, upload-time = "2026-01-27T03:27:57.455Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/96/fa3cb37a6ffe7b81073d8c74f7cb95204d0922ac1668b264685aa34add20/lancedb-0.27.1-cp39-abi3-win_amd64.whl", hash = "sha256:f2150a66758ce6fe3cff226ac1ffcac2d5f5e2c9b35bc4c2d5923abcebef98cc", size = 53374010, upload-time = "2026-01-27T03:57:13.434Z" },
 ]
 
 [[package]]
@@ -2656,15 +2594,6 @@ wheels = [
 ]
 
 [[package]]
-name = "overrides"
-version = "7.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2815,9 +2744,6 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
-    { name = "lance-namespace" },
-    { name = "lance-namespace-urllib3-client" },
-    { name = "lancedb" },
     { name = "markdown-it-py" },
     { name = "mcp", extra = ["cli"] },
     { name = "openai" },
@@ -2825,6 +2751,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "sqlite-vec" },
     { name = "typer" },
 ]
 
@@ -2862,9 +2789,6 @@ requires-dist = [
     { name = "httpx", specifier = "==0.27.2" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lance-namespace", specifier = "==0.6.1" },
-    { name = "lance-namespace-urllib3-client", specifier = "==0.6.1" },
-    { name = "lancedb", specifier = "==0.27.1" },
     { name = "markdown-it-py", specifier = "==4.0.0" },
     { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
     { name = "nemo-evaluator", marker = "extra == 'nvidia-eval'", specifier = "==0.2.5" },
@@ -2878,6 +2802,7 @@ requires-dist = [
     { name = "platformdirs", specifier = "==4.5.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.13.1" },
+    { name = "sqlite-vec", specifier = "==0.1.9" },
     { name = "typer", specifier = "==0.24.1" },
 ]
 provides-extras = ["nvidia-guardrails", "nvidia-eval", "nvidia-eval-launcher"]
@@ -3818,6 +3743,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/84/065a21e9a578ef13d9749c2bf3c382f7e50a1644af7d7a109924fbc6faee/sqlean_py-3.49.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae92413470409b3b3678c797db82c1d247b6ed2198017b5e893d9fc0606e061f", size = 3008238, upload-time = "2025-05-02T11:57:58.927Z" },
     { url = "https://files.pythonhosted.org/packages/e8/e5/d980bf0c5e67cfd4486b5e6d8daea6815fdac57b3d0899c23127a30283b5/sqlean_py-3.49.1-cp312-cp312-win_amd64.whl", hash = "sha256:b45ed4adb8442299019988d5e90aa1474f3ef8c71f6e8921a70705b9d971c590", size = 804506, upload-time = "2025-05-02T11:58:00.583Z" },
     { url = "https://files.pythonhosted.org/packages/f2/d1/8828ec685022e2b86ebd717743359dd5e8eab70a9c1ebff78aa733848216/sqlean_py-3.49.1-cp312-cp312-win_arm64.whl", hash = "sha256:c2537f69879adaed22b16e840d494c440ece5b49d28a5a51094e6c8ca6a2b0a5", size = 739690, upload-time = "2025-05-02T11:58:02.262Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `POLICYNIM_INDEX_DB_PATH` as the canonical local index setting while keeping `POLICYNIM_LANCEDB_URI` as a deprecated compatibility alias
- replace default runtime LanceDB package pins with `sqlite-vec==0.1.9` for portable local installs and standalone assets
- add a temporary `hosted-legacy-index` extra so Docker/Railway can keep using the current LanceDB service wiring until the SQLite store is wired in
- add a transition-era index-store factory so missing legacy backends fail with `ConfigurationError` instead of raw `ModuleNotFoundError`
- add the Day 2 `SQLiteVecIndexStore` skeleton plus strict-xfail storage contract tests
- update local env examples and narrow contributor/install docs for the new neutral index path

## Notes
- Hosted production config intentionally remains on the current baked LanceDB path until service rewiring lands in a later migration day.
- The SQLite store behavior is not implemented in this PR; the five `tests/test_sqlite_vec.py` cases are strict xfails that define the Day 2 contract.
- Legacy LanceDB imports are lazy, Docker/Railway explicitly opt into the temporary hosted legacy backend, and default service factories now have a controlled missing-backend error.
- Qodo inline findings 1-6 were addressed and replied to. The summary-only `Index path config ignored` recommendation is deferred to the Day 2 SQLite service-wiring PR.

## Validation
- `uv run pytest -q -m "not live and not docker_live"` -> `511 passed, 1 skipped, 10 deselected, 5 xfailed`
- `uv run pyright` -> `0 errors`
- `uv run ruff check .`
- `uv lock --check`
- `git diff --check`
- hosted-extra smoke: `uv sync --frozen --group test --group dev --extra hosted-legacy-index` then `create_ingest_service(...)` -> `IngestService`
- PR checks: GitHub lint/test pass; Railway deployment pass
