### PR TITLE
[codex] Add first-run CLI and MCP diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PolicyNIM currently ships with two main user-facing surfaces:
 - Deterministic Markdown ingest with heading-aware chunking and source line spans.
 - Ingest-time compilation of `runtime_rules` frontmatter into the persisted runtime rules artifact.
 - NVIDIA-hosted embeddings and reranking for retrieval.
-- Local LanceDB storage for the retrievable policy index.
+- Local sqlite-vec storage for the retrievable policy index.
 - Task-aware policy routing with citation-preserving selected-policy packets.
 - Policy compilation into citation-backed planning and generation constraints.
 - Grounded preflight synthesis with compiled plan steps, citation validation, and
@@ -47,17 +47,18 @@ PolicyNIM currently ships with two main user-facing surfaces:
   artifacts and local Phoenix reporting for non-headless runs.
 - Runtime-rule decisions plus SQLite-backed evidence for allowed, confirmed,
   blocked, and failed runtime actions.
-- Interactive `init` setup plus JSON-first CLI commands for `ingest`,
-  `dump-index`, `search`, `route`, `compile`, `preflight`, `eval`, `mcp`,
-  `runtime`, and `evidence`.
+- Interactive `init`, `quickstart`, and `doctor` setup plus JSON-first CLI
+  commands for `ingest`, `dump-index`, `search`, `route`, `compile`,
+  `preflight`, `eval`, `mcp`, `mcp-config`, `mcp-smoke`, `support-bundle`,
+  `beta-admin`, `runtime`, and `evidence`.
 - MCP tools for `policy_preflight` and `policy_search`.
 - Hosted HTTP `streamable-http` with `/healthz`, a self-serve `/beta` portal,
   and bearer auth on `/mcp`.
 
 ## What To Run First
 
-If you want the shortest path to a real preflight run, start with the hosted
-beta instead of cloning the repo.
+If you want the shortest path to a real preflight run, start with
+`policynim quickstart --target hosted-mcp` instead of cloning the repo.
 
 ### Install The CLI Without Cloning
 
@@ -93,6 +94,14 @@ irm https://github.com/nnennandukwe/policyNIM/releases/latest/download/install.p
 Both installer paths verify release checksums before installing. After install,
 run `policynim init`, then `policynim ingest`, then `policynim --help` whenever
 you need to confirm the entrypoint is available.
+
+If you want the CLI to print a no-network first-run plan for your setup, run:
+
+```bash
+policynim quickstart --target hosted-mcp
+policynim quickstart --target local-cli
+policynim quickstart --target local-mcp
+```
 
 ### Self-Serve Hosted Beta
 
@@ -148,6 +157,13 @@ In a source checkout, `init` writes the checkout `.env` file that PolicyNIM
 loads by default. Installed copies should keep using the direct `policynim init`
 entrypoint described below.
 
+If you want a quick local readiness check after setup, run:
+
+```bash
+uv run policynim doctor
+uv run policynim mcp-smoke --format json
+```
+
 If you prefer to manage `.env` manually, copy the template first:
 
 ```bash
@@ -186,9 +202,9 @@ Start here when you want the longer version of a specific path:
 - [docs/index.md](docs/index.md): documentation hub by audience and task
 - [docs/contributor-guide.md](docs/contributor-guide.md): local setup, env vars,
   model references, and quality gates
-- [docs/workflows.md](docs/workflows.md): CLI surfaces,
-  ingest/search/route/compile/preflight, eval, MCP, runtime/evidence, and
-  troubleshooting
+- [docs/workflows.md](docs/workflows.md): CLI surfaces, first-run
+  quickstart/diagnostics, ingest/search/route/compile/preflight, eval, MCP,
+  runtime/evidence, and troubleshooting
 - [docs/hosted-beta-operations.md](docs/hosted-beta-operations.md): hosted beta
   quickstart, recovery, container build flow, and Railway deploy notes
 - [docs/release.md](docs/release.md): CLI packaging, GitHub release, PyPI

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -42,7 +42,7 @@ flowchart LR
         direction TB
         IngestPkg["ingest/<br/>loader, parser, chunking"]
         NvidiaAdapter["providers/nvidia.py"]
-        LanceStore["storage/lancedb.py"]
+        SQLiteStore["storage/sqlite_vec.py"]
         RuntimeEvidenceStore["storage/runtime_evidence.py"]
     end
 
@@ -93,20 +93,20 @@ flowchart LR
     CompilerSvc --> NvidiaAdapter
     PreflightSvc --> NvidiaAdapter
     RegenSvc --> NvidiaAdapter
-    RuntimeDecisionSvc --> LanceStore
+    RuntimeDecisionSvc --> SQLiteStore
     RuntimeExecSvc --> RuntimeDecisionSvc
     RuntimeExecSvc --> RuntimeEvidenceStore
-    IngestSvc --> LanceStore
-    SearchSvc --> LanceStore
-    RouterSvc --> LanceStore
-    CompilerSvc --> LanceStore
-    PreflightSvc --> LanceStore
+    IngestSvc --> SQLiteStore
+    SearchSvc --> SQLiteStore
+    RouterSvc --> SQLiteStore
+    CompilerSvc --> SQLiteStore
+    PreflightSvc --> SQLiteStore
     PreflightSvc --> RouterSvc
     PreflightSvc --> CompilerSvc
     RegenSvc --> CompilerSvc
     RegenSvc --> EvidenceTraceSvc
-    DumpSvc --> LanceStore
-    HealthSvc --> LanceStore
+    DumpSvc --> SQLiteStore
+    HealthSvc --> SQLiteStore
 
     EvalSvc --> IngestSvc
     EvalSvc --> SearchSvc
@@ -151,7 +151,7 @@ flowchart LR
 
     class CLI,MCP iface
     class IngestSvc,SearchSvc,RouterSvc,CompilerSvc,PreflightSvc,RegenSvc,RuntimeDecisionSvc,RuntimeExecSvc,EvalSvc,EvidenceTraceSvc,DumpSvc,HealthSvc service
-    class IngestPkg,NvidiaAdapter,LanceStore,RuntimeEvidenceStore adapter
+    class IngestPkg,NvidiaAdapter,SQLiteStore,RuntimeEvidenceStore adapter
     class Settings,Types,Contracts shared
     class Policies,EvalSuite,RuntimeRules,RuntimeEvidenceDB local
     class Embed,Rerank,Ground nvidia
@@ -176,7 +176,7 @@ flowchart TB
         CompileRules --> RuntimeRules
         Parse --> Chunk["Chunk by section and line span"]
         Chunk --> EmbedDocs["Embed documents"]
-        EmbedDocs --> Index["Local LanceDB index"]
+        EmbedDocs --> Index["Local SQLite index"]
     end
 
     subgraph Search["Search Request"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ Ingest flow:
 5. compile any `runtime_rules` frontmatter into the persisted runtime rules artifact
 6. build deterministic chunk IDs
 7. embed chunk text through NVIDIA-hosted embeddings
-8. replace the local LanceDB table with the new embedded rows
+8. replace the local SQLite index with the new embedded rows
 
 Important ingest rules:
 
@@ -63,14 +63,14 @@ Retrieval flow:
 
 1. validate runtime settings
 2. embed the user query through NVIDIA-hosted embeddings
-3. retrieve dense candidates from the local LanceDB table
+3. retrieve dense candidates from the local SQLite index
 4. optionally filter by policy domain
 5. rerank candidates through NVIDIA-hosted reranking
 6. return a JSON-first `SearchResult`
 
 Current retrieval design choices:
 
-- one local LanceDB table stores all indexed chunks
+- one local SQLite index stores all indexed chunks
 - ingest replaces the whole table instead of incrementally merging rows
 - the same embedding model is used for document and query vectors
 - reranking is part of the normal search path, not a separate experimental mode
@@ -85,7 +85,7 @@ Routing flow:
 1. validate the route request and optional task-type override
 2. infer a deterministic `TaskProfile` from task text when no override is present
 3. embed the original task through NVIDIA-hosted embeddings
-4. retrieve broad dense candidates from the local LanceDB table
+4. retrieve broad dense candidates from the local SQLite index
 5. rerank candidates against the task plus task-profile signals
 6. retain bounded policy evidence with source chunk IDs and line spans
 7. return a JSON-first `PolicySelectionPacket`
@@ -189,7 +189,7 @@ Important evaluation rules:
 
 - offline mode is the default contributor path
 - live mode is opt-in and requires `NVIDIA_API_KEY`
-- live mode uses an isolated temporary LanceDB path
+- live mode uses an isolated temporary SQLite index path
 - the default backend is code-scored and does not use LLM-as-judge behavior
 - the `nemo` backend adds deterministic conformance checks plus final-adherence
   judgment for preflight cases
@@ -209,7 +209,7 @@ Important evaluation rules:
 
 ### Repo Root
 
-- `Dockerfile` builds the hosted image and bakes the LanceDB index into it.
+- `Dockerfile` builds the hosted image and bakes the SQLite index into it.
 - `railway.toml` pins the hosted Railway deploy contract to Dockerfile build
   plus `/healthz` health checks.
 
@@ -245,7 +245,7 @@ Important evaluation rules:
 
 ### `src/policynim/storage/`
 
-- Owns LanceDB persistence, runtime evidence storage, row mapping, replacement,
+- Owns SQLite index persistence, runtime evidence storage, row mapping,
   and search behavior.
 - Must not read environment variables directly.
 
@@ -304,6 +304,8 @@ Important evaluation rules:
 
 ### CLI
 
+- `policynim quickstart [--target hosted-mcp|local-cli|local-mcp] [--client codex|claude-code] [--format text|json]`
+- `policynim doctor [--format text|json]`
 - `policynim init`
 - `policynim ingest`
 - `policynim dump-index [--count-only]`
@@ -317,7 +319,10 @@ Important evaluation rules:
 - `policynim runtime decide --input <path|->`
 - `policynim runtime execute --input <path|->`
 - `policynim evidence report --session-id <id>`
-- `policynim beta-admin list-accounts|suspend|resume|revoke-key`
+- `policynim mcp-config [--target local-stdio|hosted-http]`
+- `policynim mcp-smoke [--mcp-config-file <path>]`
+- `policynim support-bundle [--include-mcp-smoke]`
+- `policynim beta-admin list-accounts|suspend|resume|revoke-key|audit-log`
 
 ### MCP Tools
 
@@ -407,7 +412,7 @@ Local runtime components own:
 - chunk assembly and citation spans
 - compiled runtime rules artifacts
 - runtime execution evidence in SQLite
-- LanceDB persistence and dense candidate lookup
+- SQLite index persistence and dense candidate lookup
 - baked-index startup validation for hosted HTTP images
 - offline eval execution
 - local artifact persistence under `data/`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -44,6 +44,10 @@ server:
 uv run policynim ingest
 ```
 
+After the first ingest, `uv run policynim doctor` reports whether the local
+setup is ready, and `uv run policynim mcp-smoke --format json` verifies the
+stdio MCP tool registration.
+
 ## Standalone Install
 
 If you are using an installed copy instead of a source checkout, initialize the

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -36,7 +36,7 @@ What to look for:
 - a non-zero document count
 - a non-zero chunk count
 - the configured embedding model
-- the local LanceDB path and table name
+- the local SQLite index path and table name
 
 What this proves:
 

--- a/docs/hosted-beta-operations.md
+++ b/docs/hosted-beta-operations.md
@@ -19,6 +19,10 @@ codex mcp add policynim --url https://<railway-domain>/mcp --bearer-token-env-va
 claude mcp add --transport http policynim https://<railway-domain>/mcp --header "Authorization: Bearer $POLICYNIM_TOKEN"
 ```
 
+If you want PolicyNIM to print the exact hosted setup command for one client,
+run `uv run policynim quickstart --target hosted-mcp --client codex` or
+`uv run policynim quickstart --target hosted-mcp --client claude-code`.
+
 Then ask your client to call the MCP tools directly:
 
 - `Use policy_preflight for: Implement a refresh-token cleanup background job.`
@@ -107,7 +111,7 @@ GitHub Actions smoke:
   for detailed index path, volume, or file-permission failures
 - if `/healthz` says the local index is missing or empty, confirm the latest
   build received `NVIDIA_API_KEY`, rerun the deploy so `policynim ingest` bakes
-  the index, and confirm `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`
+  the index, and confirm `POLICYNIM_INDEX_DB_PATH=/app/data/index.sqlite3`
 - if the live smoke passes `/healthz` but fails `policy_search` or
   `policy_preflight`, inspect hosted MCP logs for `upstream_failure_class`
   before rotating auth tokens or rebuilding the image
@@ -125,8 +129,8 @@ DOCKER_BUILDKIT=1 docker build \
 
 Important container defaults:
 
-- the image bakes the LanceDB index at `/app/data/lancedb-baked`
-- the image sets `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`
+- the image bakes the SQLite index at `/app/data/index.sqlite3`
+- the image sets `POLICYNIM_INDEX_DB_PATH=/app/data/index.sqlite3`
 - the image sets `POLICYNIM_MCP_HOST=0.0.0.0` so hosted HTTP can bind inside the
   container
 - the builder stage reads the bake-time key from the temporary BuildKit secret
@@ -200,7 +204,7 @@ Recommended beta setup:
 3. Set at least these Railway service variables:
    - `NVIDIA_API_KEY`
    - `POLICYNIM_ENV=production`
-   - `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`
+   - `POLICYNIM_INDEX_DB_PATH=/app/data/index.sqlite3`
    - `POLICYNIM_MCP_HOST=0.0.0.0`
 4. Deploy once so the service becomes healthy on `/healthz`.
 5. Generate a Railway public domain for that service.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@ operations into separate pages so the root README can stay short.
 ## Start Here
 
 - [../README.md](../README.md): concise project overview, current capabilities,
-  quickstart, and links outward
+  quickstart, local diagnostics, and links outward
 - [contributor-guide.md](contributor-guide.md): local setup, standalone init,
   env templates, important settings, model references, and quality gates
-- [workflows.md](workflows.md): CLI, route/preflight, MCP, runtime/evidence, eval, and
-  troubleshooting handbook
+- [workflows.md](workflows.md): CLI, quickstart, diagnostics, route/preflight,
+  MCP, runtime/evidence, eval, and troubleshooting handbook
 - [hosted-beta-operations.md](hosted-beta-operations.md): hosted beta quickstart,
   recovery, container build flow, and Railway deployment notes
 - [release.md](release.md): package, GitHub release, PyPI, and standalone

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,6 +7,8 @@ reference that used to live in the root README.
 
 ### CLI
 
+- `policynim quickstart [--target hosted-mcp|local-cli|local-mcp] [--client codex|claude-code] [--format text|json]`
+- `policynim doctor [--format text|json]`
 - `policynim init`
 - `policynim ingest`
 - `policynim dump-index [--count-only]`
@@ -21,6 +23,10 @@ reference that used to live in the root README.
 - `policynim runtime execute --input <path|->`
 - `policynim evidence report --session-id <id>`
 - `policynim evidence report --session-id <id> --format markdown --output reports/<id>.md`
+- `policynim mcp-config [--target local-stdio|hosted-http]`
+- `policynim mcp-smoke [--mcp-config-file <path>]`
+- `policynim support-bundle [--include-mcp-smoke]`
+- `policynim beta-admin list-accounts|suspend|resume|revoke-key|audit-log`
 
 ### MCP Tools
 
@@ -46,6 +52,13 @@ reference that used to live in the root README.
 
 `policynim init` writes the local config file interactively when you want the
 CLI to prompt for `NVIDIA_API_KEY` and an optional custom corpus directory.
+
+Use `policynim quickstart` when you want the safest no-network first-run path
+for hosted MCP, local CLI, or local MCP.
+
+Use `policynim doctor` when you want a local-only setup report that checks the
+config file, credentials, index path, runtime rules artifact, and MCP launch
+hints.
 
 ## Core Workflows
 
@@ -79,7 +92,7 @@ What this does:
 - chunks the documents into stable, citeable sections
 - compiles any `runtime_rules` frontmatter into the persisted runtime rules artifact
 - embeds those chunks with NVIDIA-hosted embeddings
-- rebuilds the local LanceDB table
+- rebuilds the local SQLite index
 
 Typical output includes the chunk count, document count, embedding model, and
 index location.
@@ -361,7 +374,7 @@ Hosted HTTP notes:
 - `stdio` ignores the hosted auth settings completely
 - when `POLICYNIM_ENV=production` and Railway injects `PORT`, hosted MCP
   defaults to `0.0.0.0` unless `POLICYNIM_MCP_HOST` is explicitly set
-- the baked-image workflow uses `POLICYNIM_LANCEDB_URI=/app/data/lancedb-baked`
+- the baked-image workflow uses `POLICYNIM_INDEX_DB_PATH=/app/data/index.sqlite3`
   as the fast path. Hosted startup only falls back to `policynim ingest` when
   that local index is missing or empty
 - if that automatic rebuild path runs without a runtime `NVIDIA_API_KEY`, hosted
@@ -378,6 +391,20 @@ For hosted-first client setup examples, see:
 
 - [../examples/codex/README.md](../examples/codex/README.md)
 - [../examples/claude-code/README.md](../examples/claude-code/README.md)
+
+### 9. Use The First-Run And Support Helpers
+
+```bash
+uv run policynim quickstart --target hosted-mcp --client codex
+uv run policynim doctor --format json
+uv run policynim mcp-config --target local-stdio --client codex --format json
+uv run policynim mcp-smoke --format json
+uv run policynim support-bundle --include-mcp-smoke
+```
+
+Use these commands when you want the no-network first-run plan, a local setup
+health check, copyable MCP client config, a stdio tool-registration smoke test,
+or a redacted support bundle for an issue report.
 
 ## Runtime Decisions And Evidence
 
@@ -505,7 +532,7 @@ PolicyNIM keeps the retrieval stack explicit:
 
 1. chunk Markdown policies with stable IDs and line spans
 2. embed query and document text with NVIDIA-hosted embeddings
-3. retrieve dense candidates from LanceDB
+3. retrieve dense candidates from the local SQLite index
 4. rerank candidates with NVIDIA
 5. route retained evidence into selected-policy packets
 6. compile selected policy evidence into constraint packets

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -3,6 +3,9 @@
 This example connects Claude Code to the hosted PolicyNIM Railway MCP over HTTP.
 Use the local `stdio` fallback only if you need to run PolicyNIM from a clone.
 
+If you want PolicyNIM to print the exact setup command for this client, run
+`uv run policynim quickstart --target hosted-mcp --client claude-code`.
+
 ## Hosted Railway MCP
 
 1. Open `https://<railway-domain>/beta`, sign in with GitHub, and generate or

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -3,6 +3,9 @@
 This example connects Codex to the hosted PolicyNIM Railway MCP over HTTP. Use
 the local `stdio` fallback only if you need to run PolicyNIM from a clone.
 
