### PR TITLE
[codex] Restore macOS Intel release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
           - os: macos-14
             platform: darwin-arm64
             archive: tar
+          - os: macos-15-intel
+            platform: darwin-amd64
+            archive: tar
           - os: windows-2022
             platform: windows-amd64
             archive: zip
@@ -168,6 +171,7 @@ jobs:
           case "${{ matrix.platform }}" in
             linux-amd64) ASSET_NAME="policynim-${RELEASE_TAG}-linux-amd64.tar.gz" ;;
             darwin-arm64) ASSET_NAME="policynim-${RELEASE_TAG}-darwin-arm64.tar.gz" ;;
+            darwin-amd64) ASSET_NAME="policynim-${RELEASE_TAG}-darwin-amd64.tar.gz" ;;
             *) echo "Unsupported release platform: ${{ matrix.platform }}" >&2; exit 1 ;;
           esac
           tar -C dist -czf "artifacts/${ASSET_NAME}" policynim
@@ -249,7 +253,7 @@ jobs:
           PolicyNIM release artifacts:
 
           - Python wheel and source distribution for `pipx install policynim`
-          - Standalone CLI bundles for Linux, Apple Silicon macOS, and Windows
+          - Standalone CLI bundles for Linux, Apple Silicon macOS, Intel macOS, and Windows
           - Unix and PowerShell installer scripts
           - SHA256SUMS for release asset verification
           EOF

