### PR TITLE
[codex] Gate PyPI publish behind release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,8 +268,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-24.04
     needs:
-      - verify
-      - wheel-smoke
+      - publish-github-release
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_pypi)
     environment: pypi
     permissions:

--- a/docs/release.md
+++ b/docs/release.md
@@ -74,7 +74,9 @@ downloaded asset.
 
 PyPI publishing uses PyPI trusted publishing through GitHub OIDC. Configure the
 PyPI project to trust this repository and the `pypi` GitHub environment before
-using the `publish-pypi` job.
+using the `publish-pypi` job. The release workflow runs `publish-pypi` only
+after the GitHub release asset job succeeds, because PyPI versions are immutable
+once uploaded.
 
 For normal releases, publish PyPI from the final `vX.Y.Z` tag. For manual
 workflow dispatches, leave `publish_pypi=false` unless you intentionally want to

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -85,6 +85,23 @@ def test_release_workflow_uses_pinned_actions_and_trusted_pypi_publish() -> None
     assert "TWINE_PASSWORD" not in text
 
 
+def test_release_workflow_publishes_pypi_after_release_assets() -> None:
+    """Do not let immutable PyPI files publish before release assets pass."""
+    text = _read_text(RELEASE_WORKFLOW)
+
+    publish_pypi_job = re.search(
+        r"publish-pypi:\n(?P<body>.*?)(?=\n  [a-zA-Z0-9_-]+:|\Z)",
+        text,
+        re.S,
+    )
+    assert publish_pypi_job is not None
+    body = publish_pypi_job.group("body")
+
+    assert "needs:\n      - publish-github-release" in body
+    assert "pypa/gh-action-pypi-publish@" in body
+    assert text.index("publish-github-release:") < text.index("publish-pypi:")
+
+
 def test_release_workflow_uploads_expected_install_artifacts() -> None:
     """Lock the public artifact contract used by curl and PowerShell installers."""
     text = _read_text(RELEASE_WORKFLOW)


### PR DESCRIPTION
## Summary

This PR keeps PyPI publishing behind the GitHub release asset job so immutable PyPI files cannot upload before the release payload path succeeds.

## Root Cause

`publish-pypi` previously depended only on `verify` and `wheel-smoke`, while `publish-github-release` also waited for standalone artifacts. That allowed a PyPI upload from one run to get ahead of the final release run and SHA.

## Changes

- Make `publish-pypi` depend on `publish-github-release`.
- Add a workflow contract test for the release job ordering.
- Document why PyPI publishing runs after release assets.

## Validation

- `uv run ruff check tests/test_ci_workflows.py`
- `uv run pytest -q tests/test_ci_workflows.py`
- pre-commit hook: `ruff check`, `ruff format`, `pyright`