+If you want PolicyNIM to print the exact setup command for this client, run
+`uv run policynim quickstart --target hosted-mcp --client codex`.
+
 ## Hosted Railway MCP
 
 1. Open `https://<railway-domain>/beta`, sign in with GitHub, and generate or
@@ -106,7 +109,7 @@ Why the repo path appears twice:
 
 - `--directory /ABS/PATH/TO/policyNIM` tells `uv` which project to run
 - `Working directory: /ABS/PATH/TO/policyNIM` makes relative paths such as `.env`
-  and `data/lancedb` resolve from the repo root
+  and `data/index.sqlite3` resolve from the repo root
 
 Using the same repo path in both places is the least error-prone setup for this
 project. If you keep `--directory`, the app working directory is mostly

--- a/src/policynim/agent_workflows.py
+++ b/src/policynim/agent_workflows.py
@@ -1,0 +1,78 @@
+"""Copyable coding-agent workflow prompts for first-run surfaces."""
+
+from __future__ import annotations
+
+from typing import TypedDict, cast
+
+
+class AgentWorkflow(TypedDict):
+    """Structured prompt shown by quickstart and support diagnostics."""
+
+    title: str
+    tool: str
+    prompt: str
+
+
+class AgentWorkflowCard(AgentWorkflow):
+    """Hosted portal workflow prompt with explanatory card text."""
+
+    description: str
+
+
+_AGENT_WORKFLOW_CARDS: tuple[AgentWorkflowCard, ...] = (
+    {
+        "title": "Preflight before implementation",
+        "tool": "policy_preflight",
+        "description": (
+            "Ask your coding agent to retrieve policy evidence and produce grounded "
+            "implementation guidance before it edits code."
+        ),
+        "prompt": (
+            "Before editing, call policy_preflight for: Implement a refresh-token cleanup "
+            "background job. Use the cited constraints in your implementation plan. If the "
+            "result is insufficient_context, stop and call policy_search with a narrower "
+            "query before changing files."
+        ),
+    },
+    {
+        "title": "Retrieve policy evidence while debugging",
+        "tool": "policy_search",
+        "description": (
+            "Use raw policy search when a review comment, failing gate, or unclear "
+            "constraint needs the underlying source text."
+        ),
+        "prompt": (
+            "Use policy_search for: release installer checksum verification. Summarize "
+            "the relevant cited policy lines before proposing a fix."
+        ),
+    },
+    {
+        "title": "Verify MCP tool availability",
+        "tool": "list_tools",
+        "description": (
+            "After adding the hosted server, ask your client to confirm it can see the "
+            "PolicyNIM tools before you start a longer coding session."
+        ),
+        "prompt": (
+            "List the PolicyNIM MCP tools and confirm policy_preflight and policy_search "
+            "are available before starting implementation."
+        ),
+    },
+)
+
+
+def agent_workflows() -> list[AgentWorkflow]:
+    """Return copyable first-use prompts without hosted portal descriptions."""
+    return [
+        {
+            "title": workflow["title"],
+            "tool": workflow["tool"],
+            "prompt": workflow["prompt"],
+        }
+        for workflow in _AGENT_WORKFLOW_CARDS
+    ]
+
+
+def agent_workflow_cards() -> list[AgentWorkflowCard]:
+    """Return copyable first-use prompts with hosted portal descriptions."""
+    return [cast(AgentWorkflowCard, dict(workflow)) for workflow in _AGENT_WORKFLOW_CARDS]

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import platform
+import shlex
 import sys
-from datetime import datetime
+from collections.abc import Sequence
+from datetime import datetime, timedelta
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Annotated, Literal, NoReturn
+from tempfile import NamedTemporaryFile, TemporaryFile
+from typing import Annotated, Literal, NoReturn, cast
+from urllib.parse import urlparse
 
 import typer
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
 from pydantic import TypeAdapter, ValidationError
 
 import policynim.config_discovery as config_discovery
+from policynim.agent_workflows import agent_workflows
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
 from policynim.runtime_paths import resolve_runtime_path
@@ -35,6 +43,7 @@ from policynim.services import (
     create_search_service,
 )
 from policynim.settings import Settings, get_settings