--- a/docs/release.md
+++ b/docs/release.md
@@ -53,18 +53,18 @@ git push origin v0.1.0
 ```
 
 The `Release` workflow builds the wheel, source distribution, and standalone
-archives for Linux, Apple Silicon macOS, and Windows. It creates a draft GitHub
+archives for Linux, Apple Silicon macOS, Intel macOS, and Windows. It creates a draft GitHub
 release with:
 
 - Python wheel and source distribution
 - `install.sh` and `install.ps1`
 - `policynim-vX.Y.Z-linux-amd64.tar.gz`
 - `policynim-vX.Y.Z-darwin-arm64.tar.gz`
+- `policynim-vX.Y.Z-darwin-amd64.tar.gz`
 - `policynim-vX.Y.Z-windows-amd64.zip`
 - `SHA256SUMS`
 
-PolicyNIM does not publish a macOS Intel standalone bundle because the pinned
-LanceDB dependency does not ship macOS x86_64 wheels.
+PolicyNIM publishes separate macOS bundles for Apple Silicon and Intel hosts.
 
 Review the draft GitHub release before publishing. Confirm that the release
 asset names match the installer scripts and that `SHA256SUMS` includes every

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,7 +34,7 @@ normalize_arch() {
 
 supported_platform() {
   case "$1" in
-    darwin-arm64 | linux-amd64) return 0 ;;
+    darwin-amd64 | darwin-arm64 | linux-amd64) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -138,7 +138,7 @@ OS_NAME="$(normalize_os)"
 ARCH_NAME="$(normalize_arch)"
 PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if ! supported_platform "$PLATFORM"; then
-  fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-arm64, linux-amd64."
+  fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-amd64, darwin-arm64, linux-amd64."
 fi
 
 need_command curl
@@ -161,9 +161,10 @@ fi
 VERSION="${VERSION#v}"
 TAG="v${VERSION}"
 case "$PLATFORM" in
+  darwin-amd64) ASSET_NAME="policynim-$TAG-darwin-amd64.tar.gz" ;;
   darwin-arm64) ASSET_NAME="policynim-$TAG-darwin-arm64.tar.gz" ;;
   linux-amd64) ASSET_NAME="policynim-$TAG-linux-amd64.tar.gz" ;;
-  *) fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-arm64, linux-amd64." ;;
+  *) fail "Unsupported platform: $PLATFORM. Supported platforms: darwin-amd64, darwin-arm64, linux-amd64." ;;
 esac
 RELEASE_BASE_URL="${POLICYNIM_RELEASE_BASE_URL:-$REPO_URL/releases/download/$TAG}"
 RELEASE_PAGE_URL="$REPO_URL/releases/tag/$TAG"

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -109,12 +109,25 @@ def test_release_workflow_uploads_expected_install_artifacts() -> None:
     for token in (
         "policynim-${RELEASE_TAG}-linux-amd64.tar.gz",
         "policynim-${RELEASE_TAG}-darwin-arm64.tar.gz",
+        "policynim-${RELEASE_TAG}-darwin-amd64.tar.gz",
         "policynim-${RELEASE_TAG}-windows-amd64.zip",
         "scripts/install.sh",
         "scripts/install.ps1",
         "SHA256SUMS",
         "gh release create",
         "--draft",
+    ):
+        assert token in text
+
+
+def test_release_workflow_builds_macos_intel_standalone_artifact() -> None:
+    """Restore macOS Intel as a first-class standalone release target."""
+    text = _read_text(RELEASE_WORKFLOW)
+
+    for token in (
+        "os: macos-15-intel",
+        "platform: darwin-amd64",
+        'darwin-amd64) ASSET_NAME="policynim-${RELEASE_TAG}-darwin-amd64.tar.gz" ;;',
     ):
         assert token in text
 

--- a/tests/test_installer_contract.py
+++ b/tests/test_installer_contract.py
@@ -54,6 +54,7 @@ def test_installer_scripts_lock_supported_artifact_contract() -> None:
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
 
     for asset in (
+        "policynim-$TAG-darwin-amd64.tar.gz",
         "policynim-$TAG-darwin-arm64.tar.gz",
         "policynim-$TAG-linux-amd64.tar.gz",
     ):
@@ -98,8 +99,27 @@ def test_unix_installer_rejects_unsupported_platform(tmp_path: Path) -> None:
     output = result.stdout + result.stderr
     assert result.returncode != 0
     assert "Unsupported platform: linux-arm64" in output
-    assert "Supported platforms: darwin-arm64, linux-amd64." in output
+    assert "Supported platforms: darwin-amd64, darwin-arm64, linux-amd64." in output
     assert not (home / ".local" / "bin" / "policynim").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_unix_installer_installs_macos_intel_bundle(tmp_path: Path) -> None:
+    """Allow Intel macOS users to install the restored standalone bundle."""
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    asset = "policynim-v0.1.0-darwin-amd64.tar.gz"
+    create_unix_release_asset(release_dir, asset_name=asset)
+
+    result, home = run_unix_installer(
+        tmp_path,
+        release_dir,
+        os_name="Darwin",
+        arch="x86_64",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (home / ".local" / "share" / "policynim" / VERSION / "policynim").is_file()
 
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
@@ -180,7 +200,12 @@ def test_windows_installer_contract_is_actionable() -> None:
     assert "Read-Host" not in script
 
 
-def create_unix_release_asset(release_dir: Path, *, checksum: str | None = None) -> Path:
+def create_unix_release_asset(
+    release_dir: Path,
+    *,
+    asset_name: str = LINUX_ASSET,
+    checksum: str | None = None,
+) -> Path:
     """Create a fake Unix release archive and matching checksum file."""
     build_root = release_dir / "build"
     bundle_root = build_root / "policynim"
@@ -190,12 +215,12 @@ def create_unix_release_asset(release_dir: Path, *, checksum: str | None = None)
     binary.chmod(0o755)
     (bundle_root / "_internal").mkdir()
 
-    asset_path = release_dir / LINUX_ASSET
+    asset_path = release_dir / asset_name
     with tarfile.open(asset_path, "w:gz") as archive:
         archive.add(bundle_root, arcname="policynim")
 
     digest = checksum or hashlib.sha256(asset_path.read_bytes()).hexdigest()
-    (release_dir / "SHA256SUMS").write_text(f"{digest}  {LINUX_ASSET}\n", encoding="utf-8")
+    (release_dir / "SHA256SUMS").write_text(f"{digest}  {asset_name}\n", encoding="utf-8")
     return asset_path
 
 


### PR DESCRIPTION
## Summary
- Add a `darwin-amd64` standalone build to the release workflow using the `macos-15-intel` runner.
- Teach the Unix installer to accept Intel macOS and download `policynim-$TAG-darwin-amd64.tar.gz`.
- Update release docs and contract tests so macOS Intel stays part of the public artifact set.

## Why
Day 4 of the sqlite-vec migration restores the macOS Intel standalone asset now that the local index backend no longer depends on LanceDB wheel availability.

## Validation
- `uv run --group test python -m pytest -q tests/test_ci_workflows.py tests/test_installer_contract.py tests/test_package_release.py` (`24 passed`)
- `sh -n scripts/install.sh`
- PowerShell parser check for `scripts/install.ps1`
- `uv lock --check`
- `uv run --group dev ruff check .`
- `uv run --group dev pyright`
- `uv run --group test python -m pytest -q -m "not live and not docker_live"` (`522 passed, 10 deselected`)

## Notes
- Rebased onto current `origin/main` at `6a29be2` before updating this PR.
- Built from a clean worktree so unrelated local OSS-readiness and Day 4 planning files are not included.
- The local Day 4 execution plan remains saved under `.plan/sqlite-vec-index-migration/day-4-execution-plan.md`, which is ignored by the repo.