+from policynim.storage import create_index_store
 from policynim.types import (
     MAX_TOP_K,
     CompileRequest,
@@ -57,6 +66,7 @@ _RUNTIME_REQUEST_ADAPTER = TypeAdapter(RuntimeActionRequest)
 _STANDALONE_MISSING_INDEX_MESSAGE = (
     "Local PolicyNIM data is not built yet. Run `policynim ingest` to build the local policy index."
 )
+_EXPECTED_MCP_TOOLS = ("policy_preflight", "policy_search")
 
 app = typer.Typer(
     add_completion=False,
@@ -146,6 +156,99 @@ def init() -> None:
     typer.echo(f"Wrote PolicyNIM config to {config_path}.")
     typer.echo(f"Corpus: {corpus_message}")
     typer.echo("Next step: run `policynim ingest`.")
+
+
+@app.command(
+    help=(
+        "Print the first-run path for hosted MCP, local CLI, or local MCP "
+        "without calling external services."
+    ),
+)
+def quickstart(
+    target: Annotated[
+        Literal["hosted-mcp", "local-cli", "local-mcp"],
+        typer.Option(
+            "--target",
+            help="First-run path to show. Supported values: hosted-mcp, local-cli, local-mcp.",
+        ),
+    ] = "hosted-mcp",
+    client: Annotated[
+        Literal["codex", "claude-code"],
+        typer.Option(
+            "--client",
+            help="MCP client to show when the target uses MCP.",
+        ),
+    ] = "codex",
+    hosted_url: Annotated[
+        str,
+        typer.Option(
+            "--hosted-url",
+            help="Hosted PolicyNIM MCP URL to include in generated setup commands.",
+        ),
+    ] = "https://<railway-domain>/mcp",
+    bearer_token_env_var: Annotated[
+        str,
+        typer.Option(
+            "--bearer-token-env-var",
+            help="Environment variable that stores the hosted MCP bearer token.",
+        ),
+    ] = "POLICYNIM_TOKEN",
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help="PolicyNIM source checkout root to include for local MCP config.",
+        ),
+    ] = None,
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Quickstart output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print the safest first-run path for the selected user workflow."""
+    try:
+        payload = _build_quickstart_payload(
+            target=target,
+            client=client,
+            hosted_url=hosted_url,
+            bearer_token_env_var=bearer_token_env_var,
+            repo_root=repo_root,
+        )
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    for line in _render_quickstart_payload(payload):
+        typer.echo(line)
+
+
+@app.command(
+    help=(
+        "Inspect local setup, index artifacts, and MCP launch hints without "
+        "calling NVIDIA-hosted APIs."
+    ),
+)
+def doctor(
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Diagnostic output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print a safe local setup diagnostic report."""
+    report = _build_doctor_report()
+    if output_format == "json":
+        typer.echo(json.dumps(report, indent=2))
+        return
+    for line in _render_doctor_report(report):
+        typer.echo(line)
 
 
 @app.command()
@@ -627,12 +730,216 @@ def mcp(
 ) -> None:
     """Run the MCP server."""
     try:
-        _load_setup_dependent_settings()
+        if transport != "stdio":
+            _load_setup_dependent_settings()
         run_server(transport=transport)
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
+
+
+@app.command("mcp-config")
+def mcp_config(
+    client: Annotated[
+        Literal["codex", "claude-code"],
+        typer.Option(
+            "--client",
+            help="Client config shape to print. Supported values: codex, claude-code.",
+        ),
+    ] = "codex",
+    target: Annotated[
+        Literal["local-stdio", "hosted-http"],
+        typer.Option(
+            "--target",
+            help="MCP target to configure. Supported values: local-stdio, hosted-http.",
+        ),
+    ] = "local-stdio",
+    hosted_url: Annotated[
+        str | None,
+        typer.Option(
+            "--hosted-url",
+            help=(
+                "Hosted PolicyNIM MCP URL, for example https://<host>/mcp. "
+                "Required with --target hosted-http."
+            ),
+        ),
+    ] = None,
+    bearer_token_env_var: Annotated[
+        str,
+        typer.Option(
+            "--bearer-token-env-var",
+            help=(
+                "Environment variable that stores the hosted MCP bearer token. "
+                "Used with --target hosted-http."
+            ),
+        ),
+    ] = "POLICYNIM_TOKEN",
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help=(
+                "Optional PolicyNIM source checkout root. When omitted, local stdio "
+                "config uses a discovered checkout or the installed policynim command."
+            ),
+        ),
+    ] = None,
+    server_name: Annotated[
+        str,
+        typer.Option(
+            "--server-name",
+            help="MCP server name to use in the generated client config.",
+        ),
+    ] = "policynim",
+    uv_command: Annotated[
+        str,
+        typer.Option(
+            "--uv-command",
+            help=(
+                "uv executable or absolute path to use in generated stdio config. "
+                "Used only when local stdio config targets a source checkout."
+            ),
+        ),
+    ] = "uv",
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Config output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print hosted HTTP or local stdio MCP client config without writing client files."""
+    try:
+        payload = _build_mcp_config_payload(
+            client=client,
+            target=target,
+            hosted_url=hosted_url,
+            bearer_token_env_var=bearer_token_env_var,
+            repo_root=repo_root,
+            server_name=server_name,
+            uv_command=uv_command,
+        )
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    for line in _render_mcp_config_payload(payload):
+        typer.echo(line)
+
+
+@app.command("mcp-smoke")
+def mcp_smoke(
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Smoke output format. Supported values: text, json.",
+        ),
+    ] = "text",
+    timeout_seconds: Annotated[
+        float,
+        typer.Option(
+            "--timeout-seconds",
+            min=1.0,
+            help="Read timeout for MCP initialize and list-tools calls.",
+        ),
+    ] = 5.0,
+    mcp_config_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--mcp-config-file",
+            help=(
+                "Optional JSON output from `policynim mcp-config --format json`. "
+                "When set, local stdio smoke launches with that generated config."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Launch the local stdio MCP server and verify the public tools are listed."""
+    try:
+        if mcp_config_file is None:
+            report = asyncio.run(_run_mcp_stdio_smoke(timeout_seconds=timeout_seconds))
+        else:
+            command, cwd = _mcp_stdio_smoke_command_from_config_file(mcp_config_file)
+            report = asyncio.run(
+                _run_mcp_stdio_smoke(
+                    timeout_seconds=timeout_seconds,
+                    command=command,
+                    cwd=cwd,
+                )
+            )
+            report["config_source"] = str(mcp_config_file)
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        for line in _render_mcp_smoke_report(report):
+            typer.echo(line)
+
+    if report["status"] != "ok":
+        raise typer.Exit(code=1)
+
+
+@app.command("support-bundle")
+def support_bundle(
+    output_format: Annotated[
+        Literal["json", "markdown"],
+        typer.Option(
+            "--format",
+            help="Support bundle output format. Supported values: json, markdown.",
+        ),
+    ] = "json",
+    include_mcp_smoke: Annotated[
+        bool,
+        typer.Option(
+            "--include-mcp-smoke",
+            help="Also launch local stdio MCP and verify public tool registration.",
+        ),
+    ] = False,
+    mcp_timeout_seconds: Annotated[
+        float,
+        typer.Option(
+            "--mcp-timeout-seconds",
+            min=1.0,
+            help="Read timeout for the optional MCP smoke check.",
+        ),
+    ] = 5.0,
+    include_local_paths: Annotated[
+        bool,
+        typer.Option(
+            "--include-local-paths",
+            help=(
+                "Include exact local filesystem paths for private maintainer triage. "
+                "By default, local path prefixes are redacted for public issues."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Print redacted diagnostics suitable for issues and maintainer triage."""
+    try:
+        bundle = asyncio.run(
+            _build_support_bundle(
+                include_mcp_smoke=include_mcp_smoke,
+                mcp_timeout_seconds=mcp_timeout_seconds,
+                include_local_paths=include_local_paths,
+            )
+        )
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    rendered = json.dumps(bundle, indent=2)
+    if output_format == "markdown":
+        typer.echo(_render_support_bundle_markdown(rendered))
+        return
+    typer.echo(rendered)
 
 
 @beta_admin_app.command("list-accounts")
@@ -973,6 +1280,1670 @@ def _load_setup_dependent_settings() -> Settings:
 def _missing_setup_message() -> str:
     config_path = config_discovery.resolve_init_config_file()
     return f"PolicyNIM is not set up yet. Run `policynim init` to create {config_path}."
+
+
+def _build_quickstart_payload(
+    *,
+    target: Literal["hosted-mcp", "local-cli", "local-mcp"],
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+    repo_root: Path | None,
+) -> dict[str, object]:
+    """Build offline first-run guidance for the requested workflow target."""
+    normalized_hosted_url = _normalize_hosted_mcp_url(
+        _normalize_quickstart_value(hosted_url, label="Hosted MCP URL")
+    )
+    normalized_token_env_var = _normalize_env_var_name(bearer_token_env_var)
+
+    if target == "hosted-mcp":
+        hosted_url_placeholder = _is_placeholder_hosted_url(normalized_hosted_url)
+        beta_portal_url = _hosted_beta_portal_url(normalized_hosted_url)
+        alternate_client = _alternate_mcp_client(client)
+        alternate_client_name = _mcp_client_display_name(alternate_client)
+        alternate_client_quickstart = _quickstart_installed_cli_command(
+            ["quickstart", "--target", target, "--client", alternate_client]
+        )
+        next_steps = [
+            (f"For {alternate_client_name} setup commands, rerun `{alternate_client_quickstart}`."),
+            "Ask your client to call `policy_preflight` for the main workflow.",
+            "Use `policy_search` first when you need raw retrieval/debugging context.",
+        ]
+        if hosted_url_placeholder:
+            next_steps.insert(
+                0,
+                "Replace the hosted URL placeholder with the deployed /mcp URL.",
+            )
+        return {
+            "schema_version": "1",
+            "target": target,
+            "client": client,
+            "requires_local_setup": False,
+            "calls_external_services": False,
+            "hosted_url": normalized_hosted_url,
+            "hosted_url_placeholder": hosted_url_placeholder,
+            "beta_portal_url": beta_portal_url,
+            "description": "Shortest path: use the hosted MCP endpoint without cloning.",
+            "prerequisites": [
+                "Access to the hosted beta portal.",
+                f"A shell environment variable named {normalized_token_env_var}.",
+            ],
+            "steps": [
+                (
+                    f"Open {normalized_hosted_url} in a browser; it routes to "
+                    f"{beta_portal_url} for token creation."
+                ),
+                "Sign in with GitHub.",
+                "Generate or rotate a hosted API key.",
+                "Export the token and add the hosted MCP server to your client.",
+            ],
+            "commands": [
+                f"export {normalized_token_env_var}='<generated-beta-token>'",
+                _quickstart_installed_cli_command(
+                    [
+                        "mcp-config",
+                        "--target",
+                        "hosted-http",
+                        "--client",
+                        client,
+                        "--hosted-url",
+                        normalized_hosted_url,
+                        "--bearer-token-env-var",
+                        normalized_token_env_var,
+                    ]
+                ),
+            ],
+            "client_commands": _quickstart_hosted_client_commands(
+                client=client,
+                hosted_url=normalized_hosted_url,
+                bearer_token_env_var=normalized_token_env_var,
+            ),
+            "agent_workflows": _quickstart_agent_workflows(),
+            "next_steps": next_steps,
+            "safety": [
+                "This command does not call hosted or NVIDIA services.",
+                (
+                    "Keep bearer tokens in environment variables; "
+                    "do not paste token values into issues."
+                ),
+            ],
+        }
+
+    if target == "local-cli":
+        local_cli_command = _quickstart_cli_command
+        source_checkout = _doctor_runtime_mode() == "source_checkout"
+        local_cli_description = (
+            "Local CLI path for running preflight from a source checkout."
+            if source_checkout
+            else "Local CLI path for running preflight from an installed package."
+        )
+        local_cli_prerequisites = (
+            [
+                "PolicyNIM source checkout with uv dependencies synced.",
+                "NVIDIA_API_KEY for ingest, search, route, compile, preflight, and eval.",
+            ]
+            if source_checkout
+            else [
+                "Python 3.11 or 3.12 for PyPI package installs.",
+                "NVIDIA_API_KEY for ingest, search, route, compile, preflight, and eval.",
+                "PyPI trusted-publishing evidence is tracked separately from installability.",
+            ]
+        )
+        entrypoint_step = (
+            "Check the source-checkout entrypoint."
+            if source_checkout
+            else "Check the installed entrypoint."
+        )
+        return {
+            "schema_version": "1",
+            "target": target,
+            "client": client,
+            "requires_local_setup": True,
+            "calls_external_services": False,
+            "description": local_cli_description,
+            "prerequisites": local_cli_prerequisites,
+            "steps": [
+                entrypoint_step,
+                "Create local config.",
+                "Build the bundled policy index.",
+                "Run a citation-backed preflight.",
+            ],
+            "commands": [
+                local_cli_command(["--help"]),
+                local_cli_command(["doctor"]),
+                local_cli_command(["init"]),
+                local_cli_command(["ingest"]),
+                local_cli_command(
+                    [
+                        "preflight",
+                        "--task",
+                        "Implement a refresh-token cleanup background job",
+                        "--top-k",
+                        "5",
+                    ]
+                ),
+            ],
+            "agent_workflows": _quickstart_agent_workflows(),
+            "next_steps": [
+                (
+                    f"Run `{local_cli_command(['quickstart', '--target', 'hosted-mcp'])}` "
+                    "if you want MCP without local setup."
+                ),
+                (
+                    f"Run `{local_cli_command(['support-bundle'])}` when attaching public setup "
+                    "evidence or opening an issue."
+                ),
+                (
+                    f"Keep `{local_cli_command(['doctor', '--format', 'json'])}` "
+                    "local unless a maintainer "
+                    "asks for raw paths in private triage."
+                ),
+            ],
+            "safety": [
+                "This command only prints guidance; it does not write config.",
+                "Secret values are not printed.",
+            ],
+        }
+
+    local_command = _quickstart_local_mcp_command
+    local_config = _quickstart_local_mcp_config(
+        client=client,
+        repo_root=repo_root,
+    )
+    local_config_command = cast(list[str], local_config["command"])
+    local_launch_mode = str(local_config["mode"])
+    config_step = (
+        "Generate client config from the checkout path."
+        if local_launch_mode == "source-checkout"
+        else "Generate client config from the installed entrypoint."
+    )
+    local_mcp_description = (
+        "Local MCP path for Codex or Claude Code from a source checkout."
+        if local_launch_mode == "source-checkout"
+        else "Local MCP path for Codex or Claude Code from an installed CLI."
+    )
+    local_mcp_prerequisites = (
+        [
+            "PolicyNIM source checkout with uv dependencies synced.",
+            "NVIDIA_API_KEY available in the shell that launches the MCP client.",
+        ]
+        if local_launch_mode == "source-checkout"
+        else [
+            "An installed PolicyNIM CLI.",
+            "NVIDIA_API_KEY available in the shell that launches the MCP client.",
+        ]
+    )
+    return {
+        "schema_version": "1",
+        "target": target,
+        "client": client,
+        "local_launch_mode": local_launch_mode,
+        "requires_local_setup": True,
+        "calls_external_services": False,
+        "description": local_mcp_description,
+        "prerequisites": local_mcp_prerequisites,
+        "steps": [
+            "Confirm local setup state.",
+            "Create local config if needed.",
+            "Build the policy index.",
+            "Verify the stdio MCP server lists public tools.",
+            config_step,
+        ],
+        "commands": [
+            local_command("doctor"),
+            local_command("init"),
+            local_command("ingest"),
+            local_command("mcp-smoke"),
+            _shell_join(local_config_command),
+        ],
+        "agent_workflows": _quickstart_agent_workflows(),
+        "next_steps": [
+            "Load the generated config in your MCP client.",
+            "Ask the client to list `policy_preflight` and `policy_search`.",
+        ],
+        "safety": [
+            "This command does not launch the MCP server.",
+            "Keep NVIDIA_API_KEY in environment variables.",
+            (
+                "Local MCP setup commands can include exact local filesystem paths; "
+                "do not paste them into public issues."
+            ),
+            "Use `policynim support-bundle` for public diagnostics.",
+        ],
+    }
+
+
+def _quickstart_cli_command(parts: Sequence[str]) -> str:
+    """Render a shell command for the active local CLI runtime."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return _shell_join(["uv", "run", "policynim", *parts])
+    return _shell_join(["policynim", *parts])
+
+
+def _quickstart_agent_workflows() -> list[dict[str, str]]:
+    """Return copyable first-use prompts for coding-agent workflows."""
+    return [
+        {
+            "title": workflow["title"],
+            "tool": workflow["tool"],
+            "prompt": workflow["prompt"],
+        }
+        for workflow in agent_workflows()
+    ]
+
+
+def _alternate_mcp_client(
+    client: Literal["codex", "claude-code"],
+) -> Literal["codex", "claude-code"]:
+    """Return the other supported MCP client for first-run hints."""
+    if client == "codex":
+        return "claude-code"
+    return "codex"
+
+
+def _mcp_client_display_name(client: Literal["codex", "claude-code"]) -> str:
+    """Render supported MCP client names for user-facing guidance."""
+    if client == "claude-code":
+        return "Claude Code"
+    return "Codex"
+
+
+def _quickstart_hosted_client_commands(
+    *,
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> list[str]:
+    """Return the direct hosted MCP client command for quickstart output."""
+    payload = _build_hosted_mcp_config_payload(
+        client=client,
+        hosted_url=hosted_url,
+        bearer_token_env_var=bearer_token_env_var,
+        server_name="policynim",
+    )
+    command_key = "cli_shell_command" if client == "claude-code" else "codex_cli_shell_command"
+    return [str(payload[command_key])]
+
+
+def _quickstart_all_hosted_client_commands(
+    *,
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> list[str]:
+    """Return hosted MCP setup commands for every supported client."""
+    commands: list[str] = []
+    for client in ("codex", "claude-code"):
+        commands.extend(
+            _quickstart_hosted_client_commands(
+                client=client,
+                hosted_url=hosted_url,
+                bearer_token_env_var=bearer_token_env_var,
+            )
+        )
+    return commands
+
+
+def _quickstart_installed_cli_command(parts: Sequence[str]) -> str:
+    """Render a shell command that always targets the installed CLI."""
+    return _shell_join(["policynim", *parts])
+
+
+def _quickstart_local_mcp_command(command: str) -> str:
+    """Render a local MCP setup command for quickstart output."""
+    return _doctor_cli_command(command)
+
+
+def _quickstart_local_mcp_config(
+    *,
+    client: Literal["codex", "claude-code"],
+    repo_root: Path | None,
+) -> dict[str, object]:
+    """Build a local stdio MCP config command description for quickstart."""
+    command = [
+        *_doctor_cli_command("mcp-config").split(),
+        "--target",
+        "local-stdio",
+        "--client",
+        client,
+    ]
+    if repo_root is not None:
+        return {
+            "mode": "source-checkout",
+            "command": [
+                *command,
+                "--repo-root",
+                str(repo_root.expanduser().resolve(strict=False)),
+            ],
+        }
+    discovered = config_discovery.find_source_checkout_root()
+    if discovered is not None:
+        return {"mode": "source-checkout", "command": [*command, "--repo-root", str(discovered)]}
+    return {"mode": "installed-cli", "command": command}
+
+
+def _hosted_beta_portal_url(hosted_mcp_url: str) -> str:
+    """Derive the hosted beta portal URL from a hosted MCP URL."""
+    parsed = urlparse(hosted_mcp_url)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}/beta"
+    return "https://<railway-domain>/beta"
+
+
+def _build_mcp_config_payload(
+    *,
+    client: Literal["codex", "claude-code"],
+    target: Literal["local-stdio", "hosted-http"],
+    hosted_url: str | None,
+    bearer_token_env_var: str,
+    repo_root: Path | None,
+    server_name: str,
+    uv_command: str,
+) -> dict[str, object]:
+    """Build client-specific MCP configuration without writing client files."""
+    _validate_mcp_config_target_options(
+        target=target,
+        repo_root=repo_root,
+        hosted_url=hosted_url,
+        bearer_token_env_var=bearer_token_env_var,
+        uv_command=uv_command,
+    )
+    normalized_server_name = _normalize_mcp_config_value(
+        server_name,
+        label="MCP server name",
+    )
+    if target == "hosted-http":
+        return _build_hosted_mcp_config_payload(
+            client=client,
+            hosted_url=_normalize_hosted_mcp_url(hosted_url),
+            bearer_token_env_var=_normalize_env_var_name(bearer_token_env_var),
+            server_name=normalized_server_name,
+        )
+
+    launch = _resolve_local_mcp_launch(repo_root=repo_root, uv_command=uv_command)
+    launch_mode = str(launch["mode"])
+    command = str(launch["command"])
+    args = cast(list[str], launch["args"])
+    repo_root_value = cast(str | None, launch.get("repo_root"))
+    next_steps = cast(list[str], launch["next_steps"])
+    safety = _local_mcp_config_safety()
+
+    if client == "claude-code":
+        server_config = {
+            "type": "stdio",
+            "command": command,
+            "args": args,
+            "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+        }
+        config = {"mcpServers": {normalized_server_name: server_config}}
+        compact_config = json.dumps(server_config, separators=(",", ":"))
+        payload = {
+            "schema_version": "1",
+            "client": client,
+            "target": target,
+            "server_name": normalized_server_name,
+            "local_launch_mode": launch_mode,
+            "config": config,
+            "cli_command": [
+                "claude",
+                "mcp",
+                "add-json",
+                normalized_server_name,
+                compact_config,
+            ],
+            "cli_shell_command": _shell_join(
+                ["claude", "mcp", "add-json", normalized_server_name, compact_config]
+            ),
+            "next_steps": next_steps,
+            "safety": safety,
+        }
+        if repo_root_value is not None:
+            payload["repo_root"] = repo_root_value
+        return payload
+
+    codex_command = [
+        "codex",
+        "mcp",
+        "add",
+        normalized_server_name,
+        "--env",
+        "NVIDIA_API_KEY=$NVIDIA_API_KEY",
+        "--",
+        command,
+        *args,
+    ]
+    codex_app = {
+        "name": normalized_server_name,
+        "transport": "STDIO",
+        "command": command,
+        "arguments": args,
+        "environment_variable_passthrough": ["NVIDIA_API_KEY"],
+    }
+    if repo_root_value is not None:
+        codex_app["working_directory"] = repo_root_value
+    payload = {
+        "schema_version": "1",
+        "client": client,
+        "target": target,
+        "server_name": normalized_server_name,
+        "local_launch_mode": launch_mode,
+        "codex_cli_command": codex_command,
+        "codex_cli_shell_command": _codex_cli_shell_command(
+            server_name=normalized_server_name,
+            command=command,
+            args=args,
+        ),
+        "codex_app": codex_app,
+        "next_steps": next_steps,
+        "safety": safety,
+    }
+    if repo_root_value is not None:
+        payload["repo_root"] = repo_root_value
+    return payload
+
+
+def _local_mcp_config_safety() -> list[str]:
+    """Return safety notes shared by local MCP config payloads."""
+    return [
+        (
+            "Generated local stdio config can include exact local filesystem paths; "
+            "do not paste it into public issues."
+        ),
+        "Use `policynim support-bundle` for public diagnostics.",
+    ]
+
+
+def _resolve_local_mcp_launch(
+    *,
+    repo_root: Path | None,
+    uv_command: str,
+) -> dict[str, object]:
+    """Resolve whether local MCP should launch from a checkout or installed CLI."""
+    discovered_repo_root = _resolve_mcp_config_repo_root(repo_root)
+    if discovered_repo_root is None:
+        if uv_command != "uv":
+            raise PolicyNIMError(
+                "--uv-command requires a PolicyNIM source checkout. "
+                "Pass --repo-root /ABS/PATH/TO/policyNIM."
+            )
+        return {
+            "mode": "installed-cli",
+            "command": "policynim",
+            "args": ["mcp", "--transport", "stdio"],
+            "next_steps": [
+                "policynim doctor",
+                "policynim mcp-smoke",
+                "policynim ingest",
+            ],
+        }
+
+    normalized_uv_command = _normalize_mcp_config_value(uv_command, label="uv command")
+    return {
+        "mode": "source-checkout",
+        "command": normalized_uv_command,
+        "args": [
+            "run",
+            "--directory",
+            str(discovered_repo_root),
+            "policynim",
+            "mcp",
+            "--transport",
+            "stdio",
+        ],
+        "repo_root": str(discovered_repo_root),
+        "next_steps": [
+            "uv run policynim doctor",
+            "uv run policynim mcp-smoke",
+            "uv run policynim ingest",
+        ],
+    }
+
+
+def _validate_mcp_config_target_options(
+    *,
+    target: Literal["local-stdio", "hosted-http"],
+    repo_root: Path | None,
+    hosted_url: str | None,
+    bearer_token_env_var: str,
+    uv_command: str,
+) -> None:
+    """Reject option combinations that would produce misleading MCP config."""
+    if target == "hosted-http":
+        if repo_root is not None:
+            raise PolicyNIMError("--repo-root is only valid with --target local-stdio.")
+        if uv_command != "uv":
+            raise PolicyNIMError("--uv-command is only valid with --target local-stdio.")
+        return
+
+    if hosted_url is not None:
+        raise PolicyNIMError("--hosted-url is only valid with --target hosted-http.")
+    if bearer_token_env_var != "POLICYNIM_TOKEN":
+        raise PolicyNIMError("--bearer-token-env-var is only valid with --target hosted-http.")
+
+
+def _build_hosted_mcp_config_payload(
+    *,
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+    server_name: str,
+) -> dict[str, object]:
+    """Build hosted HTTP MCP config for Codex or Claude Code."""
+    hosted_url_placeholder = _is_placeholder_hosted_url(hosted_url)
+    beta_portal_url = _hosted_beta_portal_url(hosted_url)
+    next_steps = [
+        f"Open {beta_portal_url} to generate or rotate a hosted API key.",
+        f"Export {bearer_token_env_var}='<generated-beta-token>'",
+        "Ask your client to call `policy_preflight` for the main workflow.",
+        "Use `policy_search` first when you need raw retrieval/debugging context.",
+    ]
+    if hosted_url_placeholder:
+        next_steps.insert(
+            0,
+            "Replace the hosted URL placeholder with the deployed /mcp URL.",
+        )
+    if client == "claude-code":
+        header = f"Authorization: Bearer ${bearer_token_env_var}"
+        command = [
+            "claude",
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            server_name,
+            hosted_url,
+            "--header",
+            header,
+        ]
+        return {
+            "schema_version": "1",
+            "client": client,
+            "target": "hosted-http",
+            "server_name": server_name,
+            "hosted_url": hosted_url,
+            "beta_portal_url": beta_portal_url,
+            "hosted_url_placeholder": hosted_url_placeholder,
+            "bearer_token_env_var": bearer_token_env_var,
+            "cli_command": command,
+            "cli_shell_command": _claude_hosted_shell_command(
+                server_name=server_name,
+                hosted_url=hosted_url,
+                bearer_token_env_var=bearer_token_env_var,
+            ),
+            "next_steps": next_steps,
+        }
+
+    command = [
+        "codex",
+        "mcp",
+        "add",
+        server_name,
+        "--url",
+        hosted_url,
+        "--bearer-token-env-var",
+        bearer_token_env_var,
+    ]
+    return {
+        "schema_version": "1",
+        "client": client,
+        "target": "hosted-http",
+        "server_name": server_name,
+        "hosted_url": hosted_url,
+        "beta_portal_url": beta_portal_url,
+        "hosted_url_placeholder": hosted_url_placeholder,
+        "bearer_token_env_var": bearer_token_env_var,
+        "codex_cli_command": command,
+        "codex_cli_shell_command": _shell_join(command),
+        "next_steps": [
+            *next_steps,
+            f"Run `codex mcp get {server_name}` to inspect the saved server entry.",
+        ],
+    }
+
+
+def _resolve_mcp_config_repo_root(repo_root: Path | None) -> Path | None:
+    """Resolve and validate an optional source checkout root."""
+    if repo_root is None:
+        discovered = config_discovery.find_source_checkout_root()
+        if discovered is None:
+            return None
+        candidate = discovered
+    else:
+        candidate = repo_root
+    resolved = candidate.expanduser().resolve(strict=False)
+    if not _looks_like_policynim_checkout(resolved):
+        raise PolicyNIMError(
+            "--repo-root must point to a PolicyNIM source checkout. "
+            "Omit --repo-root to launch the installed CLI."
+        )
+    return resolved
+
+
+def _looks_like_policynim_checkout(path: Path) -> bool:
+    """Return whether a path has the expected PolicyNIM checkout shape."""
+    return (path / "pyproject.toml").is_file() and (path / "src" / "policynim").is_dir()
+
+
+def _normalize_mcp_config_value(value: str, *, label: str) -> str:
+    """Trim and validate a required MCP config string value."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError(f"{label} cannot be empty.")
+    return stripped
+
+
+def _normalize_hosted_mcp_url(value: str | None) -> str:
+    """Normalize a hosted MCP URL and enforce the /mcp endpoint shape."""
+    if value is None or not value.strip():
+        raise PolicyNIMError("Hosted MCP config requires --hosted-url https://<host>/mcp.")
+    stripped = value.strip()
+    parsed = urlparse(stripped)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise PolicyNIMError(
+            "Hosted MCP URL must start with http:// or https:// and include a host."
+        )
+    if parsed.path.rstrip("/") != "/mcp":
+        raise PolicyNIMError("Hosted MCP URL must point to the /mcp endpoint.")
+    return stripped
+
+
+def _normalize_env_var_name(value: str) -> str:
+    """Normalize and validate an environment variable name."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError("Bearer token env var cannot be empty.")
+    if not (stripped[0].isalpha() or stripped[0] == "_"):
+        raise PolicyNIMError("Bearer token env var must not start with a number.")
+    if any(not (character.isalnum() or character == "_") for character in stripped):
+        raise PolicyNIMError(
+            "Bearer token env var must contain only letters, numbers, and underscores."
+        )
+    return stripped
+
+
+def _normalize_quickstart_value(value: str, *, label: str) -> str:
+    """Trim and validate a required quickstart string value."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError(f"{label} cannot be empty.")
+    return stripped
+
+
+def _is_placeholder_hosted_url(value: str) -> bool:
+    """Return whether a hosted URL still contains unresolved placeholder text."""
+    normalized = value.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "<",
+            ">",
+            "example.",
+            ".example/",
+            ".invalid",
+            "todo",
+            "placeholder",
+        )
+    )
+
+
+def _render_mcp_config_payload(payload: dict[str, object]) -> list[str]:
+    """Render an MCP config payload as terminal-friendly text."""
+    if payload.get("target") == "hosted-http":
+        return _render_hosted_mcp_config(payload)
+    client = str(payload["client"])
+    if client == "claude-code":
+        return _render_claude_code_mcp_config(payload)
+    return _render_codex_mcp_config(payload)
+
+
+def _render_quickstart_payload(payload: dict[str, object]) -> list[str]:
+    """Render a quickstart payload as terminal-friendly text."""
+    return [
+        "PolicyNIM quickstart",
+        f"Target: {payload['target']}",
+        f"Client: {payload['client']}",
+        str(payload["description"]),
+        "",
+        "Prerequisites:",
+        *_render_quickstart_list(payload, "prerequisites"),
+        "",
+        "Steps:",
+        *_render_quickstart_numbered_list(payload, "steps"),
+        "",
+        "Commands:",
+        *_render_quickstart_list(payload, "commands"),
+        *_render_quickstart_client_commands(payload),
+        "",
+        "Agent workflows:",
+        *_render_quickstart_agent_workflows(payload),
+        "",
+        "Next:",
+        *_render_quickstart_list(payload, "next_steps"),
+        "",
+        "Safety:",
+        *_render_quickstart_list(payload, "safety"),
+    ]
+
+
+def _render_quickstart_list(payload: dict[str, object], key: str) -> list[str]:
+    """Render one quickstart list field as bullet lines."""
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        return []
+    return [f"- {value}" for value in values]
+
+
+def _render_quickstart_numbered_list(payload: dict[str, object], key: str) -> list[str]:
+    """Render one quickstart list field as numbered steps."""
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        return []
+    return [f"{index}. {value}" for index, value in enumerate(values, start=1)]
+
+
+def _render_quickstart_client_commands(payload: dict[str, object]) -> list[str]:
+    """Render optional direct MCP client setup commands."""
+    lines = _render_quickstart_list(payload, "client_commands")
+    if not lines:
+        return []
+    return ["", "Client setup:", *lines]
+
+
+def _render_quickstart_agent_workflows(payload: dict[str, object]) -> list[str]:
+    """Render quickstart agent workflow cards as terminal-friendly prompts."""
+    values = payload.get("agent_workflows", [])
+    if not isinstance(values, list):
+        return []
+    lines: list[str] = []
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        title = value.get("title")
+        prompt = value.get("prompt")
+        if isinstance(title, str) and isinstance(prompt, str):
+            lines.append(f"- {title}: {prompt}")
+    return lines
+
+
+def _render_hosted_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render hosted HTTP MCP client setup guidance."""
+    client_label = "Claude Code" if payload["client"] == "claude-code" else "Codex"
+    command_label = "Claude Code CLI" if payload["client"] == "claude-code" else "Codex CLI"
+    lines = [
+        f"PolicyNIM hosted MCP config for {client_label}",
+        f"Hosted URL: {payload['hosted_url']}",
+        f"Bearer token env var: {payload['bearer_token_env_var']}",
+        "",
+        f"{command_label}:",
+        str(payload["cli_shell_command"])
+        if payload["client"] == "claude-code"
+        else str(payload["codex_cli_shell_command"]),
+    ]
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_claude_code_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render local stdio MCP setup guidance for Claude Code."""
+    config = payload["config"]
+    lines = [
+        "PolicyNIM MCP config for Claude Code",
+        f"Launch mode: {payload['local_launch_mode']}",
+    ]
+    if "repo_root" in payload:
+        lines.append(f"Repo root: {payload['repo_root']}")
+    lines.extend(
+        [
+            "",
+            "Project-scoped .mcp.json:",
+            json.dumps(config, indent=2),
+            "",
+            "Claude Code CLI:",
+            str(payload["cli_shell_command"]),
+        ]
+    )
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_codex_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render local stdio MCP setup guidance for Codex."""
+    codex_app = payload["codex_app"]
+    if not isinstance(codex_app, dict):
+        raise PolicyNIMError("Generated Codex app config was malformed.")
+    arguments = codex_app.get("arguments", [])
+    if not isinstance(arguments, list):
+        raise PolicyNIMError("Generated Codex app arguments were malformed.")
+    lines = [
+        "PolicyNIM MCP config for Codex",
+        f"Launch mode: {payload['local_launch_mode']}",
+    ]
+    if "repo_root" in payload:
+        lines.append(f"Repo root: {payload['repo_root']}")
+    lines.extend(
+        [
+            "",
+            "Codex CLI:",
+            str(payload["codex_cli_shell_command"]),
+            "",
+            "Codex App:",
+            f"Name: {codex_app.get('name')}",
+            f"Transport: {codex_app.get('transport')}",
+            f"Command to launch: {codex_app.get('command')}",
+            "Arguments:",
+            *[f"- {argument}" for argument in arguments],
+        ]
+    )
+    working_directory = codex_app.get("working_directory")
+    if working_directory is not None:
+        lines.append(f"Working directory: {working_directory}")
+    lines.append("Environment variable passthrough: NVIDIA_API_KEY")
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_mcp_config_next_steps(payload: dict[str, object]) -> list[str]:
+    """Render shared MCP config next-step and safety sections."""
+    next_steps = payload.get("next_steps", [])
+    safety = payload.get("safety", [])
+    lines: list[str] = []
+    if not isinstance(next_steps, list):
+        next_steps = []
+    if next_steps:
+        lines.extend(["", "Before using this config:", *[f"- {step}" for step in next_steps]])
+    if isinstance(safety, list) and safety:
+        lines.extend(["", "Safety:", *[f"- {item}" for item in safety]])
+    return lines
+
+
+def _shell_join(command: Sequence[str]) -> str:
+    """Render argv as a shell-safe command string."""
+    return shlex.join(command)
+
+
+def _claude_hosted_shell_command(
+    *,
+    server_name: str,
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> str:
+    """Render the hosted Claude Code MCP command without exposing token values."""
+    prefix = _shell_join(
+        [
+            "claude",
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            server_name,
+            hosted_url,
+            "--header",
+        ]
+    )
+    return f'{prefix} "Authorization: Bearer ${bearer_token_env_var}"'
+
+
+def _codex_cli_shell_command(
+    *,
+    server_name: str,
+    command: str,
+    args: Sequence[str],
+) -> str:
+    """Render the Codex CLI command for a local stdio MCP server."""
+    prefix = _shell_join(["codex", "mcp", "add", server_name, "--env"])
+    launch = _shell_join([command, *args])
+    return f"{prefix} NVIDIA_API_KEY=$NVIDIA_API_KEY -- {launch}"
+
+
+async def _build_support_bundle(
+    *,
+    include_mcp_smoke: bool,
+    mcp_timeout_seconds: float,
+    include_local_paths: bool,
+) -> dict[str, object]:
+    """Build public or private diagnostics for maintainer support."""
+    bundle: dict[str, object] = {
+        "schema_version": "1",
+        "generated_at": datetime.now().astimezone().isoformat(),
+        "policynim_version": _safe_installed_version(),
+        "python": {
+            "version": platform.python_version(),
+            "executable": sys.executable,
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "first_run": _build_support_bundle_first_run_report(),
+        "doctor": _build_doctor_report(),
+        "mcp_smoke": {
+            "status": "skipped",
+            "reason": ("Pass --include-mcp-smoke to verify stdio tool registration."),
+        },
+        "redaction": {
+            "secrets_included": False,
+            "local_paths": "included" if include_local_paths else "redacted",
+            "path_markers": [],
+            "note": (
+                "Secret values are not printed. Local paths are included for private "
+                "maintainer triage."
+                if include_local_paths
+                else (
+                    "Secret values are not printed; local path prefixes are redacted "
+                    "for public issues. Pass --include-local-paths only for private "
+                    "maintainer triage."
+                )
+            ),
+        },
+    }
+    if include_mcp_smoke:
+        bundle["mcp_smoke"] = await _run_mcp_stdio_smoke(timeout_seconds=mcp_timeout_seconds)
+    if include_local_paths:
+        return bundle
+
+    redacted_bundle, markers = _redact_support_bundle_paths(bundle)
+    redaction = redacted_bundle.get("redaction")
+    if isinstance(redaction, dict):
+        redaction["path_markers"] = markers
+    return redacted_bundle
+
+
+def _build_support_bundle_first_run_report() -> dict[str, object]:
+    """Build quickstart summaries for all first-run targets."""
+    targets: dict[str, object] = {}
+    target_specs: tuple[
+        tuple[str, Literal["hosted-mcp", "local-cli", "local-mcp"]],
+        ...,
+    ] = (
+        ("hosted_mcp", "hosted-mcp"),
+        ("local_cli", "local-cli"),
+        ("local_mcp", "local-mcp"),
+    )
+    for key, target in target_specs:
+        payload = _build_quickstart_payload(
+            target=target,
+            client="codex",
+            hosted_url="https://<railway-domain>/mcp",
+            bearer_token_env_var="POLICYNIM_TOKEN",
+            repo_root=None,
+        )
+        targets[key] = _support_bundle_quickstart_summary(
+            payload,
+            quickstart_command=_support_bundle_quickstart_command(target),
+        )
+
+    return {
+        "runtime_mode": _doctor_runtime_mode(),
+        "default_target": "hosted-mcp",
+        "targets": targets,
+    }
+
+
+def _support_bundle_quickstart_command(
+    target: Literal["hosted-mcp", "local-cli", "local-mcp"],
+) -> str:
+    """Return the command that reproduces one quickstart target."""
+    command = f"quickstart --target {target}"
+    if target == "local-mcp":
+        command = f"{command} --client codex"
+    if target == "hosted-mcp":
+        return _quickstart_installed_cli_command([*command.split(), "--format", "json"])
+    return _doctor_cli_command(f"{command} --format json")
+
+
+def _support_bundle_quickstart_summary(
+    payload: dict[str, object],
+    *,
+    quickstart_command: str,
+) -> dict[str, object]:
+    """Extract support-bundle-safe quickstart fields."""
+    summary: dict[str, object] = {
+        "target": payload["target"],
+        "description": payload["description"],
+        "quickstart_command": quickstart_command,
+        "requires_local_setup": payload["requires_local_setup"],
+        "calls_external_services": payload["calls_external_services"],
+        "steps": payload["steps"],
+        "commands": payload["commands"],
+        "agent_workflows": payload["agent_workflows"],
+        "next_steps": payload["next_steps"],
+        "safety": payload["safety"],
+    }
+    for optional_key in (
+        "hosted_url",
+        "beta_portal_url",
+        "hosted_url_placeholder",
+        "local_launch_mode",
+        "client_commands",
+    ):
+        if optional_key in payload:
+            summary[optional_key] = payload[optional_key]
+    if payload["target"] == "hosted-mcp":
+        summary["client_commands"] = _quickstart_all_hosted_client_commands(
+            hosted_url=str(payload["hosted_url"]),
+            bearer_token_env_var="POLICYNIM_TOKEN",
+        )
+    return summary
+
+
+def _redact_support_bundle_paths(bundle: dict[str, object]) -> tuple[dict[str, object], list[str]]:
+    """Redact local path prefixes from a support bundle."""
+    replacements = _support_bundle_path_replacements()
+    redacted = _replace_local_path_prefixes(bundle, replacements)
+    markers = sorted({marker for _, marker in replacements})
+    return cast(dict[str, object], redacted), markers
+
+
+def _support_bundle_path_replacements() -> list[tuple[str, str]]:
+    """Return local path prefixes and the markers that should replace them."""
+    candidates: list[tuple[Path, str]] = [
+        (Path(sys.executable), "<python-executable>"),
+        (Path.home(), "<home>"),
+    ]
+    source_root = config_discovery.find_source_checkout_root()
+    if source_root is not None:
+        candidates.append((source_root, "<repo-root>"))
+
+    standalone = config_discovery.standalone_paths()
+    candidates.extend(
+        [
+            (standalone.config_file.parent, "<config-dir>"),
+            (standalone.data_root, "<data-dir>"),
+        ]
+    )
+
+    replacements: dict[str, str] = {}
+    if sys.executable:
+        replacements[sys.executable] = "<python-executable>"
+    for path, marker in candidates:
+        for candidate in (
+            path.expanduser().as_posix(),
+            path.expanduser().resolve(strict=False).as_posix(),
+        ):
+            if candidate and candidate != "/":
+                replacements[candidate] = marker
+    return sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True)
+
+
+def _replace_local_path_prefixes(value: object, replacements: Sequence[tuple[str, str]]) -> object:
+    """Recursively replace local path prefixes in support-bundle values."""
+    if isinstance(value, str):
+        redacted = value
+        for path_prefix, marker in replacements:
+            redacted = redacted.replace(path_prefix, marker)
+        return redacted
+    if isinstance(value, list):
+        return [_replace_local_path_prefixes(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _replace_local_path_prefixes(item, replacements) for key, item in value.items()
+        }
+    return value
+
+
+def _safe_installed_version() -> str:
+    """Return the installed package version without failing diagnostics."""
+    try:
+        return _resolve_installed_version()
+    except PolicyNIMError:
+        return "unknown"
+
+
+def _render_support_bundle_markdown(rendered_json: str) -> str:
+    """Wrap rendered support-bundle JSON in a Markdown code fence."""
+    return "\n".join(
+        [
+            "## PolicyNIM Support Bundle",
+            "",
+            "```json",
+            rendered_json,
+            "```",
+        ]
+    )
+
+
+async def _run_mcp_stdio_smoke(
+    *,
+    timeout_seconds: float,
+    command: list[str] | None = None,
+    cwd: Path | None = None,
+) -> dict[str, object]:
+    """Launch local stdio MCP and report public tool registration."""
+    command = command or _mcp_stdio_smoke_command()
+    report: dict[str, object] = {
+        "status": "error",
+        "transport": "stdio",
+        "command": command,
+        "tools": [],
+        "missing_tools": list(_EXPECTED_MCP_TOOLS),
+    }
+    with TemporaryFile(mode="w+", encoding="utf-8") as errlog:
+        try:
+            parameters = StdioServerParameters(
+                command=command[0],
+                args=command[1:],
+                env=_mcp_stdio_smoke_env(),
+                cwd=cwd or Path.cwd(),
+            )
+            async with stdio_client(parameters, errlog=errlog) as (read_stream, write_stream):
+                async with ClientSession(
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                ) as session:
+                    await session.initialize()
+                    tool_result = await session.list_tools()
+        except Exception as exc:
+            report["message"] = f"MCP stdio smoke failed: {type(exc).__name__}: {exc}"
+            report["next_steps"] = _mcp_stdio_recovery_steps()
+            errlog.seek(0)
+            stderr_tail = errlog.read().strip()[-2000:]
+            if stderr_tail:
+                report["server_stderr_tail"] = stderr_tail
+            return report
+
+    tool_names = sorted(tool.name for tool in tool_result.tools)
+    missing_tools = [tool for tool in _EXPECTED_MCP_TOOLS if tool not in tool_names]
+    report["tools"] = tool_names
+    report["missing_tools"] = missing_tools
+    report["status"] = "ok" if not missing_tools else "error"
+    if missing_tools:
+        report["message"] = "MCP stdio server did not list all expected public tools."
+        report["next_steps"] = _mcp_stdio_recovery_steps()
+    return report
+
+
+def _mcp_stdio_smoke_command_from_config_file(path: Path) -> tuple[list[str], Path | None]:
+    """Extract a local stdio launch command from generated mcp-config JSON."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise PolicyNIMError(f"Could not read MCP config file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyNIMError(f"MCP config file {path} must contain JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PolicyNIMError("MCP config file must contain a JSON object.")
+    if payload.get("target") != "local-stdio":
+        raise PolicyNIMError(
+            "mcp-smoke --mcp-config-file only supports local-stdio configs. "
+            "Use hosted launch evidence for hosted-http configs."
+        )
+
+    client = payload.get("client")
+    if client == "codex":
+        return _codex_stdio_command_from_config_payload(payload)
+    if client == "claude-code":
+        return _claude_stdio_command_from_config_payload(payload)
+    raise PolicyNIMError("MCP config file client must be codex or claude-code.")
+
+
+def _codex_stdio_command_from_config_payload(
+    payload: dict[object, object],
+) -> tuple[list[str], Path | None]:
+    codex_app = payload.get("codex_app")
+    if not isinstance(codex_app, dict):
+        raise PolicyNIMError("Codex MCP config file is missing codex_app.")
+    if codex_app.get("transport") != "STDIO":
+        raise PolicyNIMError("Codex MCP config file must use STDIO transport.")
+    command = codex_app.get("command")
+    arguments = codex_app.get("arguments")
+    launch_command = _mcp_stdio_launch_command(command, arguments)
+    cwd = _optional_path(codex_app.get("working_directory")) or _optional_path(
+        payload.get("repo_root")
+    )
+    return launch_command, cwd
+
+
+def _claude_stdio_command_from_config_payload(
+    payload: dict[object, object],
+) -> tuple[list[str], Path | None]:
+    config = payload.get("config")
+    server_name = payload.get("server_name")
+    if not isinstance(config, dict) or not isinstance(server_name, str):
+        raise PolicyNIMError("Claude Code MCP config file is missing config or server_name.")
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        raise PolicyNIMError("Claude Code MCP config file is missing mcpServers.")
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        raise PolicyNIMError(f"Claude Code MCP config file is missing {server_name!r}.")
+    if server.get("type") != "stdio":
+        raise PolicyNIMError("Claude Code MCP config file must use stdio transport.")
+    launch_command = _mcp_stdio_launch_command(server.get("command"), server.get("args"))
+    return launch_command, _optional_path(payload.get("repo_root"))
+
+
+def _mcp_stdio_launch_command(command: object, arguments: object) -> list[str]:
+    if not isinstance(command, str) or not command:
+        raise PolicyNIMError("MCP config file must include a non-empty stdio command.")
+    if not isinstance(arguments, list) or any(
+        not isinstance(argument, str) for argument in arguments
+    ):
+        raise PolicyNIMError("MCP config file stdio arguments must be a string list.")
+    return [command, *cast(list[str], arguments)]
+
+
+def _optional_path(value: object) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return Path(value)
+
+
+def _mcp_stdio_smoke_command() -> list[str]:
+    """Return the command used to re-enter the local MCP stdio server."""
+    if getattr(sys, "frozen", False):
+        return [sys.executable, "mcp", "--transport", "stdio"]
+    return [sys.executable, "-m", "policynim.interfaces.cli", "mcp", "--transport", "stdio"]
+
+
+def _mcp_stdio_smoke_env() -> dict[str, str]:
+    """Return an env that can resolve the current installed policynim entrypoint."""
+    env = os.environ.copy()
+    executable_dir = str(Path(sys.executable).parent)
+    existing_path = env.get("PATH", "")
+    env["PATH"] = (
+        f"{executable_dir}{os.pathsep}{existing_path}" if existing_path else executable_dir
+    )
+    return env
+
+
+def _mcp_stdio_recovery_steps() -> list[str]:
+    """Return setup steps for failed local MCP stdio smoke checks."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return [
+            "Run `uv run policynim doctor` to inspect config, credentials, and local index state.",
+            "Run `uv run policynim ingest` before calling policy_preflight or policy_search.",
+            "Run `uv run policynim mcp-smoke --format json` after changing local setup.",
+            (
+                "Regenerate client config with `uv run policynim mcp-config --target "
+                "local-stdio --client codex --repo-root /ABS/PATH/TO/policyNIM --format json` "
+                "or the same command with `--client claude-code`."
+            ),
+            (
+                "If the MCP client cannot find `uv`, rerun mcp-config with "
+                "`--uv-command /ABS/PATH/TO/uv`."
+            ),
+        ]
+    return [
+        "Run `policynim doctor` to inspect config, credentials, and local index state.",
+        "Run `policynim ingest` before calling policy_preflight or policy_search.",
+        "Run `policynim mcp-smoke --format json` after changing local setup.",
+        (
+            "Regenerate client config with `policynim mcp-config --target local-stdio "
+            "--client codex --format json` or the same command with `--client claude-code`."
+        ),
+    ]
+
+
+def _render_mcp_smoke_report(report: dict[str, object]) -> list[str]:
+    """Render an MCP smoke report as terminal-friendly text."""
+    lines = [
+        "PolicyNIM MCP smoke",
+        f"Status: {report['status']}",
+        f"Transport: {report['transport']}",
+    ]
+    command = report.get("command")
+    if isinstance(command, list):
+        lines.append(f"Command: {' '.join(str(part) for part in command)}")
+    tools = report.get("tools")
+    if isinstance(tools, list):
+        lines.append(f"Tools: {', '.join(str(tool) for tool in tools) or 'none'}")
+    missing_tools = report.get("missing_tools")
+    if isinstance(missing_tools, list) and missing_tools:
+        lines.append(f"missing_tools: {', '.join(str(tool) for tool in missing_tools)}")
+    message = report.get("message")
+    if isinstance(message, str) and message:
+        lines.append(f"Message: {message}")
+    next_steps = report.get("next_steps")
+    if isinstance(next_steps, list) and next_steps:
+        lines.append("")
+        lines.append("Next steps:")
+        for step in next_steps:
+            lines.append(f"- {step}")
+    return lines
+
+
+def _build_doctor_report() -> dict[str, object]:
+    """Build a setup diagnostic report without calling hosted APIs."""
+    discovery = config_discovery.discover_config_files()
+    expected_config_file = config_discovery.resolve_init_config_file()
+    report: dict[str, object] = {
+        "status": "ok",
+        "runtime_mode": _doctor_runtime_mode(),
+        "config": {
+            "active_config_file": _path_text(discovery.active_config_file),
+            "discovered_env_files": [_path_text(path) for path in discovery.env_files],
+            "expected_init_config_file": expected_config_file.as_posix(),
+        },
+        "checks": [],
+        "paths": {},
+        "mcp": {},
+        "next_steps": [],
+    }
+    checks: list[dict[str, str]] = []
+    next_steps: list[str] = []
+
+    if config_discovery.standalone_setup_missing():
+        message = f"Run `policynim init` to create {expected_config_file}."
+        checks.append({"name": "setup", "status": "action_required", "message": message})
+        report["status"] = "action_required"
+        report["checks"] = checks
+        report["next_steps"] = [message]
+        return report
+
+    try:
+        settings = get_settings()
+    except PolicyNIMError as exc:
+        checks.append(
+            {
+                "name": "configuration",
+                "status": "error",
+                "message": _cli_error_message(exc),
+            }
+        )
+        report["status"] = "error"
+        report["checks"] = checks
+        report["next_steps"] = ["Fix the configuration error above, then rerun `policynim doctor`."]
+        return report
+
+    checks.append(
+        {
+            "name": "configuration",
+            "status": "ok",
+            "message": "Settings loaded without validation errors.",
+        }
+    )
+    if settings.nvidia_api_key:
+        checks.append(
+            {"name": "nvidia_api_key", "status": "ok", "message": "NVIDIA_API_KEY is set."}
+        )
+    else:
+        checks.append(
+            {
+                "name": "nvidia_api_key",
+                "status": "action_required",
+                "message": "NVIDIA_API_KEY is not set.",
+            }
+        )
+        next_steps.append(
+            f"Run `{_doctor_cli_command('init')}` or set `NVIDIA_API_KEY` before ingest/search."
+        )
+
+    index_path = resolve_runtime_path(settings.index_db_path)
+    runtime_rules_path = resolve_runtime_path(settings.runtime_rules_artifact_path)
+    report["paths"] = {
+        "index_db_path": index_path.as_posix(),
+        "runtime_rules_artifact_path": runtime_rules_path.as_posix(),
+        "runtime_evidence_db_path": resolve_runtime_path(
+            settings.runtime_evidence_db_path
+        ).as_posix(),
+        "eval_workspace_dir": resolve_runtime_path(settings.eval_workspace_dir).as_posix(),
+    }
+
+    legacy_lancedb_alias_configured = _doctor_legacy_lancedb_alias_configured(discovery)
+    index_recovery_step_added = False
+    if index_path.is_dir():
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": (
+                    "Configured local SQLite index path points to a directory. "
+                    "Set POLICYNIM_INDEX_DB_PATH to a SQLite file path such as "
+                    "data/index.sqlite3."
+                ),
+            }
+        )
+        next_steps.append(
+            _doctor_index_directory_next_step(
+                legacy_lancedb_alias_configured=legacy_lancedb_alias_configured
+            )
+        )
+        index_recovery_step_added = True
+    elif index_path.exists():
+        if _doctor_local_index_ready(settings):
+            checks.append(
+                {
+                    "name": "local_index_path",
+                    "status": "ok",
+                    "message": "A populated local SQLite index exists.",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "local_index_path",
+                    "status": "action_required",
+                    "message": (
+                        "Configured local SQLite index file is not a populated "
+                        "PolicyNIM sqlite-vec index."
+                    ),
+                }
+            )
+            next_steps.append(_doctor_ingest_next_step())
+            index_recovery_step_added = True
+    else:
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": "No local index path exists yet.",
+            }
+        )
+        next_steps.append(_doctor_ingest_next_step())
+
+    if runtime_rules_path.exists():
+        checks.append(
+            {
+                "name": "runtime_rules_artifact",
+                "status": "ok",
+                "message": "Runtime rules artifact exists.",
+            }
+        )
+    else:
+        checks.append(
+            {
+                "name": "runtime_rules_artifact",
+                "status": "action_required",
+                "message": "Runtime rules artifact is missing.",
+            }
+        )
+        ingest_next_step = _doctor_ingest_next_step()
+        if not index_recovery_step_added and ingest_next_step not in next_steps:
+            next_steps.append(ingest_next_step)
+
+    report["mcp"] = {
+        "stdio_command": _doctor_mcp_command("mcp --transport stdio"),
+        "smoke_command": _doctor_mcp_command("mcp-smoke --format json"),
+        "local_stdio_config_commands": _doctor_mcp_config_commands(),
+        "streamable_http_url": f"http://{settings.mcp_host}:{settings.mcp_port}/mcp",
+        "auth_required": settings.mcp_require_auth,
+    }
+    if not next_steps:
+        search_command = _doctor_cli_command('search --query "refresh token cleanup" --top-k 5')
+        mcp_command = _doctor_cli_command("mcp --transport stdio")
+        next_steps.append(f"Run `{search_command}` or `{mcp_command}`.")
+
+    if any(check["status"] == "error" for check in checks):
+        report["status"] = "error"
+    elif any(check["status"] == "action_required" for check in checks):
+        report["status"] = "action_required"
+    report["checks"] = checks
+    report["next_steps"] = next_steps
+    return report
+
+
+def _doctor_runtime_mode() -> str:
+    """Return the current runtime mode for diagnostic output."""
+    if config_discovery.is_hosted_process_environment():
+        return "hosted"
+    if config_discovery.is_source_checkout():
+        return "source_checkout"
+    return "standalone"
+
+
+def _doctor_cli_command(command: str) -> str:
+    """Render a CLI command for the current diagnostic runtime."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return f"uv run policynim {command}"
+    return f"policynim {command}"
+
+
+def _doctor_ingest_next_step() -> str:
+    """Return the standard ingest recovery step for doctor output."""
+    return (
+        f"Run `{_doctor_cli_command('ingest')}` to build the local policy index "
+        "and runtime rules artifact."
+    )
+
+
+def _doctor_local_index_ready(settings: Settings) -> bool:
+    """Return whether the configured local SQLite index is ready for runtime use."""
+    try:
+        return create_index_store(settings).exists()
+    except Exception:
+        return False
+
+
+def _doctor_index_directory_next_step(*, legacy_lancedb_alias_configured: bool) -> str:
+    """Return recovery guidance for SQLite index paths that point at directories."""
+    if legacy_lancedb_alias_configured:
+        return (
+            "Replace deprecated `POLICYNIM_LANCEDB_URI` with "
+            f"`POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run "
+            f"`{_doctor_cli_command('ingest')}`."
+        )
+    return (
+        "Set `POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run "
+        f"`{_doctor_cli_command('ingest')}`."
+    )
+
+
+def _doctor_legacy_lancedb_alias_configured(
+    discovery: config_discovery.ConfigDiscovery,
+) -> bool:
+    """Return true when the deprecated LanceDB env alias is still configured."""
+    if "POLICYNIM_LANCEDB_URI" in os.environ:
+        return True
+    for env_file in discovery.env_files:
+        try:
+            for line in env_file.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped.startswith("POLICYNIM_LANCEDB_URI="):
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _doctor_mcp_command(command: str) -> str:
+    """Render an MCP-related command for doctor output."""
+    return _doctor_cli_command(command)
+
+
+def _doctor_mcp_config_commands() -> dict[str, str]:
+    """Return shell-safe local stdio MCP config commands by client."""
+    if _doctor_runtime_mode() != "source_checkout":
+        return {
+            "codex": _shell_join(
+                [
+                    "policynim",
+                    "mcp-config",
+                    "--target",
+                    "local-stdio",
+                    "--client",
+                    "codex",
+                    "--format",
+                    "json",
+                ]
+            ),
+            "claude-code": _shell_join(
+                [
+                    "policynim",
+                    "mcp-config",
+                    "--target",
+                    "local-stdio",
+                    "--client",
+                    "claude-code",
+                    "--format",
+                    "json",
+                ]
+            ),
+        }
+
+    repo_root = config_discovery.find_source_checkout_root()
+    return {
+        "codex": _doctor_local_stdio_mcp_config_command("codex", repo_root=repo_root),
+        "claude-code": _doctor_local_stdio_mcp_config_command(
+            "claude-code",
+            repo_root=repo_root,
+        ),
+    }
+
+
+def _doctor_local_stdio_mcp_config_command(
+    client: Literal["codex", "claude-code"],
+    *,
+    repo_root: Path | None,
+) -> str:
+    """Render a shell-safe local stdio MCP config command for doctor output."""
+    parts = [
+        "uv",
+        "run",
+        "policynim",
+        "mcp-config",
+        "--target",
+        "local-stdio",
+        "--client",
+        client,
+    ]
+    if repo_root is not None:
+        parts.extend(["--repo-root", str(repo_root)])
+    parts.extend(["--format", "json"])
+    return _shell_join(parts)
+
+
+def _render_doctor_report(report: dict[str, object]) -> list[str]:
+    """Render a doctor report as terminal-friendly text."""
+    lines = [
+        "PolicyNIM doctor",
+        f"Status: {report['status']}",
+        f"Runtime mode: {report['runtime_mode']}",
+    ]
+    config = report["config"]
+    if isinstance(config, dict):
+        lines.append(f"Config file: {config.get('active_config_file') or 'not found'}")
+    checks = report["checks"]
+    if isinstance(checks, list):
+        lines.append("")
+        lines.append("Checks:")
+        for check in checks:
+            if isinstance(check, dict):
+                lines.append(
+                    f"- {check.get('name')}: {check.get('status')} - {check.get('message')}"
+                )
+    mcp = report["mcp"]
+    if isinstance(mcp, dict) and mcp:
+        lines.append("")
+        lines.append("MCP:")
+        lines.append(f"- stdio: {mcp.get('stdio_command')}")
+        smoke_command = mcp.get("smoke_command")
+        if isinstance(smoke_command, str):
+            lines.append(f"- smoke: {smoke_command}")
+        config_commands = mcp.get("local_stdio_config_commands")
+        if isinstance(config_commands, dict):
+            for client, command in config_commands.items():
+                lines.append(f"- {client} config: {command}")
+        lines.append(f"- streamable-http: {mcp.get('streamable_http_url')}")
+    next_steps = report["next_steps"]
+    if isinstance(next_steps, list) and next_steps:
+        lines.append("")
+        lines.append("Next steps:")
+        for step in next_steps:
+            lines.append(f"- {step}")
+    return lines
+
+
+def _path_text(path: Path | None) -> str | None:
+    """Return a POSIX path string for optional paths."""
+    return None if path is None else path.as_posix()
 
 
 def _cli_error_message(error: PolicyNIMError) -> str:

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import platform
+import re
 import shlex
 import sys
 from collections.abc import Sequence
@@ -67,6 +68,7 @@ _STANDALONE_MISSING_INDEX_MESSAGE = (
     "Local PolicyNIM data is not built yet. Run `policynim ingest` to build the local policy index."
 )
 _EXPECTED_MCP_TOOLS = ("policy_preflight", "policy_search")
+_POSIX_PATH_TOKEN_RE = re.compile(r"(^|[\s\"'`=(:])(/(?!/)[^\s\"'`<>),;]+)")
 
 app = typer.Typer(
     add_completion=False,
@@ -1941,6 +1943,8 @@ def _normalize_hosted_mcp_url(value: str | None) -> str:
         raise PolicyNIMError(
             "Hosted MCP URL must start with http:// or https:// and include a host."
         )
+    if parsed.username is not None or parsed.password is not None or "@" in parsed.netloc:
+        raise PolicyNIMError("Hosted MCP URL must not include embedded credentials.")
     if parsed.path.rstrip("/") != "/mcp":
         raise PolicyNIMError("Hosted MCP URL must point to the /mcp endpoint.")
     return stripped
@@ -2325,13 +2329,15 @@ def _support_bundle_quickstart_summary(
 
 def _redact_support_bundle_paths(bundle: dict[str, object]) -> tuple[dict[str, object], list[str]]:
     """Redact local path prefixes from a support bundle."""
-    replacements = _support_bundle_path_replacements()
+    replacements = _support_bundle_path_replacements(bundle)
     redacted = _replace_local_path_prefixes(bundle, replacements)
     markers = sorted({marker for _, marker in replacements})
     return cast(dict[str, object], redacted), markers
 
 
-def _support_bundle_path_replacements() -> list[tuple[str, str]]:
+def _support_bundle_path_replacements(
+    bundle: dict[str, object] | None = None,
+) -> list[tuple[str, str]]:
     """Return local path prefixes and the markers that should replace them."""
     candidates: list[tuple[Path, str]] = [
         (Path(sys.executable), "<python-executable>"),
@@ -2359,7 +2365,91 @@ def _support_bundle_path_replacements() -> list[tuple[str, str]]:
         ):
             if candidate and candidate != "/":
                 replacements[candidate] = marker
+
+    if bundle is not None:
+        for path_text in _support_bundle_discovered_path_prefixes(bundle, replacements):
+            replacements.setdefault(path_text, "<local-path>")
     return sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True)
+
+
+def _support_bundle_discovered_path_prefixes(
+    bundle: dict[str, object],
+    known_replacements: dict[str, str],
+) -> list[str]:
+    """Find additional local path prefixes embedded in support-bundle values."""
+    prefixes: set[str] = set()
+    for path_text in _support_bundle_absolute_path_strings(bundle):
+        if _support_bundle_path_is_known(path_text, known_replacements):
+            continue
+        path_prefix = _support_bundle_redaction_prefix(path_text)
+        if path_prefix is None or _support_bundle_path_is_known(path_prefix, known_replacements):
+            continue
+        prefixes.add(path_prefix)
+    return sorted(prefixes, key=len, reverse=True)
+
+
+def _support_bundle_absolute_path_strings(value: object) -> list[str]:
+    """Extract path-like absolute strings from a support-bundle value."""
+    paths: set[str] = set()
+    if isinstance(value, str):
+        paths.update(_support_bundle_absolute_path_tokens(value))
+    elif isinstance(value, list):
+        for item in value:
+            paths.update(_support_bundle_absolute_path_strings(item))
+    elif isinstance(value, dict):
+        for item in value.values():
+            paths.update(_support_bundle_absolute_path_strings(item))
+    return sorted(paths, key=len, reverse=True)
+
+
+def _support_bundle_absolute_path_tokens(value: str) -> list[str]:
+    """Return absolute path tokens found inside a support-bundle string."""
+    tokens = [value]
+    try:
+        tokens.extend(shlex.split(value))
+    except ValueError:
+        tokens.extend(value.split())
+    tokens.extend(match.group(2) for match in _POSIX_PATH_TOKEN_RE.finditer(value))
+
+    paths: set[str] = set()
+    for token in tokens:
+        candidate = token.strip("`'\".,;:()[]{}")
+        if _support_bundle_token_is_absolute_path(candidate):
+            paths.add(candidate)
+    return sorted(paths, key=len, reverse=True)
+
+
+def _support_bundle_token_is_absolute_path(value: str) -> bool:
+    """Return whether a token looks like an absolute local filesystem path."""
+    if "/ABS/PATH/" in value:
+        return False
+    if value.startswith("/") and not value.startswith("//"):
+        return len(Path(value).parts) >= 3
+    return len(value) >= 3 and value[0].isalpha() and value[1] == ":" and value[2] in {"\\", "/"}
+
+
+def _support_bundle_redaction_prefix(path_text: str) -> str | None:
+    """Return the parent prefix to redact for an absolute path string."""
+    if path_text.startswith("/"):
+        path = Path(path_text).expanduser()
+        parent = path.parent
+        if parent == path or parent.as_posix() == "/":
+            return None
+        return parent.as_posix()
+    return None
+
+
+def _support_bundle_path_is_known(
+    path_text: str,
+    replacements: dict[str, str],
+) -> bool:
+    """Return whether a path already falls under an existing redaction prefix."""
+    normalized = path_text.rstrip("/")
+    for existing in replacements:
+        prefix = existing.rstrip("/")
+        if normalized == prefix or normalized.startswith(f"{prefix}/"):
+            return True
+    return False
 
 
 def _replace_local_path_prefixes(value: object, replacements: Sequence[tuple[str, str]]) -> object:
@@ -2477,6 +2567,7 @@ def _mcp_stdio_smoke_command_from_config_file(path: Path) -> tuple[list[str], Pa
 def _codex_stdio_command_from_config_payload(
     payload: dict[object, object],
 ) -> tuple[list[str], Path | None]:
+    """Return the launch command and working directory from a Codex MCP config."""
     codex_app = payload.get("codex_app")
     if not isinstance(codex_app, dict):
         raise PolicyNIMError("Codex MCP config file is missing codex_app.")
@@ -2494,6 +2585,7 @@ def _codex_stdio_command_from_config_payload(
 def _claude_stdio_command_from_config_payload(
     payload: dict[object, object],
 ) -> tuple[list[str], Path | None]:
+    """Return the launch command and working directory from a Claude Code MCP config."""
     config = payload.get("config")
     server_name = payload.get("server_name")
     if not isinstance(config, dict) or not isinstance(server_name, str):
@@ -2511,6 +2603,7 @@ def _claude_stdio_command_from_config_payload(
 
 
 def _mcp_stdio_launch_command(command: object, arguments: object) -> list[str]:
+    """Validate and return a local MCP stdio launch command."""
     if not isinstance(command, str) or not command:
         raise PolicyNIMError("MCP config file must include a non-empty stdio command.")
     if not isinstance(arguments, list) or any(
@@ -2521,6 +2614,7 @@ def _mcp_stdio_launch_command(command: object, arguments: object) -> list[str]:
 
 
 def _optional_path(value: object) -> Path | None:
+    """Convert a non-empty string value to a path when present."""
     if not isinstance(value, str) or not value:
         return None
     return Path(value)

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -24,6 +24,7 @@ from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from policynim.agent_workflows import agent_workflow_cards
 from policynim.errors import (
     ConfigurationError,
     InvalidPolicyDocumentError,
@@ -609,8 +610,10 @@ def _beta_command_card_context(
     description: str,
     command: str,
     button_label: str = "Copy command",
+    eyebrow: str = "Client setup",
 ) -> dict[str, str]:
     return {
+        "eyebrow": eyebrow,
         "title": title,
         "description": description,
         "command": command,
@@ -755,7 +758,7 @@ def _render_beta_dashboard(
         )
     new_key_context: dict[str, str] | None = None
     if new_api_key is not None:
-        export_command = f"export POLICYNIM_TOKEN={new_api_key}"
+        export_command = f"export POLICYNIM_TOKEN='{new_api_key}'"
         new_key_context = {
             "button_label": "Copy export",
             "export_command": export_command,
@@ -801,6 +804,16 @@ def _render_beta_dashboard(
                     ),
                     command=claude_command,
                 ),
+            ],
+            "workflow_cards": [
+                _beta_command_card_context(
+                    eyebrow="Agent workflow",
+                    title=workflow["title"],
+                    description=workflow["description"],
+                    command=workflow["prompt"],
+                    button_label="Copy prompt",
+                )
+                for workflow in agent_workflow_cards()
             ],
         }
     )
@@ -889,11 +902,13 @@ class _BearerProtectedASGIApp:
         protected_path: str,
         valid_tokens: list[str],
         beta_auth_service: BetaAuthService | None,
+        beta_portal_url: str | None,
     ) -> None:
         self._app = app
         self._protected_path = protected_path
         self._valid_tokens = set(valid_tokens)
         self._beta_auth_service = beta_auth_service
+        self._beta_portal_url = beta_portal_url
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Authorize protected MCP HTTP requests before delegating to the app."""
@@ -903,7 +918,7 @@ class _BearerProtectedASGIApp:
 
         token = _extract_bearer_token(scope)
         auth_result: str | None = None
-        response: JSONResponse | None = None
+        response: Response | None = None
         if token is not None and token in self._valid_tokens:
             auth_result = "authorized"
         elif self._beta_auth_service is not None:
@@ -918,14 +933,12 @@ class _BearerProtectedASGIApp:
                 response = JSONResponse({"error": "Quota exceeded."}, status_code=429)
             else:
                 auth_result = "unauthorized"
-                response = JSONResponse({"error": "Unauthorized."}, status_code=401)
         else:
             auth_result = "unauthorized"
-            response = JSONResponse({"error": "Unauthorized."}, status_code=401)
 
         if auth_result != "authorized":
             if response is None:
-                response = JSONResponse({"error": "Unauthorized."}, status_code=401)
+                response = self._unauthorized_response(scope)
             _emit_hosted_event(
                 "mcp.auth",
                 auth_result=auth_result or "unauthorized",
@@ -943,6 +956,12 @@ class _BearerProtectedASGIApp:
         finally:
             _HOSTED_AUTH_RESULT.reset(token_state)
 
+    def _unauthorized_response(self, scope: Scope) -> Response:
+        """Return onboarding for browser visits and JSON for MCP clients."""
+        if self._beta_portal_url is not None and _is_browser_mcp_visit(scope):
+            return RedirectResponse(self._beta_portal_url, status_code=303)
+        return JSONResponse({"error": "Unauthorized."}, status_code=401)
+
 
 def _extract_bearer_token(scope: Scope) -> str | None:
     """Return the bearer token from the HTTP Authorization header, if valid."""
@@ -958,6 +977,14 @@ def _extract_bearer_token(scope: Scope) -> str | None:
     if scheme.lower() != "bearer":
         return None
     return token.strip() or None
+
+
+def _is_browser_mcp_visit(scope: Scope) -> bool:
+    """Return true when a human likely opened /mcp in a browser."""
+    headers = Headers(scope=scope)
+    if headers.get("authorization") is not None:
+        return False
+    return "text/html" in headers.get("accept", "")
 
 
 def _build_streamable_http_app(settings: Settings) -> ASGIApp:
@@ -985,6 +1012,7 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
         protected_path=server.settings.streamable_http_path,
         valid_tokens=settings.mcp_bearer_tokens,
         beta_auth_service=beta_auth_service,
+        beta_portal_url=_derive_beta_url(settings) if settings.beta_signup_enabled else None,
     )
 
 

--- a/src/policynim/templates/beta/dashboard.html.j2
+++ b/src/policynim/templates/beta/dashboard.html.j2
@@ -126,5 +126,19 @@
       {% endfor %}
     </div>
   </section>
+
+  <section class="beta-section">
+    <div class="beta-section__header">
+      <p class="beta-kicker">Agent workflows</p>
+      <h2 class="beta-section-title">Use PolicyNIM where policy context changes the code</h2>
+    </div>
+    <div class="beta-card-grid beta-card-grid--commands">
+      {% for command_card in workflow_cards %}
+        {% with command=command_card %}
+          {% include "beta/partials/command_card.html.j2" %}
+        {% endwith %}
+      {% endfor %}
+    </div>
+  </section>
 </main>
 {% endblock %}

--- a/src/policynim/templates/beta/partials/command_card.html.j2
+++ b/src/policynim/templates/beta/partials/command_card.html.j2
@@ -1,7 +1,7 @@
 <section class="beta-card">
   <div class="beta-command-header">
     <div>
-      <p class="beta-eyebrow">Client setup</p>
+      <p class="beta-eyebrow">{{ command.eyebrow }}</p>
       <h2 class="beta-card-title">{{ command.title }}</h2>
     </div>
     <div class="beta-command-actions">

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Current automated coverage includes:
 
 - Markdown policy parsing, metadata normalization, and deterministic chunking
 - Additional chunking edge cases around blank sections and repeated nested headings
-- Ingest orchestration with local LanceDB rebuild behavior
+- Ingest orchestration with local SQLite index rebuild behavior
 - Search orchestration with domain filters and missing-index handling
 - Runtime decision orchestration with compiled runtime rules and evidence-linked citations
 - Runtime execution orchestration with confirmation handling, redaction, and durable evidence persistence

--- a/tests/test_beta_portal.py
+++ b/tests/test_beta_portal.py
@@ -152,6 +152,40 @@ def test_beta_portal_login_flow_sets_session_and_renders_dashboard(monkeypatch) 
     assert "claude mcp add --transport http policynim" in dashboard.text
 
 
+def test_beta_portal_dashboard_shows_agent_workflow_prompts(monkeypatch) -> None:
+    """Show hosted users what to ask their coding agent after setup."""
+    stub = StubBetaAuthService()
+    monkeypatch.setattr(mcp_module, "create_beta_auth_service", lambda settings: stub)
+
+    app = mcp_module._build_streamable_http_app(_signup_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        client.get("/auth/github/start", follow_redirects=False)
+        client.get(
+            f"/auth/github/callback?state={stub.oauth_states[0]}&code=oauth-code",
+            follow_redirects=False,
+        )
+        dashboard = client.get("/beta")
+
+    assert dashboard.status_code == 200
+    for token in (
+        "Agent workflows",
+        "Preflight before implementation",
+        "Retrieve policy evidence while debugging",
+        "Verify MCP tool availability",
+        "Before editing, call policy_preflight for: Implement a refresh-token cleanup",
+        "cited constraints",
+        "insufficient_context",
+        "Use policy_search for: release installer checksum verification.",
+        "cited policy lines",
+        (
+            "List the PolicyNIM MCP tools and confirm policy_preflight and "
+            "policy_search are available before starting implementation."
+        ),
+    ):
+        assert token in dashboard.text
+
+
 def test_beta_portal_rejects_invalid_oauth_state(monkeypatch) -> None:
     stub = StubBetaAuthService()
     monkeypatch.setattr(mcp_module, "create_beta_auth_service", lambda settings: stub)
@@ -222,7 +256,7 @@ def test_beta_portal_regenerate_route_shows_new_api_key_once(monkeypatch) -> Non
     assert response.status_code == 200
     assert "pnm_new_secret" in response.text
     assert "Copy export" in response.text
-    assert "export POLICYNIM_TOKEN=pnm_new_secret" in response.text
+    assert "export POLICYNIM_TOKEN=&#39;pnm_new_secret&#39;" in response.text
 
 
 def test_beta_portal_serves_packaged_logo_assets(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from collections.abc import Generator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -14,6 +16,7 @@ from click import unstyle
 from typer.testing import CliRunner
 
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
+from policynim.interfaces import cli as cli_module
 from policynim.interfaces.cli import app
 from policynim.services.runtime_evidence_report import RuntimeEvidenceReportService
 from policynim.services.runtime_execution import RuntimeExecutionService
@@ -27,6 +30,7 @@ from policynim.types import (
     CompiledPolicyPacket,
     CompileRequest,
     CompileResult,
+    EmbeddedChunk,
     EvalAggregateMetrics,
     EvalBackend,
     EvalCaseMetrics,
@@ -82,12 +86,39 @@ def write_env_file(path: Path, **values: str) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def write_ready_sqlite_index(path: Path) -> None:
+    """Write a minimal populated PolicyNIM sqlite-vec index for doctor tests."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    SQLiteVecIndexStore(path=path).replace(
+        [
+            EmbeddedChunk(
+                chunk_id="DOCTOR-READY-1",
+                path="policies/backend/doctor-ready.md",
+                section="Rules",
+                lines="1-3",
+                text="Backend services should keep request ids in logs.",
+                policy=PolicyMetadata(
+                    policy_id="BACKEND-DOCTOR-001",
+                    title="Doctor Ready",
+                    doc_type="guidance",
+                    domain="backend",
+                    tags=["setup"],
+                    grounded_in=["https://example.com/policy"],
+                ),
+                vector=[1.0, 0.0],
+            )
+        ]
+    )
+
+
 def clear_installer_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear env that would interfere with standalone installer-style tests."""
     for key in (
         "NVIDIA_API_KEY",
         "POLICYNIM_CONFIG_FILE",
         "POLICYNIM_CORPUS_DIR",
+        "POLICYNIM_INDEX_DB_PATH",
         "POLICYNIM_LANCEDB_URI",
         "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
         "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
@@ -173,7 +204,7 @@ class MockIngestService:
     def run(self) -> IngestResult:
         return IngestResult(
             corpus_path="policies",
-            index_uri="data/lancedb",
+            index_uri="data/index.sqlite3",
             table_name="policy_chunks",
             embedding_model="mock-model",
             document_count=8,
@@ -1512,6 +1543,11 @@ def test_help_includes_runtime_and_evidence_commands() -> None:
     assert result.exit_code == 0
     assert "--version" in help_output
     assert "init" in help_output
+    assert "quickstart" in help_output
+    assert "doctor" in help_output
+    assert "mcp-config" in help_output
+    assert "mcp-smoke" in help_output
+    assert "support-bundle" in help_output
     assert "runtime" in help_output
     assert "evidence" in help_output
     assert "route" in help_output
@@ -1558,6 +1594,475 @@ def test_init_help_documents_interactive_setup_flow() -> None:
     assert "interactive" in result.stdout.lower()
     assert "NVIDIA_API_KEY" in result.stdout
     assert "--non-interactive" not in result.stdout
+
+
+def test_doctor_reports_missing_standalone_setup_without_provider_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Diagnose first-run setup before settings or provider construction."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    assert payload["runtime_mode"] == "standalone"
+    assert payload["config"]["expected_init_config_file"] == str(config_root / "config.env")
+    assert payload["next_steps"] == [
+        f"Run `policynim init` to create {config_root / 'config.env'}."
+    ]
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_doctor_reports_ready_checkout_and_mcp_hints(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Report safe local setup state without exposing configured secrets."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_path = checkout_root / "data" / "index.sqlite3"
+    runtime_rules_path = checkout_root / "data" / "runtime" / "runtime_rules.json"
+    write_ready_sqlite_index(index_path)
+    runtime_rules_path.parent.mkdir(parents=True)
+    runtime_rules_path.write_text("{}", encoding="utf-8")
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index.sqlite3",
+        POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH="data/runtime/runtime_rules.json",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["runtime_mode"] == "source_checkout"
+    assert payload["config"]["active_config_file"] == str(checkout_root / ".env")
+    assert payload["paths"]["index_db_path"] == str(index_path)
+    assert payload["mcp"]["stdio_command"] == "uv run policynim mcp --transport stdio"
+    assert payload["mcp"]["smoke_command"] == "uv run policynim mcp-smoke --format json"
+    assert payload["mcp"]["local_stdio_config_commands"] == {
+        "codex": "uv run policynim mcp-config --target local-stdio --client codex "
+        f"--repo-root {checkout_root} --format json",
+        "claude-code": (
+            "uv run policynim mcp-config --target local-stdio --client claude-code "
+            f"--repo-root {checkout_root} --format json"
+        ),
+    }
+    assert payload["mcp"]["streamable_http_url"] == "http://127.0.0.1:8000/mcp"
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_doctor_source_checkout_recovery_uses_uv_run_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Give source-checkout users recovery commands that run in the uv project."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    assert (
+        "Run `uv run policynim ingest` to build the local policy index and runtime rules artifact."
+    ) in payload["next_steps"]
+    assert (
+        "Run `policynim ingest` to build the local policy index and runtime rules artifact."
+        not in payload["next_steps"]
+    )
+
+
+def test_doctor_flags_invalid_sqlite_index_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Do not report ready when the configured SQLite file is not a PolicyNIM index."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_path = checkout_root / "data" / "index.sqlite3"
+    runtime_rules_path = checkout_root / "data" / "runtime" / "runtime_rules.json"
+    index_path.parent.mkdir(parents=True)
+    index_path.write_text("placeholder", encoding="utf-8")
+    runtime_rules_path.parent.mkdir(parents=True)
+    runtime_rules_path.write_text("{}", encoding="utf-8")
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index.sqlite3",
+        POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH="data/runtime/runtime_rules.json",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check == {
+        "name": "local_index_path",
+        "status": "action_required",
+        "message": (
+            "Configured local SQLite index file is not a populated PolicyNIM sqlite-vec index."
+        ),
+    }
+    assert payload["next_steps"] == [
+        (
+            "Run `uv run policynim ingest` to build the local policy index "
+            "and runtime rules artifact."
+        )
+    ]
+
+
+def test_doctor_flags_legacy_lancedb_directory_index_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide sqlite-vec upgrades away from old LanceDB directory paths."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    legacy_index_dir = checkout_root / "data" / "lancedb"
+    legacy_index_dir.mkdir(parents=True)
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_LANCEDB_URI="data/lancedb",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check == {
+        "name": "local_index_path",
+        "status": "action_required",
+        "message": (
+            "Configured local SQLite index path points to a directory. "
+            "Set POLICYNIM_INDEX_DB_PATH to a SQLite file path such as data/index.sqlite3."
+        ),
+    }
+    assert (
+        "Replace deprecated `POLICYNIM_LANCEDB_URI` with "
+        "`POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run `uv run policynim ingest`."
+    ) in payload["next_steps"]
+    assert (
+        "Run `uv run policynim ingest` to build the local policy index and runtime rules artifact."
+        not in payload["next_steps"]
+    )
+
+
+def test_doctor_flags_canonical_directory_index_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Tell users that sqlite-vec needs a file path, not a directory."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_dir = checkout_root / "data" / "index-dir"
+    index_dir.mkdir(parents=True)
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index-dir",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check["status"] == "action_required"
+    assert "points to a directory" in local_index_check["message"]
+    assert (
+        "Set `POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run `uv run policynim ingest`."
+    ) in payload["next_steps"]
+    assert "POLICYNIM_LANCEDB_URI" not in " ".join(payload["next_steps"])
+
+
+def test_doctor_reports_installed_mcp_config_commands_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep installed no-clone MCP setup discoverable from doctor output."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["runtime_mode"] == "standalone"
+    assert payload["mcp"]["smoke_command"] == "policynim mcp-smoke --format json"
+    assert payload["mcp"]["local_stdio_config_commands"] == {
+        "codex": "policynim mcp-config --target local-stdio --client codex --format json",
+        "claude-code": (
+            "policynim mcp-config --target local-stdio --client claude-code --format json"
+        ),
+    }
+    assert "--repo-root" not in json.dumps(payload["mcp"])
+    assert "uv run" not in json.dumps(payload["mcp"])
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_doctor_text_output_is_human_readable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the default diagnostic useful in a terminal."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "PolicyNIM doctor" in result.stdout
+    assert "Status: action_required" in result.stdout
+    assert "Next steps:" in result.stdout
+    assert "policynim init" in result.stdout
+
+
+def test_doctor_text_output_prints_mcp_config_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make local MCP client setup discoverable from the default diagnostic."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "MCP:" in result.stdout
+    assert "policynim mcp-smoke --format json" in result.stdout
+    assert (
+        "uv run policynim mcp-config --target local-stdio --client codex "
+        f"--repo-root {checkout_root} --format json"
+    ) in result.stdout
+    assert (
+        "uv run policynim mcp-config --target local-stdio --client claude-code "
+        f"--repo-root {checkout_root} --format json"
+    ) in result.stdout
+
+
+def test_doctor_mcp_config_commands_quote_checkout_paths_with_spaces(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep doctor's copyable MCP setup commands valid for spaced checkout paths."""
+    clear_installer_env(monkeypatch)
+    checkout_root = tmp_path / "checkout with spaces"
+    package_root = checkout_root / "src" / "policynim"
+    package_root.mkdir(parents=True)
+    (checkout_root / "pyproject.toml").write_text(
+        "[project]\nname = 'policynim'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(checkout_root)
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_config_path",
+        lambda *args, **kwargs: tmp_path / "user-config",
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_data_path",
+        lambda *args, **kwargs: tmp_path / "user-data",
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    commands = payload["mcp"]["local_stdio_config_commands"]
+    assert f"--repo-root '{checkout_root}' --format json" in commands["codex"]
+    assert f"--repo-root '{checkout_root}' --format json" in commands["claude-code"]
+
+
+def test_support_bundle_reports_redacted_first_run_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Collect issue-ready diagnostics without requiring completed setup."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["policynim_version"] == "1.2.3"
+    assert payload["python"]["version"]
+    assert payload["platform"]["system"]
+    assert payload["first_run"]["runtime_mode"] == "standalone"
+    assert payload["first_run"]["default_target"] == "hosted-mcp"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["target"] == "hosted-mcp"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["requires_local_setup"] is False
+    assert payload["first_run"]["targets"]["hosted_mcp"]["hosted_url"] == (
+        "https://<railway-domain>/mcp"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["beta_portal_url"] == (
+        "https://<railway-domain>/beta"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["hosted_url_placeholder"] is True
+    assert payload["first_run"]["targets"]["local_cli"]["requires_local_setup"] is True
+    assert payload["first_run"]["targets"]["local_mcp"]["local_launch_mode"] == "installed-cli"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["quickstart_command"] == (
+        "policynim quickstart --target hosted-mcp --format json"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["agent_workflows"][0]["tool"] == (
+        "policy_preflight"
+    )
+    assert (
+        "policy_search"
+        in (payload["first_run"]["targets"]["local_mcp"]["agent_workflows"][1]["prompt"])
+    )
+    assert (
+        "policynim mcp-config --target hosted-http"
+        in (payload["first_run"]["targets"]["hosted_mcp"]["commands"][1])
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["client_commands"] == [
+        (
+            "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        ),
+        (
+            "claude mcp add --transport http policynim 'https://<railway-domain>/mcp' "
+            '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+        ),
+    ]
+    assert payload["doctor"]["status"] == "action_required"
+    assert payload["python"]["executable"] == "<python-executable>"
+    assert payload["doctor"]["config"]["expected_init_config_file"] == ("<config-dir>/config.env")
+    assert payload["redaction"]["local_paths"] == "redacted"
+    assert payload["redaction"]["path_markers"] == [
+        "<config-dir>",
+        "<data-dir>",
+        "<home>",
+        "<python-executable>",
+    ]
+    assert payload["mcp_smoke"] == {
+        "status": "skipped",
+        "reason": "Pass --include-mcp-smoke to verify stdio tool registration.",
+    }
+    assert str(tmp_path) not in result.stdout
+    assert "<repo-root>" not in result.stdout
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_support_bundle_does_not_label_installed_cwd_as_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Avoid treating an arbitrary installed-runtime CWD as a source checkout."""
+    workspace, _, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["first_run"]["runtime_mode"] == "standalone"
+    assert "<repo-root>" not in payload["redaction"]["path_markers"]
+    assert str(workspace) not in result.stdout
+    assert "workspace" not in result.stdout
+
+
+def test_support_bundle_can_include_local_paths_for_private_triage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let maintainers opt into exact paths when support happens privately."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle", "--include-local-paths"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["python"]["executable"] == sys.executable
+    assert payload["doctor"]["config"]["expected_init_config_file"] == str(
+        config_root / "config.env"
+    )
+    assert payload["redaction"]["local_paths"] == "included"
+    assert str(config_root) in result.stdout
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_support_bundle_can_include_mcp_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let issue reporters include local MCP launch evidence on demand."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for support-bundle output."""
+        assert timeout_seconds == 7.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(
+        app,
+        ["support-bundle", "--include-mcp-smoke", "--mcp-timeout-seconds", "7"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["doctor"]["runtime_mode"] == "source_checkout"
+    assert payload["first_run"]["runtime_mode"] == "source_checkout"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["quickstart_command"] == (
+        "policynim quickstart --target hosted-mcp --format json"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["commands"][1].startswith(
+        "policynim mcp-config --target hosted-http"
+    )
+    assert "uv run" not in payload["first_run"]["targets"]["hosted_mcp"]["commands"][1]
+    assert payload["first_run"]["targets"]["local_mcp"]["local_launch_mode"] == ("source-checkout")
+    assert "<repo-root>" in " ".join(payload["first_run"]["targets"]["local_mcp"]["commands"])
+    assert payload["mcp_smoke"]["status"] == "ok"
+    assert payload["mcp_smoke"]["command"][0] == "<python-executable>"
+    assert payload["mcp_smoke"]["tools"] == ["policy_preflight", "policy_search"]
+    assert str(checkout_root) not in result.stdout
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_support_bundle_markdown_wraps_json_for_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Provide a paste-friendly Markdown form for issue bodies."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle", "--format", "markdown"])
+
+    assert result.exit_code == 0
+    assert "## PolicyNIM Support Bundle" in result.stdout
+    assert "```json" in result.stdout
+    assert '"schema_version": "1"' in result.stdout
 
 
 def test_init_command_writes_config_and_prints_next_step(
@@ -1639,6 +2144,387 @@ def test_init_command_surfaces_unwritable_config_destination(
     assert "permission denied" in result.stderr
     assert not target_config.exists()
     assert list(target_config.parent.glob("*.tmp")) == []
+
+
+def test_quickstart_defaults_to_hosted_mcp_without_requiring_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Show the shortest no-clone path before local config exists."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["target"] == "hosted-mcp"
+    assert payload["client"] == "codex"
+    assert payload["requires_local_setup"] is False
+    assert payload["calls_external_services"] is False
+    assert payload["hosted_url"] == "https://<railway-domain>/mcp"
+    assert payload["hosted_url_placeholder"] is True
+    assert payload["steps"][0] == (
+        "Open https://<railway-domain>/mcp in a browser; it routes to "
+        "https://<railway-domain>/beta for token creation."
+    )
+    assert "POLICYNIM_TOKEN" in " ".join(payload["commands"])
+    assert "export POLICYNIM_TOKEN='<generated-beta-token>'" in payload["commands"]
+    assert "export POLICYNIM_TOKEN=<generated-beta-token>" not in payload["commands"]
+    assert payload["client_commands"] == [
+        (
+            "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        )
+    ]
+    assert "<generated-beta-token>" not in " ".join(payload["client_commands"])
+    assert "Replace the hosted URL placeholder" in " ".join(payload["next_steps"])
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+    agent_workflows = payload["agent_workflows"]
+    assert [workflow["title"] for workflow in agent_workflows] == [
+        "Preflight before implementation",
+        "Retrieve policy evidence while debugging",
+        "Verify MCP tool availability",
+    ]
+    assert agent_workflows[0]["tool"] == "policy_preflight"
+    assert "Before editing, call policy_preflight" in agent_workflows[0]["prompt"]
+    assert "cited constraints" in agent_workflows[0]["prompt"]
+    assert "insufficient_context" in agent_workflows[0]["prompt"]
+    assert agent_workflows[1]["tool"] == "policy_search"
+    assert (
+        "Use policy_search for: release installer checksum verification."
+        in (agent_workflows[1]["prompt"])
+    )
+    assert "cited policy lines" in agent_workflows[1]["prompt"]
+    assert "policy_preflight and policy_search" in agent_workflows[2]["prompt"]
+    assert "before starting implementation" in agent_workflows[2]["prompt"]
+
+
+def test_quickstart_text_renders_agent_workflows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make the human-readable first-run output show copyable agent prompts."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert "Agent workflows:" in output
+    assert "- Preflight before implementation: Before editing, call policy_preflight" in output
+    assert "- Retrieve policy evidence while debugging: Use policy_search for:" in output
+    assert "insufficient_context" in output
+    assert "cited policy lines" in output
+    assert "- Verify MCP tool availability: List the PolicyNIM MCP tools" in output
+
+
+def test_quickstart_text_renders_hosted_client_setup_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make hosted first-run output copy-pasteable without opening extra docs."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert "Client setup:" in output
+    assert (
+        "Open https://<railway-domain>/mcp in a browser; it routes to "
+        "https://<railway-domain>/beta for token creation."
+    ) in output
+    assert (
+        "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+        "--bearer-token-env-var POLICYNIM_TOKEN"
+    ) in output
+    assert "<generated-beta-token>" not in output.split("Client setup:", maxsplit=1)[1]
+
+
+def test_quickstart_text_points_to_alternate_hosted_mcp_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make default quickstart self-guiding for non-default MCP clients."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert (
+        "For Claude Code setup commands, rerun "
+        "`policynim quickstart --target hosted-mcp --client claude-code`."
+    ) in output
+
+
+def test_quickstart_uses_installed_entrypoint_for_hosted_config_from_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the hosted path no-clone even when quickstart runs from a checkout."""
+    configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "hosted-mcp", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert "policynim mcp-config --target hosted-http --client codex" in payload["commands"][1]
+    assert payload["commands"][1].startswith("policynim mcp-config")
+    assert "uv run" not in payload["commands"][1]
+    assert "uv run" not in " ".join(payload["next_steps"])
+    assert "policynim quickstart --target hosted-mcp --client claude-code" in " ".join(
+        payload["next_steps"]
+    )
+    assert payload["requires_local_setup"] is False
+
+
+def test_quickstart_derives_beta_portal_from_hosted_mcp_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep hosted first-run guidance concrete when operators pass a real /mcp URL."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "hosted-mcp",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["hosted_url_placeholder"] is False
+    assert payload["hosted_url"] == "https://policy.policynim.dev/mcp"
+    assert payload["beta_portal_url"] == "https://policy.policynim.dev/beta"
+    assert payload["steps"][0] == (
+        "Open https://policy.policynim.dev/mcp in a browser; it routes to "
+        "https://policy.policynim.dev/beta for token creation."
+    )
+    assert payload["client_commands"] == [
+        (
+            "codex mcp add policynim --url https://policy.policynim.dev/mcp "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        )
+    ]
+    assert "https://<railway-domain>/beta" not in payload["steps"]
+    assert "Replace the hosted URL placeholder" not in " ".join(payload["next_steps"])
+
+
+def test_quickstart_prints_claude_hosted_client_setup_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Honor --client when printing the hosted MCP command to paste."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "hosted-mcp",
+            "--client",
+            "claude-code",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["client"] == "claude-code"
+    assert payload["client_commands"] == [
+        (
+            "claude mcp add --transport http policynim https://policy.policynim.dev/mcp "
+            '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+        )
+    ]
+    assert "<generated-beta-token>" not in payload["client_commands"][0]
+
+
+def test_quickstart_text_points_claude_users_back_to_codex_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the alternate-client hint symmetric when Claude Code is selected."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--client", "claude-code"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert (
+        "For Codex setup commands, rerun `policynim quickstart --target hosted-mcp --client codex`."
+    ) in output
+
+
+def test_quickstart_rejects_hosted_url_that_is_not_mcp_endpoint() -> None:
+    """Do not print hosted first-run commands that cannot work in MCP clients."""
+    result = runner.invoke(
+        app,
+        ["quickstart", "--target", "hosted-mcp", "--hosted-url", "https://policy.example"],
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted MCP URL must point to the /mcp endpoint." in result.stderr
+
+
+def test_quickstart_prints_current_pypi_local_cli_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep installed CLI first-run guidance aligned with public package state."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "local-cli", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    prerequisites = " ".join(payload["prerequisites"])
+    assert payload["target"] == "local-cli"
+    assert "Python 3.11 or 3.12 for PyPI package installs." in payload["prerequisites"]
+    assert "after publication" not in prerequisites
+    assert "trusted-publishing evidence is tracked separately" in prerequisites
+    assert "policynim quickstart" in " ".join(payload["next_steps"])
+    assert "policynim support-bundle" in " ".join(payload["next_steps"])
+    assert "attaching public setup evidence" in " ".join(payload["next_steps"])
+    assert "doctor --format json` local" in " ".join(payload["next_steps"])
+
+
+def test_quickstart_uses_source_checkout_entrypoint_for_local_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep local CLI first-run commands runnable from a source checkout."""
+    configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "local-cli", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["description"] == "Local CLI path for running preflight from a source checkout."
+    assert "PolicyNIM source checkout with uv dependencies synced." in payload["prerequisites"]
+    assert "PyPI package installs" not in " ".join(payload["prerequisites"])
+    assert "Check the source-checkout entrypoint." in payload["steps"]
+    assert "installed entrypoint" not in " ".join(payload["steps"])
+    commands = payload["commands"]
+    assert commands[:4] == [
+        "uv run policynim --help",
+        "uv run policynim doctor",
+        "uv run policynim init",
+        "uv run policynim ingest",
+    ]
+    assert commands[4].startswith("uv run policynim preflight --task")
+    assert "Run `uv run policynim quickstart --target hosted-mcp`" in (
+        " ".join(payload["next_steps"])
+    )
+    assert "uv run policynim support-bundle" in " ".join(payload["next_steps"])
+
+
+def test_quickstart_prints_local_mcp_path_with_source_checkout_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide local MCP users through doctor, ingest, smoke, and config generation."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "local-mcp",
+            "--client",
+            "claude-code",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "local-mcp"
+    assert payload["client"] == "claude-code"
+    assert payload["local_launch_mode"] == "source-checkout"
+    assert payload["description"] == (
+        "Local MCP path for Codex or Claude Code from a source checkout."
+    )
+    assert "PolicyNIM source checkout with uv dependencies synced." in payload["prerequisites"]
+    assert "installed PolicyNIM CLI" not in " ".join(payload["prerequisites"])
+    assert payload["requires_local_setup"] is True
+    assert "Generate client config from the checkout path." in payload["steps"]
+    assert "uv run policynim doctor" in payload["commands"]
+    assert "uv run policynim init" in payload["commands"]
+    assert "uv run policynim ingest" in payload["commands"]
+    assert "uv run policynim mcp-smoke" in payload["commands"]
+    assert "uv run policynim mcp-config --target local-stdio --client claude-code" in " ".join(
+        payload["commands"]
+    )
+    assert "policynim mcp-smoke" not in payload["commands"]
+    assert f"--repo-root {checkout_root}" in " ".join(payload["commands"])
+    assert "NVIDIA_API_KEY" in " ".join(payload["prerequisites"])
+    assert "exact local filesystem paths" in " ".join(payload["safety"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+
+
+def test_quickstart_prints_installed_local_mcp_path_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide installed users to local stdio MCP without requiring a source checkout."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "local-mcp",
+            "--client",
+            "codex",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "local-mcp"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "installed PolicyNIM CLI" in " ".join(payload["prerequisites"])
+    assert "Generate client config from the installed entrypoint." in payload["steps"]
+    assert "checkout path" not in " ".join(payload["steps"])
+    assert "policynim mcp-config --target local-stdio --client codex" in payload["commands"]
+    assert "--repo-root" not in " ".join(payload["commands"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+
+
+def test_quickstart_help_mentions_targets_clients_and_json_output() -> None:
+    """Keep help discoverable for installed users starting from --help."""
+    result = runner.invoke(app, ["quickstart", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "Print the first-run path" in help_output
+    assert "--target" in help_output
+    assert "hosted-mcp" in help_output
+    assert "local-cli" in help_output
+    assert "local-mcp" in help_output
+    assert "--client" in help_output
+    assert "--format" in help_output
 
 
 def test_route_help_mentions_task_type_override() -> None:
@@ -1776,7 +2662,7 @@ def test_search_command_points_to_ingest_when_config_exists_but_index_is_missing
             ),
         ),
         (["evidence", "report", "--session-id", "session-123"], None),
-        (["mcp"], None),
+        (["mcp", "--transport", "streamable-http"], None),
     ],
 )
 def test_setup_dependent_commands_point_to_init_when_redirected_config_is_missing(
@@ -1799,6 +2685,26 @@ def test_setup_dependent_commands_point_to_init_when_redirected_config_is_missin
     assert "PolicyNIM is not set up yet." in result.stderr
     assert "policynim init" in result.stderr
     assert str(redirected_config) in result.stderr
+
+
+def test_mcp_stdio_launch_does_not_require_completed_standalone_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let stdio MCP launch for client discovery before API-key setup."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    launched: list[str] = []
+
+    def fake_run_server(*, transport: str) -> None:
+        """Record the selected MCP transport without starting a server."""
+        launched.append(transport)
+
+    monkeypatch.setattr("policynim.interfaces.cli.run_server", fake_run_server)
+
+    result = runner.invoke(app, ["mcp"])
+
+    assert result.exit_code == 0
+    assert launched == ["stdio"]
 
 
 def test_preflight_command_surfaces_missing_index_errors(monkeypatch) -> None:
@@ -1892,12 +2798,13 @@ def test_mcp_command_surfaces_hosted_rebuild_key_errors(monkeypatch) -> None:
         "policynim.interfaces.cli.run_server",
         lambda transport: (_ for _ in ()).throw(
             ConfigurationError(
-                "Hosted streamable-http startup requires a populated local index at "
-                "/app/data/lancedb-baked (table: policy_chunks). "
+                "Hosted streamable-http startup requires a populated local SQLite index at "
+                "/app/data/index.sqlite3 (table: policy_chunks). "
                 "Automatic hosted-index rebuild failed: ConfigurationError: "
                 "NVIDIA_API_KEY is required for embeddings. "
-                "Rebuild the image so `policynim ingest` runs during Docker build "
-                "or set `POLICYNIM_LANCEDB_URI` to a populated directory."
+                "Run `policynim ingest` before serving traffic, or bake that command "
+                "during Docker build. Configure the path with `POLICYNIM_INDEX_DB_PATH`; "
+                "`POLICYNIM_LANCEDB_URI` is only a deprecated alias for that path."
             )
         ),
     )
@@ -1906,7 +2813,643 @@ def test_mcp_command_surfaces_hosted_rebuild_key_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "NVIDIA_API_KEY is required for embeddings." in result.stderr
-    assert "Rebuild the image so `policynim ingest` runs during Docker build" in result.stderr
+    assert "Configure the path with `POLICYNIM_INDEX_DB_PATH`" in result.stderr
+
+
+def test_mcp_config_prints_claude_code_json_without_secret_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate a project-scoped Claude Code config from a verified checkout path."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-secret-value")
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "claude-code",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    server = payload["config"]["mcpServers"]["policynim"]
+    assert payload["client"] == "claude-code"
+    assert payload["repo_root"] == str(checkout_root)
+    assert server == {
+        "type": "stdio",
+        "command": "uv",
+        "args": [
+            "run",
+            "--directory",
+            str(checkout_root),
+            "policynim",
+            "mcp",
+            "--transport",
+            "stdio",
+        ],
+        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+    }
+    assert "uv run policynim doctor" in payload["next_steps"]
+    assert "uv run policynim mcp-smoke" in payload["next_steps"]
+    assert "exact local filesystem paths" in " ".join(payload["safety"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+    assert "nvapi-secret-value" not in result.stdout
+
+
+def test_mcp_config_prints_codex_installed_stdio_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate no-clone local MCP config from an installed CLI entrypoint."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--client",
+            "codex",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["client"] == "codex"
+    assert payload["target"] == "local-stdio"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "repo_root" not in payload
+    assert payload["codex_cli_command"] == [
+        "codex",
+        "mcp",
+        "add",
+        "policynim",
+        "--env",
+        "NVIDIA_API_KEY=$NVIDIA_API_KEY",
+        "--",
+        "policynim",
+        "mcp",
+        "--transport",
+        "stdio",
+    ]
+    assert payload["codex_app"] == {
+        "name": "policynim",
+        "transport": "STDIO",
+        "command": "policynim",
+        "arguments": ["mcp", "--transport", "stdio"],
+        "environment_variable_passthrough": ["NVIDIA_API_KEY"],
+    }
+
+
+def test_mcp_config_prints_claude_installed_stdio_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate Claude Code local MCP config from an installed CLI entrypoint."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--client",
+            "claude-code",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    server = payload["config"]["mcpServers"]["policynim"]
+    assert payload["client"] == "claude-code"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "repo_root" not in payload
+    assert server == {
+        "type": "stdio",
+        "command": "policynim",
+        "args": ["mcp", "--transport", "stdio"],
+        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+    }
+
+
+def test_mcp_config_prints_codex_cli_and_app_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate Codex CLI and app setup guidance from the same stdio contract."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(checkout_root),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PolicyNIM MCP config for Codex" in result.stdout
+    assert "codex mcp add policynim" in result.stdout
+    assert "--env NVIDIA_API_KEY=$NVIDIA_API_KEY --" in result.stdout
+    assert f"uv run --directory {checkout_root} policynim mcp --transport stdio" in result.stdout
+    assert "Command to launch: uv" in result.stdout
+    assert f"Working directory: {checkout_root}" in result.stdout
+    assert "Environment variable passthrough: NVIDIA_API_KEY" in result.stdout
+    assert "Safety:" in result.stdout
+    assert "exact local filesystem paths" in result.stdout
+    assert "policynim support-bundle" in result.stdout
+
+
+def test_mcp_config_prints_codex_hosted_http_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate hosted Codex setup without requiring a local source checkout."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "codex",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--bearer-token-env-var",
+            "POLICYNIM_TOKEN",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "hosted-http"
+    assert payload["client"] == "codex"
+    assert payload["hosted_url"] == "https://policy.policynim.dev/mcp"
+    assert payload["beta_portal_url"] == "https://policy.policynim.dev/beta"
+    assert payload["hosted_url_placeholder"] is False
+    assert payload["bearer_token_env_var"] == "POLICYNIM_TOKEN"
+    assert "repo_root" not in payload
+    assert payload["codex_cli_command"] == [
+        "codex",
+        "mcp",
+        "add",
+        "policynim",
+        "--url",
+        "https://policy.policynim.dev/mcp",
+        "--bearer-token-env-var",
+        "POLICYNIM_TOKEN",
+    ]
+    assert payload["codex_cli_shell_command"] == (
+        "codex mcp add policynim --url https://policy.policynim.dev/mcp "
+        "--bearer-token-env-var POLICYNIM_TOKEN"
+    )
+    assert "Export POLICYNIM_TOKEN='<generated-beta-token>'" in payload["next_steps"]
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+
+
+def test_mcp_config_marks_placeholder_hosted_url_without_failing() -> None:
+    """Keep offline placeholder smokes possible while warning users before setup."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "codex",
+            "--hosted-url",
+            "https://<railway-domain>/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["hosted_url"] == "https://<railway-domain>/mcp"
+    assert payload["beta_portal_url"] == "https://<railway-domain>/beta"
+    assert payload["hosted_url_placeholder"] is True
+    assert "Replace the hosted URL placeholder" in " ".join(payload["next_steps"])
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+
+
+def test_mcp_config_prints_claude_hosted_http_guidance() -> None:
+    """Generate hosted Claude Code setup from the same MCP URL contract."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "claude-code",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PolicyNIM hosted MCP config for Claude Code" in result.stdout
+    assert (
+        "claude mcp add --transport http policynim https://policy.policynim.dev/mcp "
+        '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+    ) in result.stdout
+    assert "Export POLICYNIM_TOKEN='<generated-beta-token>'" in result.stdout
+    assert "policy_search" in result.stdout
+
+
+def test_mcp_config_rejects_hosted_http_without_url() -> None:
+    """Hosted config should fail before printing unusable client commands."""
+    result = runner.invoke(app, ["mcp-config", "--target", "hosted-http"])
+
+    assert result.exit_code == 1
+    assert "Hosted MCP config requires --hosted-url" in result.stderr
+
+
+def test_mcp_config_rejects_non_http_hosted_url() -> None:
+    """Reject hosted config URLs that MCP clients cannot use as HTTP endpoints."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--hosted-url",
+            "file:///tmp/mcp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted MCP URL must start with http:// or https://" in result.stderr
+
+
+def test_mcp_config_rejects_hosted_http_with_local_only_options(tmp_path: Path) -> None:
+    """Avoid silently ignoring local stdio flags for hosted config."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--hosted-url",
+            "https://policy.example/mcp",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--repo-root is only valid with --target local-stdio" in result.stderr
+
+
+def test_mcp_config_rejects_local_stdio_with_hosted_only_options() -> None:
+    """Avoid silently ignoring hosted HTTP flags for local stdio config."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--hosted-url",
+            "https://policy.example/mcp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--hosted-url is only valid with --target hosted-http" in result.stderr
+
+
+def test_mcp_config_rejects_uv_command_without_source_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Avoid silently ignoring source-checkout launch flags in installed mode."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["mcp-config", "--uv-command", "/opt/uv"])
+
+    assert result.exit_code == 1
+    assert "--uv-command requires a PolicyNIM source checkout" in result.stderr
+    assert "Pass --repo-root /ABS/PATH/TO/policyNIM" in result.stderr
+
+
+def test_mcp_config_help_mentions_hosted_http_options() -> None:
+    """Keep CLI help aligned with hosted-first docs."""
+    result = runner.invoke(app, ["mcp-config", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "hosted HTTP or local stdio MCP client config" in help_output
+    assert "--target" in help_output
+    assert "local-stdio" in help_output
+    assert "hosted-http" in help_output
+    assert "--hosted-url" in help_output
+    assert "--bearer-token-env-var" in help_output
+
+
+def test_mcp_config_rejects_non_checkout_repo_root(tmp_path: Path) -> None:
+    """Avoid emitting client config that points at an arbitrary directory."""
+    not_checkout = tmp_path / "not-policyNIM"
+    not_checkout.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(not_checkout),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--repo-root must point to a PolicyNIM source checkout" in result.stderr
+    assert "Omit --repo-root to launch the installed CLI" in result.stderr
+
+
+def test_mcp_smoke_prints_stdio_tool_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Print machine-readable MCP tool discovery evidence."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for CLI rendering."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["tools"] == ["policy_preflight", "policy_search"]
+
+
+def test_mcp_smoke_can_launch_from_generated_codex_config_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Handshake with the same local stdio command emitted by mcp-config."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    config_result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+    config_file = tmp_path / "codex-mcp-config.json"
+    config_file.write_text(config_result.stdout, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    async def fake_smoke(
+        *,
+        timeout_seconds: float,
+        command: list[str] | None = None,
+        cwd: Path | None = None,
+    ) -> dict[str, object]:
+        """Capture the config-derived stdio launch command."""
+        captured["timeout_seconds"] = timeout_seconds
+        captured["command"] = command
+        captured["cwd"] = cwd
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": command,
+            "config_source": str(config_file),
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(
+        app,
+        ["mcp-smoke", "--mcp-config-file", str(config_file), "--format", "json"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["timeout_seconds"] == 5.0
+    assert captured["command"] == [
+        "uv",
+        "run",
+        "--directory",
+        str(checkout_root),
+        "policynim",
+        "mcp",
+        "--transport",
+        "stdio",
+    ]
+    assert captured["cwd"] == checkout_root
+    payload = json.loads(result.stdout)
+    assert payload["config_source"] == str(config_file)
+
+
+def test_mcp_smoke_rejects_hosted_mcp_config_file(tmp_path: Path) -> None:
+    """Do not imply that local stdio smoke proves a hosted HTTP config."""
+    config_file = tmp_path / "hosted-mcp-config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "client": "codex",
+                "target": "hosted-http",
+                "server_name": "policynim",
+                "hosted_url": "https://policy.example/mcp",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["mcp-smoke", "--mcp-config-file", str(config_file)])
+
+    assert result.exit_code == 1
+    assert "mcp-smoke --mcp-config-file only supports local-stdio configs" in result.stderr
+
+
+def test_mcp_smoke_help_mentions_generated_config_file() -> None:
+    """Keep the generated-config handshake discoverable from CLI help."""
+    result = runner.invoke(app, ["mcp-smoke", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "--mcp-config-file" in help_output
+    assert "mcp-config" in help_output
+    assert "--format json" in help_output
+
+
+def test_mcp_smoke_does_not_require_completed_standalone_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let clean installs prove MCP tool registration before API-key setup."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for a clean install."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["missing_tools"] == []
+
+
+def test_mcp_smoke_exits_nonzero_when_tools_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exit nonzero when local stdio smoke misses expected MCP tools."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return incomplete MCP smoke evidence for CLI rendering."""
+        return {
+            "status": "error",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_search"],
+            "missing_tools": ["policy_preflight"],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke"])
+
+    assert result.exit_code == 1
+    assert "PolicyNIM MCP smoke" in result.stdout
+    assert "missing_tools" in result.stdout
+    assert "policy_preflight" in result.stdout
+
+
+def test_mcp_smoke_failure_text_prints_recovery_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Tell users how to recover when local stdio registration fails."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return failed MCP smoke evidence with recovery steps."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "error",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": [],
+            "missing_tools": ["policy_preflight", "policy_search"],
+            "message": "MCP stdio smoke failed: RuntimeError: launch failed",
+            "next_steps": [
+                "Run `policynim doctor` to inspect config, credentials, and local index state.",
+                "Run `policynim ingest` before calling policy_preflight or policy_search.",
+            ],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke"])
+
+    assert result.exit_code == 1
+    assert "Next steps:" in result.stdout
+    assert "policynim doctor" in result.stdout
+    assert "policynim ingest" in result.stdout
+
+
+def test_mcp_stdio_smoke_exception_report_includes_recovery_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Include recovery steps in machine-readable stdio launch failures."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    @asynccontextmanager
+    async def failing_stdio_client(*args: object, **kwargs: object):
+        """Raise during stdio client startup to exercise recovery output."""
+        raise RuntimeError("spawn failed")
+        yield
+
+    monkeypatch.setattr("policynim.interfaces.cli.stdio_client", failing_stdio_client)
+
+    report = asyncio.run(cli_module._run_mcp_stdio_smoke(timeout_seconds=1.0))
+
+    assert report["status"] == "error"
+    next_steps = cast(list[str], report["next_steps"])
+    assert "policynim doctor" in " ".join(next_steps)
+    assert "policynim ingest" in " ".join(next_steps)
+    assert "mcp-config --target local-stdio" in " ".join(next_steps)
+
+
+def test_mcp_stdio_smoke_uses_frozen_executable_for_standalone_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Re-enter PyInstaller bundles directly instead of using Python -m."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    binary = tmp_path / "dist" / "policynim" / "policynim"
+    monkeypatch.setattr(cli_module.sys, "executable", str(binary))
+    monkeypatch.setattr(cli_module.sys, "frozen", True, raising=False)
+
+    @asynccontextmanager
+    async def failing_stdio_client(*args: object, **kwargs: object):
+        """Raise during frozen stdio client startup to capture the command."""
+        raise RuntimeError("spawn failed")
+        yield
+
+    monkeypatch.setattr("policynim.interfaces.cli.stdio_client", failing_stdio_client)
+
+    report = asyncio.run(cli_module._run_mcp_stdio_smoke(timeout_seconds=1.0))
+
+    assert report["status"] == "error"
+    assert report["command"] == [str(binary), "mcp", "--transport", "stdio"]
 
 
 def test_beta_admin_list_accounts_prints_json(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1981,6 +1981,32 @@ def test_support_bundle_does_not_label_installed_cwd_as_repo_root(
     assert "workspace" not in result.stdout
 
 
+def test_support_bundle_redacts_custom_absolute_runtime_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Redact absolute runtime path overrides outside default config roots."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    custom_runtime = tmp_path / "external-runtime"
+    custom_index = custom_runtime / "index.sqlite3"
+    write_env_file(
+        config_root / "config.env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH=str(custom_index),
+    )
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["doctor"]["paths"]["index_db_path"] == "<local-path>/index.sqlite3"
+    assert "<local-path>" in payload["redaction"]["path_markers"]
+    assert str(custom_runtime) not in result.stdout
+    assert str(custom_index) not in result.stdout
+    assert "nvapi" not in result.stdout.lower()
+
+
 def test_support_bundle_can_include_local_paths_for_private_triage(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -3101,6 +3127,24 @@ def test_mcp_config_rejects_non_http_hosted_url() -> None:
 
     assert result.exit_code == 1
     assert "Hosted MCP URL must start with http:// or https://" in result.stderr
+
+
+def test_mcp_config_rejects_hosted_url_userinfo() -> None:
+    """Reject hosted URLs that could echo embedded credentials into setup output."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--hosted-url",
+            "https://user:pass@policy.example/mcp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted MCP URL must not include embedded credentials." in result.stderr
+    assert "user:pass" not in result.stdout
 
 
 def test_mcp_config_rejects_hosted_http_with_local_only_options(tmp_path: Path) -> None:

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -27,10 +27,16 @@ def test_workflows_guide_documents_runtime_request_shapes_and_sqlite_usage() -> 
     text = _read_text(WORKFLOWS_GUIDE)
 
     for token in (
+        "policynim quickstart [--target hosted-mcp|local-cli|local-mcp]",
+        "policynim doctor [--format text|json]",
         "policynim runtime decide --input <path|->",
         "policynim runtime execute --input <path|->",
         "policynim evidence report --session-id <id>",
         "policynim evidence report --session-id <id> --format markdown --output reports/<id>.md",
+        "policynim mcp-config [--target local-stdio|hosted-http]",
+        "policynim mcp-smoke [--mcp-config-file <path>]",
+        "policynim support-bundle [--include-mcp-smoke]",
+        "policynim beta-admin list-accounts|suspend|resume|revoke-key|audit-log",
         '"kind": "shell_command"',
         '"kind": "file_write"',
         '"kind": "http_request"',
@@ -70,6 +76,32 @@ def test_standalone_setup_docs_use_installed_cli_entrypoint() -> None:
     for path in STANDALONE_SETUP_DOCS:
         text = _read_text(path)
         assert "policynim init" in text, f"{path.name} should document standalone init"
+
+
+def test_first_run_docs_cover_quickstart_and_doctor() -> None:
+    """Keep the no-network first-run path documented in the main entry points."""
+    readme_text = _read_text(README)
+    workflows_text = _read_text(WORKFLOWS_GUIDE)
+    contributor_text = _read_text(CONTRIBUTOR_GUIDE)
+
+    for token in (
+        "policynim quickstart --target hosted-mcp",
+        "policynim quickstart --target local-cli",
+        "policynim quickstart --target local-mcp",
+    ):
+        assert token in readme_text
+
+    for token in (
+        "policynim quickstart [--target hosted-mcp|local-cli|local-mcp]",
+        "policynim doctor [--format text|json]",
+    ):
+        assert token in workflows_text
+
+    for token in (
+        "uv run policynim doctor",
+        "uv run policynim mcp-smoke --format json",
+    ):
+        assert token in contributor_text
 
 
 def test_source_checkout_setup_docs_state_init_writes_checkout_dotenv() -> None:
@@ -119,6 +151,8 @@ def test_hosted_operations_documents_operator_beta_release_gate() -> None:
 
     for token in (
         "90-Day Operator Beta Release Gate",
+        "policynim quickstart --target hosted-mcp --client codex",
+        "POLICYNIM_INDEX_DB_PATH=/app/data/index.sqlite3",
         "uv run ruff check .",
         "uv run pyright",
         'uv run pytest -q -m "not live and not docker_live"',

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -922,6 +922,42 @@ def test_streamable_http_app_rejects_missing_bearer_token(monkeypatch) -> None:
     assert response.json() == {"error": "Unauthorized."}
 
 
+def test_streamable_http_app_redirects_browser_mcp_visits_to_beta_portal(monkeypatch) -> None:
+    """Route humans who paste the hosted MCP URL toward token creation."""
+    _stub_streamable_http_server(monkeypatch)
+
+    app = mcp_module._build_streamable_http_app(_self_serve_hosted_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        response = client.get(
+            "/mcp",
+            headers={"accept": "text/html"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://beta.example.com/beta"
+
+
+def test_streamable_http_app_keeps_bad_bearer_header_json_for_browser_accept(
+    monkeypatch,
+) -> None:
+    """Do not hide broken MCP client auth behind the human onboarding redirect."""
+    _stub_streamable_http_server(monkeypatch)
+
+    app = mcp_module._build_streamable_http_app(_self_serve_hosted_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        response = client.get(
+            "/mcp",
+            headers={"accept": "text/html", "authorization": "Token wrong"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"error": "Unauthorized."}
+
+
 def test_streamable_http_app_logs_auth_rejection(monkeypatch) -> None:
     events: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Stack position

1 of 4. Base: `main`. Next PR should target `codex/first-run-cli-mcp`.

## Summary

- Add first-run CLI flows for `quickstart`, `doctor`, `mcp-config`, `mcp-smoke`, and `support-bundle`.
- Extend MCP diagnostics around `policy_preflight` and `policy_search` so client setup failures are inspectable.
- Add agent workflow metadata and hosted beta command-card rendering for the new developer journey.
- Align the docs surface with the current CLI and SQLite index contract.

## Documentation pass

- Updated the root README, docs hub, workflow handbook, hosted beta operations guide, architecture pages, examples, and tests README to describe the current first-run flow.
- Replaced stale LanceDB and baked-path wording with the current SQLite index contract.
- Added docs coverage for the new helper commands and beta-admin audit-log flow.
- Updated docs parity tests to lock in the current wording.

## Validation

- `uv run pytest -q tests/test_cli.py tests/test_mcp.py tests/test_beta_portal.py` -> 204 passed
- `uv run pytest -q tests/test_docs_hosted_onboarding.py tests/test_docs_runtime_workflows.py` -> 19 passed
- `uv run pytest -q tests/test_docs_runtime_workflows.py` -> 11 passed
- `git diff --check`
- Commit hooks on the latest commit passed `ruff check`, `ruff format`, and `pyright`
- Top of stack: `uv lock --check`, `uv run ruff check .`, `uv run pyright`, `uv run pytest -q -m "not live and not docker_live"` -> 776 passed, 10 deselected
- Top of stack: `uv run python scripts/release_check.py --format json` -> `decision: ship`
