### PR TITLE
[codex] Add maintainer metadata taxonomy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# PolicyNIM ownership map.
+# GitHub loads CODEOWNERS from .github/, the repository root, or docs/.
+
+* @nnennandukwe
+
+/.github/workflows/ @nnennandukwe
+/.github/dependabot.yml @nnennandukwe
+/.github/labels.yml @nnennandukwe
+/.github/ISSUE_TEMPLATE/ @nnennandukwe
+/.github/PULL_REQUEST_TEMPLATE.md @nnennandukwe
+/pyproject.toml @nnennandukwe
+/uv.lock @nnennandukwe
+/scripts/release_check.py @nnennandukwe
+/scripts/release_manifest.py @nnennandukwe
+/scripts/oss_readiness_check.py @nnennandukwe
+/scripts/sync_github_labels.py @nnennandukwe
+/scripts/install.sh @nnennandukwe
+/scripts/install.ps1 @nnennandukwe
+/src/policynim/interfaces/cli.py @nnennandukwe
+/src/policynim/interfaces/mcp.py @nnennandukwe
+/docs/release.md @nnennandukwe
+/docs/public-launch-runbook.md @nnennandukwe
+/SECURITY.md @nnennandukwe

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report reproducible PolicyNIM CLI, MCP, install, or runtime behavior.
+title: "[Bug]: "
+labels: ["type/bug", "status/needs-triage", "needs/support-bundle"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a PolicyNIM issue. Do not paste API keys, bearer
+        tokens, hosted beta tokens, or private policy content.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - CLI
+        - MCP stdio
+        - Hosted MCP streamable-http
+        - Hosted beta portal
+        - Install or release artifact
+        - Runtime evidence
+        - Docs
+    validations:
+      required: true
+  - type: textarea
+    id: support_bundle
+    attributes:
+      label: policynim support-bundle output
+      description: Run `policynim support-bundle` and paste redacted output. The bundle includes `policynim doctor` diagnostics and redacts local path prefixes by default. For local MCP stdio issues, run `policynim support-bundle --include-mcp-smoke`. Use `--include-local-paths` only in private maintainer triage.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: mcp_config
+    attributes:
+      label: MCP config evidence
+      description: For hosted MCP issues, paste redacted `policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json` output and include the `hosted_url_placeholder` value. For local stdio issues, include the matching local `mcp-config` JSON when client setup is involved.
+      render: json
+    validations:
+      required: false
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Include exact commands, install channel, and MCP transport if relevant.
+      placeholder: |
+        1. Install with ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Redact tokens and private policy content before pasting logs.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: live
+    attributes:
+      label: Did this call live or hosted services?
+      options:
+        - No, offline/local only
+        - Yes, NVIDIA-hosted API
+        - Yes, hosted MCP or beta portal
+        - Yes, Docker or Railway
+        - Not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support questions
+    url: https://github.com/nnennandukwe/policyNIM/blob/main/SUPPORT.md
+    about: Read support routing and issue evidence expectations before opening a report.
+  - name: Security vulnerability
+    url: https://github.com/nnennandukwe/policyNIM/security/advisories/new
+    about: Report suspected credential, token, hosted MCP, or release security issues privately.
+  - name: Community standards
+    url: https://github.com/nnennandukwe/policyNIM/blob/main/CODE_OF_CONDUCT.md
+    about: Review conduct and enforcement expectations for project participation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Propose a PolicyNIM workflow, CLI, MCP, docs, or release improvement.
+title: "[Feature]: "
+labels: ["type/feature", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        PolicyNIM prioritizes verifiable agent workflows, fail-closed behavior,
+        and docs that match command output.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Primary surface
+      options:
+        - CLI
+        - MCP
+        - Hosted beta
+        - Installability
+        - Runtime evidence
+        - Docs
+        - CI or release
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What developer or maintainer workflow is blocked or slow?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Include example commands, MCP calls, or docs shape where useful.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How should this be verified?
+      description: Name deterministic tests, `doctor`, MCP smoke, docs parity, or opt-in live gates.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+## Summary
+
+Describe the CLI, MCP, docs, release, or runtime workflow this changes.
+
+## PR Lane
+
+Choose one primary lane from
+[docs/oss-readiness-audit.md#high-value-pr-sequence](../docs/oss-readiness-audit.md#high-value-pr-sequence).
+Keep the PR scoped to one user-facing thesis, one primary evidence surface, and
+a bounded rollback story.
+
+- [ ] First-run and hosted MCP onboarding
+- [ ] Local CLI and MCP verification loop
+- [ ] Installability and release trust
+- [ ] SQLite migration and storage contract
+- [ ] Maintainer trust and public launch proof
+- [ ] Other: explain why this does not fit one high-value lane.
+
+## Verification
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run pyright`
+- [ ] `uv run pytest -q -m "not live and not docker_live"`
+- [ ] `uv lock --check`
+- [ ] `uv build --out-dir dist`
+- [ ] `uv run policynim doctor --format json`
+- [ ] `uv run policynim support-bundle`
+- [ ] Release-affecting change: `uv run python scripts/release_check.py`
+- [ ] Public launch evidence changed or claimed:
+      `uv run python scripts/oss_readiness_check.py --format launch-issue`
+- [ ] Public launch is claimed ready:
+      `uv run python scripts/release_check.py --strict-public --external-evidence-file docs/launch-evidence.json`
+
+## User-Facing Evidence
+
+Include command output or screenshots for changed CLI, MCP, hosted beta, docs,
+or release behavior. If a listed check was skipped, explain why. For local MCP
+`stdio` changes, include `uv run policynim support-bundle --include-mcp-smoke`.
+When CI has run, reviewers can also inspect the `package-smoke-evidence`
+artifact; it includes `policynim-mcp-smoke.json`, generated MCP client config,
+doctor output, primary command help (`init --help`, `ingest --help`, and
+`preflight --help`), support-bundle output, local OSS-readiness JSON, and the
+paste-ready launch issue from the clean wheel install.
+
+## Live Or Hosted Checks
+
+- [ ] No live NVIDIA, Docker, hosted MCP, or Railway check is required.
+- [ ] Live or hosted check was required and the exact command/result is included.
+- [ ] Public launch proof is not being claimed, or strict public readiness returned
+      `public_ready`. If it returned `hold_external_missing`, list the remaining
+      external proof points instead of presenting the PR as launch-ready.
+
+## Safety
+
+- [ ] No API keys, bearer tokens, generated beta tokens, or private policy
+      corpus content are included.
+- [ ] Docs match the current command output and install channel state.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "surface/install-release"
+      - "surface/ci"
+      - "needs/codeowner-review"
+      - "status/needs-triage"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "surface/ci"
+      - "needs/codeowner-review"
+      - "status/needs-triage"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,99 @@
+# PolicyNIM issue and PR label taxonomy.
+# Apply these labels in GitHub before broad public triage; this file is the
+# repository source of truth even if label sync is manual at first.
+
+- name: type/bug
+  color: "d73a4a"
+  description: Reproducible broken behavior in CLI, MCP, install, hosted beta, or runtime flows.
+
+- name: type/feature
+  color: "a2eeef"
+  description: Request for a new or expanded user-facing workflow.
+
+- name: type/docs
+  color: "0075ca"
+  description: Documentation, examples, README, or release-note work.
+
+- name: type/launch
+  color: "bfdadc"
+  description: Public launch evidence review for release, PyPI, hosted MCP, and client proof.
+
+- name: type/security
+  color: "b60205"
+  description: Public placeholder only; private security reports use GitHub advisories.
+
+- name: status/needs-triage
+  color: "fbca04"
+  description: Maintainer has not yet routed priority, surface, or required evidence.
+
+- name: status/needs-repro
+  color: "fef2c0"
+  description: Maintainer needs a smaller reproduction, command output, or refreshed support bundle.
+
+- name: status/blocked-external
+  color: "cccccc"
+  description: Waiting on external service state such as PyPI, Railway, GitHub, Docker, or NVIDIA.
+
+- name: status/accepted
+  color: "0e8a16"
+  description: Maintainer agrees the issue or proposal is in scope.
+
+- name: priority/p0
+  color: "b60205"
+  description: Security, release integrity, install breakage, or data-leak risk.
+
+- name: priority/p1
+  color: "d93f0b"
+  description: Blocks first-run CLI, MCP setup, release gates, or core verification workflows.
+
+- name: priority/p2
+  color: "fbca04"
+  description: Important rough edge that affects contributor or maintainer confidence.
+
+- name: surface/cli
+  color: "1d76db"
+  description: PolicyNIM command-line behavior, flags, help text, or output contracts.
+
+- name: surface/mcp-stdio
+  color: "5319e7"
+  description: Local stdio MCP server, client config, mcp-smoke, or local agent integration.
+
+- name: surface/hosted-mcp
+  color: "5319e7"
+  description: Hosted streamable-http MCP, beta portal, auth, health, or Railway deployment.
+
+- name: surface/install-release
+  color: "006b75"
+  description: Package install, standalone installers, release artifacts, checksums, or manifests.
+
+- name: surface/runtime-evidence
+  color: "0e8a16"
+  description: Runtime decision, execution, evidence report, or audit log workflows.
+
+- name: surface/ci
+  color: "c5def5"
+  description: CI, release workflow, offline/live gate, Pyright, Ruff, or test infrastructure.
+
+- name: surface/docs
+  color: "0075ca"
+  description: README, docs pages, examples, roadmap, support, or maintainer guidance.
+
+- name: needs/support-bundle
+  color: "fef2c0"
+  description: Needs policynim support-bundle output before maintainers can reproduce confidently.
+
+- name: needs/live-check
+  color: "fef2c0"
+  description: Needs explicit opt-in NVIDIA, hosted MCP, Docker, Railway, or PyPI evidence.
+
+- name: needs/launch-evidence
+  color: "fef2c0"
+  description: Needs external public-launch proof before launch-ready claims can be accepted.
+
+- name: needs/codeowner-review
+  color: "fef2c0"
+  description: Needs review from the listed CODEOWNERS path owner before merge.
+
+- name: good-first-issue
+  color: "7057ff"
+  description: Small, well-scoped change with deterministic verification and clear owner guidance.

--- a/.github/topics.yml
+++ b/.github/topics.yml
@@ -1,0 +1,15 @@
+# PolicyNIM repository topic taxonomy.
+# Keep this list aligned with README positioning, PyPI keywords, and OSS
+# discoverability. Apply with scripts/sync_github_topics.py only from an
+# authenticated maintainer session.
+
+- ai-agents
+- cli
+- code-quality
+- mcp
+- model-context-protocol
+- nvidia-nim
+- policy
+- preflight
+- python
+- verification

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# PolicyNIM Community Standards
+
+PolicyNIM is an open-source verification tool for AI-coding-agent workflows.
+The project needs direct technical disagreement, but it also needs a review
+environment where maintainers and contributors can reason clearly about code,
+docs, releases, MCP workflows, hosted services, and security boundaries.
+
+## Expected Behavior
+
+- Be specific about the technical issue, command output, affected surface, and
+  verification evidence.
+- Respect contributor time by using the issue and pull request templates.
+- Redact API keys, bearer tokens, hosted beta tokens, private policy content,
+  and private runtime evidence before posting.
+- Assume maintainers may ask for deterministic reproduction steps before acting.
+- Keep disagreement focused on code, docs, tests, release artifacts, and user
+  workflows.
+
+## Unacceptable Behavior
+
+- Harassment, threats, discrimination, or personal attacks.
+- Publishing secrets, tokens, private policy content, private runtime evidence,
+  or another person's private information.
+- Repeatedly ignoring maintainer review requests, issue templates, or safety
+  guidance.
+- Misrepresenting live-service status, release state, security impact, or
+  verification results.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments; close issues; reject pull
+requests; block accounts; or escalate to GitHub when behavior threatens the
+project or its users. Enforcement decisions should be proportional to the impact
+on contributor safety, maintainer review, secret safety, and project integrity.
+
+Report conduct concerns privately through the maintainer contact listed in
+[SECURITY.md](SECURITY.md) when public discussion would expose private context;
+maintainers should keep enforcement notes specific and evidence-backed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to PolicyNIM
+
+PolicyNIM is a verification tool for AI-coding-agent workflows. Contributions
+should keep the public CLI, MCP tools, docs, and release gates easy to verify.
+
+## Before Opening a PR
+
+1. Read [docs/contributor-guide.md](docs/contributor-guide.md) for local setup.
+2. Run `uv run policynim doctor --format json` and fix any setup issues it
+   reports.
+3. Run the offline quality gates:
+
+```bash
+uv run ruff check .
+uv run pyright
+uv run pytest -q -m "not live and not docker_live"
+uv lock --check
+uv build --out-dir dist
+uv run policynim support-bundle
+```
+
+4. If your change affects MCP setup, also check the relevant hosted-first client
+   example under [examples/](examples).
+5. If your change affects packaging, installers, or release automation, run
+   `uv run python scripts/release_check.py` and attach the ship/hold output.
+
+## What To Include
+
+- Explain the user-facing workflow you changed.
+- Choose one primary lane from
+  [docs/oss-readiness-audit.md#high-value-pr-sequence](docs/oss-readiness-audit.md#high-value-pr-sequence):
+  first-run and hosted MCP onboarding, local CLI and MCP verification,
+  installability and release trust, SQLite migration and storage contract, or
+  maintainer trust and public launch proof.
+- Keep the PR scoped to one user-facing thesis, one primary evidence surface,
+  and a bounded rollback story.
+- Include exact commands and test output, not just "tests pass."
+- Call out whether live NVIDIA, hosted beta, Docker, or Railway checks were not
+  run.
+- For CLI or MCP changes, include the relevant `--help`, `policynim doctor`, or
+  `policynim support-bundle` output.
+- No API keys, bearer tokens, generated hosted beta tokens, or private policy
+  corpus content should appear in issues, pull requests, screenshots, or logs.
+
+## Live And Hosted Checks
+
+Default CI is offline. Live NVIDIA, hosted MCP, and Docker checks are opt-in so
+pull requests stay reproducible for outside contributors. See
+[tests/README.md](tests/README.md) for the exact environment variables and
+commands.
+
+## Dependency And Ownership Updates
+
+PolicyNIM keeps review ownership in [.github/CODEOWNERS](.github/CODEOWNERS)
+and bounded weekly dependency updates in
+[.github/dependabot.yml](.github/dependabot.yml). Dependabot PRs are not
+auto-merge candidates. Treat updates to `uv.lock`, GitHub Actions, installers,
+release scripts, and MCP entrypoints as code changes that need deterministic
+offline gates and code-owner review before merge.
+
+## Review Bar
+
+Maintainer trust matters more than broad feature claims. Prefer small,
+evidence-backed changes with clear recovery behavior, deterministic tests, and
+docs that match the actual command output.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+PolicyNIM handles local configuration, API keys, hosted MCP bearer tokens, and
+runtime evidence artifacts. Please report security issues privately instead of
+opening a public issue.
+
+## Reporting A Vulnerability
+
+Email the maintainer listed in [pyproject.toml](pyproject.toml) or open a
+private GitHub security advisory if repository access allows it.
+
+Include:
+
+- affected version, commit, install channel, and operating system
+- whether the issue affects CLI, MCP `stdio`, hosted `streamable-http`, the
+  hosted beta portal, release installers, or runtime evidence
+- minimal reproduction steps without secrets
+- whether credentials, policy content, runtime evidence, or hosted beta tokens
+  may have been exposed
+
+Do not include real `NVIDIA_API_KEY` values, hosted bearer tokens, generated beta
+tokens, or private policy documents. Redact secrets before attaching logs.
+
+## Supported Versions
+
+PolicyNIM is currently pre-1.0. Security fixes target `main` and the latest
+GitHub release unless a release note says otherwise.
+
+## Security-Relevant Local Checks
+
+For local setup diagnostics, run:
+
+```bash
+policynim doctor --format json
+```
+
+`doctor` reports config and artifact paths without calling NVIDIA-hosted APIs or
+printing configured secret values.
+
+## Supply Chain Stewardship
+
+PolicyNIM keeps sensitive path ownership in [.github/CODEOWNERS](.github/CODEOWNERS)
+and bounded weekly dependency update checks in
+[.github/dependabot.yml](.github/dependabot.yml). Dependency, installer,
+release, and GitHub Actions updates still need the offline gates and maintainer
+review before release; update bots do not replace security review.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,87 @@
+# PolicyNIM Support
+
+PolicyNIM support works best when reports include reproducible CLI, MCP,
+release, or hosted-beta evidence. Please do not paste API keys, bearer tokens,
+hosted beta tokens, private policy content, or private runtime evidence.
+`policynim support-bundle` redacts local path prefixes by default for public
+issues; use `--include-local-paths` only for private maintainer triage.
+
+## Where To Ask
+
+- Bugs: open a bug report and include `policynim support-bundle` output.
+- Local MCP stdio launch issues: run
+  `policynim support-bundle --include-mcp-smoke` and include the output.
+- Hosted MCP or hosted beta issues: include the hosted URL shape, the failing
+  client command, the `/healthz` status when available, and whether the failure
+  was `401`, insufficient context, upstream NVIDIA failure, or service
+  unavailable. For hosted MCP client setup issues, also include redacted
+  `policynim mcp-config --target hosted-http --client codex --hosted-url
+  'https://<host>/mcp' --format json` output and the `hosted_url_placeholder`
+  value.
+- Install or release artifact issues: include the installer command, platform,
+  asset name, checksum or `RELEASE_MANIFEST.json` evidence, and exact failure
+  output.
+- Public launch evidence: use the
+  [Public launch evidence](.github/ISSUE_TEMPLATE/public_launch_evidence.yml)
+  issue form when strict public readiness, generated launch issue output,
+  attached evidence records, or remaining external proof need maintainer review.
+- Feature requests: use the feature request template and name the CLI, MCP,
+  hosted beta, docs, runtime evidence, installability, or CI/release surface.
+
+Security issues belong in [SECURITY.md](SECURITY.md), not public issues.
+Maintainer triage labels and response rules live in
+[docs/maintainer-triage.md](docs/maintainer-triage.md).
+
+## Before Opening A Bug
+
+Run the lowest-risk diagnostics first:
+
+```bash
+policynim support-bundle
+```
+
+For source checkouts, use `uv run`:
+
+```bash
+uv run policynim support-bundle
+```
+
+Attach `policynim support-bundle` output to public issues. The bundle includes
+a `first_run` section with hosted MCP, local CLI, and local MCP quickstart
+targets plus each target's `quickstart_command`, so maintainers can route setup
+reports without asking for raw quickstart output. Keep raw `policynim doctor --format json` output local unless a maintainer asks for it in a private channel, because raw doctor output can include exact filesystem paths.
+
+If a maintainer asks for exact filesystem paths in a private channel, rerun:
+
+```bash
+policynim support-bundle --include-local-paths
+```
+
+For MCP stdio issues:
+
+```bash
+uv run policynim support-bundle --include-mcp-smoke
+```
+
+For hosted MCP client setup issues:
+
+```bash
+policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json
+```
+
+If the output reports `"hosted_url_placeholder": true`, replace the placeholder
+with the deployed `/mcp` URL before debugging auth, client, or service failures.
+
+## Issue Response Expectations
+
+PolicyNIM is pre-1.0. Maintainer priority goes to:
+
+1. security, secret exposure, token handling, and hosted MCP auth issues
+2. install failures, broken release artifacts, and checksum or manifest drift
+3. first-run setup failures in `init`, `doctor`, `support-bundle`, and
+   `mcp-smoke`
+4. deterministic CLI, MCP, runtime evidence, and CI gate regressions
+5. feature requests and roadmap discussion
+
+If a report cannot be reproduced from the supplied evidence, maintainers may ask
+for a smaller reproduction or a refreshed support bundle.

--- a/docs/maintainer-triage.md
+++ b/docs/maintainer-triage.md
@@ -1,0 +1,199 @@
+# PolicyNIM Maintainer Triage
+
+Use this guide to route public issues and pull requests without losing the
+evidence trail that makes PolicyNIM trustworthy as an MCP and CLI verification
+tool.
+
+## Label Source Of Truth
+
+The repository label taxonomy lives in [../.github/labels.yml](../.github/labels.yml).
+Preview the GitHub label sync plan before opening broad public triage:
+
+```bash
+uv run python scripts/sync_github_labels.py --format json
+```
+
+Compare the checked-in taxonomy against live GitHub labels without changing
+anything:
+
+```bash
+uv run python scripts/sync_github_labels.py --live --format json
+```
+
+Apply the taxonomy only from an authenticated maintainer session with label
+write access:
+
+```bash
+gh auth status
+uv run python scripts/sync_github_labels.py --apply --format json
+```
+
+If `gh` is missing or not authenticated, the sync command fails without a
+traceback and tells the maintainer to install GitHub CLI, run `gh auth status`,
+rerun `--live` to inspect the GitHub delta, and use `--apply` only when ready
+to mutate labels.
+
+Do not invent one-off labels when a listed label already fits.
+
+Start every new public issue with:
+
+- one `type/*` label
+- one or more `surface/*` labels
+- one `priority/*` label after the maintainer understands blast radius
+- `status/needs-triage` until the report has enough evidence to route
+
+Use `needs/launch-evidence` when an issue or PR claims public launch readiness
+but still needs strict public launch evidence, such as GitHub artifact proof,
+artifact attestation verification, PyPI trusted-publishing evidence, hosted MCP
+domain proof, Hosted Beta Smoke output, applied labels/topics, or a real MCP
+client-session record.
+
+Use `type/launch` with
+[../.github/ISSUE_TEMPLATE/public_launch_evidence.yml](../.github/ISSUE_TEMPLATE/public_launch_evidence.yml)
+for public launch evidence reviews. The Public launch evidence form asks for the
+strict public readiness result, the generated launch issue, attached evidence
+records, and any remaining external proof so launch claims stay reviewable
+without mixing them into bug or feature reports.
+
+## Topic Source Of Truth
+
+The repository discoverability topics live in
+[../.github/topics.yml](../.github/topics.yml). Preview the topic sync plan
+before broad public promotion:
+
+```bash
+uv run python scripts/sync_github_topics.py --format json
+```
+
+Compare the checked-in taxonomy against live GitHub topics without changing
+anything:
+
+```bash
+uv run python scripts/sync_github_topics.py --live --format json
+```
+
+Apply topics only from an authenticated maintainer session with repository
+metadata write access:
+
+```bash
+gh auth status
+uv run python scripts/sync_github_topics.py --apply --format json
+```
+
+If `gh` is missing or not authenticated, the sync command fails without a
+traceback and tells the maintainer to install GitHub CLI, run `gh auth status`,
+rerun `--live` to inspect the GitHub delta, and use `--apply` only when ready
+to mutate topics.
+
+Keep topics aligned with README positioning and PyPI package keywords. Do not
+add hosted-health or public-ready topics until strict public launch evidence
+proves those claims.
+
+## Ownership And Dependency Updates
+
+The review ownership map lives in [../.github/CODEOWNERS](../.github/CODEOWNERS).
+Use `needs/codeowner-review` when a PR touches release automation, installers,
+security reporting, public MCP surfaces, or dependency-update configuration and
+the listed owner has not reviewed it yet.
+
+The dependency update policy lives in
+[../.github/dependabot.yml](../.github/dependabot.yml). Dependabot is allowed to
+open bounded weekly PRs for the `uv` dependency graph and GitHub Actions. Treat
+those PRs as normal code changes: require offline CI, code-owner review when
+the changed path is owned, and `uv run python scripts/release_check.py` before
+merging updates that affect install, release, or workflow behavior.
+
+## Evidence First
+
+For bugs, ask for:
+
+- `policynim support-bundle`
+- the bundle's `first_run` target summary when the report involves hosted MCP,
+  local CLI, or local MCP setup
+- exact install channel or source checkout command
+- exact CLI command, MCP client command, hosted URL shape, or release artifact
+- whether live NVIDIA, hosted MCP, Docker, Railway, or PyPI was involved
+
+For local MCP stdio issues, prefer:
+
+```bash
+policynim support-bundle --include-mcp-smoke
+policynim mcp-config --client codex --format json
+```
+
+Support bundles redact local path prefixes by default. Ask for exact paths only
+in private maintainer triage, using:
+
+```bash
+policynim support-bundle --include-local-paths
+```
+
+For source checkouts, ask reporters to use `uv run` for both commands and add
+`--repo-root /ABS/PATH/TO/policyNIM` when the checkout is not auto-detected.
+
+For hosted MCP client setup issues, ask for redacted generated config:
+
+```bash
+policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json
+```
+
+If `hosted_url_placeholder` is `true`, route the report to setup guidance first:
+the client is still configured with an example or placeholder URL, not the
+deployed `/mcp` endpoint.
+
+## Priority Rules
+
+Use `priority/p0` for:
+
+- private data, API key, bearer token, hosted beta token, or policy-content leaks
+- release artifact, checksum, installer, or `RELEASE_MANIFEST.json` integrity
+  failures
+- install paths that fail before `policynim --help`, `doctor`, or
+  `support-bundle` can run
+
+Use `priority/p1` for:
+
+- first-run setup regressions in `init`, `doctor`, `support-bundle`,
+  `mcp-smoke`, or `mcp-config`
+- local or hosted MCP regressions that block `policy_preflight` or
+  `policy_search`
+- CI or release gate drift that could ship unverified artifacts
+
+Use `priority/p2` for:
+
+- docs drift, unclear recovery guidance, and non-blocking UX issues
+- feature requests that improve verification but do not block current workflows
+
+## Surface Routing
+
+- CLI command, flag, help, JSON, or exit-code issues: `surface/cli`
+- Local MCP launch, generated config, or stdio client behavior:
+  `surface/mcp-stdio`
+- Hosted MCP, beta portal, auth, `/healthz`, or Railway deployment:
+  `surface/hosted-mcp`
+- Install scripts, PyPI, release assets, checksums, or manifests:
+  `surface/install-release`
+- Runtime decision, execution, evidence, or audit logs:
+  `surface/runtime-evidence`
+- GitHub Actions, release automation, markers, Ruff, Pyright, or tests:
+  `surface/ci`
+- README, examples, support docs, roadmap, or maintainer policy:
+  `surface/docs`
+
+## Response Expectations
+
+Within maintainer capacity:
+
+- P0: acknowledge quickly, move security-sensitive details to private advisory
+  handling, and avoid asking reporters to paste secrets publicly
+- P1: request missing deterministic evidence or reproduce from the supplied
+  commands before accepting
+- P2: keep scope narrow and ask for verification evidence before implementation
+
+When evidence is incomplete, use `status/needs-repro` and ask for the smallest
+command sequence that reproduces the behavior. When progress depends on PyPI,
+Railway, Docker, NVIDIA, GitHub Actions state, or another external service, use
+`status/blocked-external` and name the external dependency in the issue.
+For public launch claims, also use `needs/launch-evidence` until
+`scripts/release_check.py --strict-public --external-evidence-file
+docs/launch-evidence.json` returns `public_ready`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+# PolicyNIM Roadmap
+
+This roadmap describes the current public direction without promising dates.
+PolicyNIM should earn adoption through reliable install paths, useful first-run
+diagnostics, verifiable MCP workflows, deterministic release gates, and clear
+maintainer expectations.
+
+## Now
+
+- Keep the hosted-first MCP examples current for Codex and Claude Code.
+- Keep `policynim quickstart`, `policynim doctor`, `policynim support-bundle`,
+  and `policynim mcp-smoke` aligned with the real first-run experience.
+- Keep generated-config MCP smoke working so local Codex and Claude Code stdio
+  configs can be handshaked before users paste them into a client.
+- Keep CI offline by default with Ruff, Pyright, live/Docker marker exclusion,
+  package build, clean wheel install smoke, and release manifest checks.
+- Keep GitHub release artifacts tied to `SHA256SUMS` and
+  `RELEASE_MANIFEST.json`.
+- Keep `scripts/oss_readiness_check.py` green so maintainers can distinguish
+  local readiness from missing external launch proof.
+- Keep `.github/CODEOWNERS` and `.github/dependabot.yml` aligned with release,
+  installer, MCP, and CI ownership risk.
+- Keep `scripts/sync_github_labels.py` as the offline dry-run, live dry-run,
+  and apply path for label taxonomy maintenance.
+- Keep `.github/topics.yml` and `scripts/sync_github_topics.py` aligned with
+  the MCP + CLI verification positioning before public promotion, with live
+  dry-run checks before apply.
+- Keep PyPI package installs documented while treating trusted-publishing
+  evidence and clean public install smoke as separate public-launch proof
+  points.
+
+## Next
+
+- Publish and verify the first public GitHub release artifact set.
+- Run `scripts/oss_readiness_check.py --strict-public --format json` before the
+  first broad public launch, and attach the resulting external proof status to
+  the launch issue or release notes using `docs/public-launch-runbook.md`.
+- Attach PyPI trusted-publishing evidence for the current tag so package
+  availability and release-workflow provenance are both reviewable.
+- Attach clean PyPI install smoke evidence for the current tag so the public
+  package path proves first-run CLI behavior.
+- Tighten Hosted beta smoke evidence so `/healthz`, `policy_search`, and
+  `policy_preflight` promotion status is easy to attach to release decisions.
+- Refine the applied `.github/labels.yml` taxonomy after the first external
+  issue flow shows which buckets contributors actually use.
+- Refine the applied `.github/topics.yml` taxonomy after search, install, and
+  issue traffic shows which discoverability channels are working.
+
+## Later
+
+- Broaden the sample policy corpus without weakening citation grounding.
+- Keep README's bounded public metadata badges current, and add hosted health and
+  public-ready badges only when they reflect stable, meaningful checks.
+- Expand maintained client examples beyond Codex and Claude Code when there is
+  evidence of real user demand.
+- Add observability around hosted MCP usage, upstream provider failures, and
+  first-run support-bundle patterns.
+
+## Not committed yet
+
+- Enterprise policy corpus hosting.
+- A hosted multi-tenant admin console beyond the current beta portal.
+- A default-on live NVIDIA CI gate.
+- A full compatibility matrix for every MCP client.
+- A release date for 1.0.

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -1,0 +1,298 @@
+"""Dry-run or apply the PolicyNIM GitHub label taxonomy with gh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LABELS_FILE = REPO_ROOT / ".github" / "labels.yml"
+GITHUB_LABEL_LIST_COMMAND = "gh label list --json name,color,description --limit 1000"
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+Action = Literal["create", "update", "noop"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--labels-file",
+        type=Path,
+        default=DEFAULT_LABELS_FILE,
+        help="Path to the repository label taxonomy.",
+    )
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply create/update operations with gh. Defaults to dry-run.",
+    )
+    mode_group.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Compare against current GitHub labels without applying changes. "
+            "Defaults to offline dry-run."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for the sync plan.",
+    )
+    args = parser.parse_args()
+
+    try:
+        desired = load_label_taxonomy(args.labels_file)
+        result = sync_labels(
+            desired=desired,
+            apply=args.apply,
+            live=args.live,
+            labels_file=args.labels_file.resolve(strict=False),
+        )
+    except LabelSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+    return 0
+
+
+class LabelSyncError(Exception):
+    """GitHub label sync failed."""
+
+
+def load_label_taxonomy(path: Path) -> list[dict[str, str]]:
+    """Load the limited YAML label taxonomy used by this repository."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise LabelSyncError(f"Could not read label taxonomy {path}: {exc}") from exc
+
+    labels: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- name:"):
+            if current is not None:
+                labels.append(_validate_label(current))
+            current = {"name": _unquote(stripped.removeprefix("- name:").strip())}
+            continue
+        if current is None:
+            raise LabelSyncError(f"Unexpected label taxonomy line before a name: {raw_line}")
+        key, separator, raw_value = stripped.partition(":")
+        if not separator:
+            raise LabelSyncError(f"Invalid label taxonomy line: {raw_line}")
+        if key not in {"color", "description"}:
+            raise LabelSyncError(f"Unsupported label field {key!r} in {raw_line!r}.")
+        current[key] = _unquote(raw_value.strip())
+    if current is not None:
+        labels.append(_validate_label(current))
+    if not labels:
+        raise LabelSyncError(f"No labels found in {path}.")
+    return labels
+
+
+def plan_label_sync(
+    desired: list[dict[str, str]],
+    existing: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Return deterministic create/update/noop actions for desired labels."""
+    existing_by_name = {label["name"]: label for label in existing}
+    plan: list[dict[str, Any]] = []
+    for label in desired:
+        current = existing_by_name.get(label["name"])
+        if current is None:
+            plan.append({"action": "create", **label})
+            continue
+        updates: dict[str, dict[str, str]] = {}
+        for key in ("color", "description"):
+            if current.get(key, "") != label[key]:
+                updates[key] = {"from": current.get(key, ""), "to": label[key]}
+        if updates:
+            plan.append({"action": "update", **label, "updates": updates})
+        else:
+            plan.append({"action": "noop", **label})
+    return plan
+
+
+def sync_labels(
+    *,
+    desired: list[dict[str, str]],
+    apply: bool,
+    live: bool = False,
+    labels_file: Path | None = None,
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Build or apply a GitHub label sync plan."""
+    if apply and live:
+        raise LabelSyncError("--apply and --live cannot be used together.")
+    command_runner = runner or _run_command
+    existing = _load_existing_labels(command_runner) if apply or live else []
+    plan = plan_label_sync(desired, existing)
+    if apply:
+        for entry in plan:
+            _apply_plan_entry(entry, command_runner)
+    mode = "apply" if apply else "live-dry-run" if live else "dry-run"
+    return {
+        "schema_version": "1",
+        "mode": mode,
+        "labels_file": str(labels_file) if labels_file is not None else None,
+        "plan": plan,
+        "next_step": _next_step_for_mode(apply=apply, live=live, plan=plan),
+    }
+
+
+def _load_existing_labels(runner: Runner) -> list[dict[str, str]]:
+    command = ["gh", "label", "list", "--json", "name,color,description", "--limit", "1000"]
+    completed = _run_gh(command, runner, failure="list existing GitHub labels")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise LabelSyncError(f"Could not parse gh label list JSON: {exc}") from exc
+    if not isinstance(payload, list):
+        raise LabelSyncError("gh label list returned JSON that was not a list.")
+    labels: list[dict[str, str]] = []
+    for raw_label in payload:
+        if not isinstance(raw_label, dict):
+            raise LabelSyncError("gh label list returned a non-object label entry.")
+        labels.append(
+            {
+                "name": str(raw_label.get("name", "")),
+                "color": str(raw_label.get("color", "")),
+                "description": str(raw_label.get("description", "")),
+            }
+        )
+    return labels
+
+
+def _apply_plan_entry(entry: dict[str, Any], runner: Runner) -> None:
+    action = entry["action"]
+    if action == "noop":
+        return
+    if action == "create":
+        command = [
+            "gh",
+            "label",
+            "create",
+            str(entry["name"]),
+            "--color",
+            str(entry["color"]),
+            "--description",
+            str(entry["description"]),
+        ]
+    elif action == "update":
+        command = [
+            "gh",
+            "label",
+            "edit",
+            str(entry["name"]),
+            "--color",
+            str(entry["color"]),
+            "--description",
+            str(entry["description"]),
+        ]
+    else:
+        raise LabelSyncError(f"Unsupported label sync action: {action}")
+
+    _run_gh(command, runner, failure=f"{action} label {entry['name']}")
+
+
+def _run_gh(
+    command: list[str],
+    runner: Runner,
+    *,
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = runner(command)
+    except OSError as exc:
+        raise LabelSyncError(_gh_recovery_message("GitHub CLI is required")) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        if not detail:
+            detail = f"gh exited with status {completed.returncode}"
+        raise LabelSyncError(f"Could not {failure}: {detail}. {_gh_recovery_message('Recovery')}")
+    return completed
+
+
+def _gh_recovery_message(prefix: str) -> str:
+    return (
+        f"{prefix} for live/apply label sync. Install `gh`, run `gh auth status`, "
+        "rerun with `--live` to inspect the GitHub delta, then rerun with "
+        "`--apply` only when ready to mutate labels."
+    )
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _next_step_for_mode(
+    *,
+    apply: bool,
+    live: bool,
+    plan: list[dict[str, Any]],
+) -> str:
+    if apply:
+        return "Applied non-noop label changes with gh."
+    if live:
+        if any(entry["action"] != "noop" for entry in plan):
+            return "Review the live label plan, then rerun with --apply when ready."
+        return "GitHub labels already match .github/labels.yml."
+    return (
+        "Run with --live to compare against current GitHub state "
+        f"(`{GITHUB_LABEL_LIST_COMMAND}`), or rerun with --apply when ready."
+    )
+
+
+def _validate_label(label: dict[str, str]) -> dict[str, str]:
+    required = ("name", "color", "description")
+    missing = [key for key in required if not label.get(key)]
+    if missing:
+        raise LabelSyncError(
+            f"Label entry {label.get('name') or '<unknown>'} is missing: {', '.join(missing)}"
+        )
+    color = label["color"].strip().removeprefix("#")
+    if len(color) != 6 or any(character not in "0123456789abcdefABCDEF" for character in color):
+        raise LabelSyncError(f"Label {label['name']} has invalid hex color: {label['color']}")
+    return {
+        "name": label["name"].strip(),
+        "color": color.lower(),
+        "description": label["description"].strip(),
+    }
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines = [
+        "PolicyNIM GitHub label sync",
+        f"Mode: {result['mode']}",
+        f"Labels file: {result['labels_file']}",
+        "",
+        "Plan:",
+    ]
+    for entry in result["plan"]:
+        lines.append(f"- {entry['action']}: {entry['name']}")
+    lines.extend(["", f"Next step: {result['next_step']}"])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_github_topics.py
+++ b/scripts/sync_github_topics.py
@@ -1,0 +1,261 @@
+"""Dry-run or apply the PolicyNIM GitHub repository topic taxonomy with gh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TOPICS_FILE = REPO_ROOT / ".github" / "topics.yml"
+GITHUB_TOPIC_LIST_COMMAND = "gh repo view --json repositoryTopics,nameWithOwner"
+TOPIC_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,49}$")
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+Action = Literal["add", "remove", "noop", "ensure"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--topics-file",
+        type=Path,
+        default=DEFAULT_TOPICS_FILE,
+        help="Path to the repository topic taxonomy.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repository in OWNER/REPO form. Defaults to gh's current repo.",
+    )
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply add/remove topic operations with gh. Defaults to dry-run.",
+    )
+    mode_group.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Compare against current GitHub topics without applying changes. "
+            "Defaults to offline dry-run."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for the sync plan.",
+    )
+    args = parser.parse_args()
+
+    try:
+        desired = load_topic_taxonomy(args.topics_file)
+        result = sync_topics(
+            desired=desired,
+            apply=args.apply,
+            live=args.live,
+            repo=args.repo,
+            topics_file=args.topics_file.resolve(strict=False),
+        )
+    except TopicSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+    return 0
+
+
+class TopicSyncError(Exception):
+    """GitHub topic sync failed."""
+
+
+def load_topic_taxonomy(path: Path) -> list[str]:
+    """Load the limited YAML topic taxonomy used by this repository."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise TopicSyncError(f"Could not read topic taxonomy {path}: {exc}") from exc
+
+    topics: list[str] = []
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not stripped.startswith("- "):
+            raise TopicSyncError(f"Invalid topic taxonomy line: {raw_line}")
+        topic = stripped.removeprefix("- ").strip()
+        topics.append(_validate_topic(topic))
+    if not topics:
+        raise TopicSyncError(f"No topics found in {path}.")
+    duplicates = sorted({topic for topic in topics if topics.count(topic) > 1})
+    if duplicates:
+        raise TopicSyncError(f"Duplicate topics found: {', '.join(duplicates)}")
+    return topics
+
+
+def plan_topic_sync(desired: list[str], existing: list[str]) -> list[dict[str, str]]:
+    """Return deterministic add/remove/noop actions for desired topics."""
+    existing_topics = set(existing)
+    desired_topics = set(desired)
+    plan: list[dict[str, str]] = []
+    for topic in desired:
+        action: Action = "noop" if topic in existing_topics else "add"
+        plan.append({"action": action, "topic": topic})
+    for topic in sorted(existing_topics - desired_topics):
+        plan.append({"action": "remove", "topic": topic})
+    return plan
+
+
+def sync_topics(
+    *,
+    desired: list[str],
+    apply: bool,
+    live: bool = False,
+    repo: str | None = None,
+    topics_file: Path | None = None,
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Build or apply a GitHub topic sync plan."""
+    if apply and live:
+        raise TopicSyncError("--apply and --live cannot be used together.")
+    command_runner = runner or _run_command
+    if apply or live:
+        existing = _load_existing_topics(command_runner, repo=repo)
+        plan = plan_topic_sync(desired, existing)
+    else:
+        plan = [{"action": "ensure", "topic": topic} for topic in desired]
+    if apply:
+        for entry in plan:
+            _apply_plan_entry(entry, command_runner, repo=repo)
+    mode = "apply" if apply else "live-dry-run" if live else "dry-run"
+    return {
+        "schema_version": "1",
+        "mode": mode,
+        "repo": repo,
+        "topics_file": str(topics_file) if topics_file is not None else None,
+        "plan": plan,
+        "next_step": _next_step_for_mode(apply=apply, live=live, plan=plan),
+    }
+
+
+def _load_existing_topics(runner: Runner, *, repo: str | None) -> list[str]:
+    command = ["gh", "repo", "view"]
+    if repo:
+        command.append(repo)
+    command.extend(["--json", "repositoryTopics,nameWithOwner"])
+    completed = _run_gh(command, runner, failure="list existing GitHub topics")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise TopicSyncError(f"Could not parse gh repo view JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise TopicSyncError("gh repo view returned JSON that was not an object.")
+    raw_topics = payload.get("repositoryTopics")
+    if not isinstance(raw_topics, list):
+        raise TopicSyncError("gh repo view did not return a repositoryTopics list.")
+    topics: list[str] = []
+    for raw_topic in raw_topics:
+        if not isinstance(raw_topic, dict):
+            raise TopicSyncError("gh repo view returned a non-object topic entry.")
+        topics.append(_validate_topic(str(raw_topic.get("name", ""))))
+    return topics
+
+
+def _apply_plan_entry(entry: dict[str, str], runner: Runner, *, repo: str | None) -> None:
+    action = entry["action"]
+    if action == "noop":
+        return
+    if action not in {"add", "remove"}:
+        raise TopicSyncError(f"Unsupported topic sync action: {action}")
+    flag = "--add-topic" if action == "add" else "--remove-topic"
+    command = ["gh", "repo", "edit"]
+    if repo:
+        command.append(repo)
+    command.extend([flag, entry["topic"]])
+    _run_gh(command, runner, failure=f"{action} topic {entry['topic']}")
+
+
+def _run_gh(
+    command: list[str],
+    runner: Runner,
+    *,
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = runner(command)
+    except OSError as exc:
+        raise TopicSyncError(_gh_recovery_message("GitHub CLI is required")) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        if not detail:
+            detail = f"gh exited with status {completed.returncode}"
+        raise TopicSyncError(f"Could not {failure}: {detail}. {_gh_recovery_message('Recovery')}")
+    return completed
+
+
+def _gh_recovery_message(prefix: str) -> str:
+    return (
+        f"{prefix} for live/apply topic sync. Install `gh`, run `gh auth status`, "
+        "rerun with `--live` to inspect the GitHub delta, then rerun with "
+        "`--apply` only when ready to mutate topics."
+    )
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _next_step_for_mode(
+    *,
+    apply: bool,
+    live: bool,
+    plan: list[dict[str, str]],
+) -> str:
+    if apply:
+        return "Applied non-noop topic changes with gh."
+    if live:
+        if any(entry["action"] != "noop" for entry in plan):
+            return "Review the live topic plan, then rerun with --apply when ready."
+        return "GitHub repository topics already match .github/topics.yml."
+    return (
+        "Run with --live to compare against current GitHub state "
+        f"(`{GITHUB_TOPIC_LIST_COMMAND}`), or rerun with --apply when ready."
+    )
+
+
+def _validate_topic(value: str) -> str:
+    topic = value.strip()
+    if not TOPIC_PATTERN.fullmatch(topic):
+        raise TopicSyncError(
+            f"Topic {value!r} must be lowercase, start with a letter or digit, "
+            "and contain only letters, digits, or hyphens."
+        )
+    return topic
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines = [
+        "PolicyNIM GitHub topic sync",
+        f"Mode: {result['mode']}",
+        f"Topics file: {result['topics_file']}",
+        "",
+        "Plan:",
+    ]
+    for entry in result["plan"]:
+        lines.append(f"- {entry['action']}: {entry['topic']}")
+    lines.extend(["", f"Next step: {result['next_step']}"])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_label_sync.py
+++ b/tests/test_github_label_sync.py
@@ -1,0 +1,261 @@
+"""GitHub label sync script contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_github_labels.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_github_labels", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_label_taxonomy_preserves_names_colors_and_descriptions(tmp_path: Path) -> None:
+    """Load the checked-in label taxonomy without relying on GitHub state."""
+    module = _load_script_module()
+    label_file = tmp_path / "labels.yml"
+    label_file.write_text(
+        "\n".join(
+            [
+                "- name: type/bug",
+                '  color: "d73a4a"',
+                "  description: Reproducible broken behavior.",
+                "",
+                "- name: surface/mcp-stdio",
+                '  color: "5319e7"',
+                "  description: Local stdio MCP server.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    labels = module.load_label_taxonomy(label_file)
+
+    assert [label["name"] for label in labels] == ["type/bug", "surface/mcp-stdio"]
+    assert labels[0] == {
+        "name": "type/bug",
+        "color": "d73a4a",
+        "description": "Reproducible broken behavior.",
+    }
+
+
+def test_plan_label_sync_creates_updates_and_leaves_matching_labels() -> None:
+    """Produce deterministic create/update/noop actions from current GitHub labels."""
+    module = _load_script_module()
+    desired = [
+        {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+        {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+        {"name": "priority/p1", "color": "d93f0b", "description": "Blocks first run."},
+    ]
+    existing = [
+        {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+        {"name": "surface/cli", "color": "000000", "description": "Old CLI text."},
+    ]
+
+    plan = module.plan_label_sync(desired, existing)
+
+    assert [entry["action"] for entry in plan] == ["noop", "update", "create"]
+    assert plan[0]["name"] == "type/bug"
+    assert plan[1]["updates"] == {
+        "color": {"from": "000000", "to": "1d76db"},
+        "description": {"from": "Old CLI text.", "to": "CLI issues."},
+    }
+    assert plan[2]["name"] == "priority/p1"
+
+
+def test_sync_github_labels_dry_run_outputs_json_without_gh_calls() -> None:
+    """Keep the default path safe and machine-readable for maintainers."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--labels-file",
+            str(REPO_ROOT / ".github" / "labels.yml"),
+            "--format",
+            "json",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "dry-run"
+    assert payload["labels_file"] == str(REPO_ROOT / ".github" / "labels.yml")
+    assert "--live" in payload["next_step"]
+    assert any(entry["name"] == "type/bug" for entry in payload["plan"])
+    assert all(entry["action"] == "create" for entry in payload["plan"])
+
+
+def test_live_dry_run_reads_gh_state_without_applying_label_changes() -> None:
+    """Let maintainers inspect the real GitHub delta without mutating labels."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "type/bug",
+                        "color": "d73a4a",
+                        "description": "Bug reports.",
+                    },
+                    {
+                        "name": "surface/cli",
+                        "color": "000000",
+                        "description": "Old text.",
+                    },
+                ]
+            ),
+            stderr="",
+        )
+
+    result = module.sync_labels(
+        desired=[
+            {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+            {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+            {"name": "priority/p1", "color": "d93f0b", "description": "Blocks first run."},
+        ],
+        apply=False,
+        live=True,
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "live-dry-run"
+    assert [entry["action"] for entry in result["plan"]] == ["noop", "update", "create"]
+    assert calls == [["gh", "label", "list", "--json", "name,color,description", "--limit", "1000"]]
+    assert "rerun with --apply" in result["next_step"]
+
+
+def test_apply_mode_runs_gh_create_and_update_commands(tmp_path: Path) -> None:
+    """Apply mode should call gh only after an explicit --apply flag."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "surface/cli",
+                            "color": "000000",
+                            "description": "Old text.",
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = module.sync_labels(
+        desired=[
+            {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+            {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+        ],
+        apply=True,
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "apply"
+    assert [entry["action"] for entry in result["plan"]] == ["create", "update"]
+    assert [
+        "gh",
+        "label",
+        "create",
+        "type/bug",
+        "--color",
+        "d73a4a",
+        "--description",
+        "Bug reports.",
+    ] in calls
+    assert [
+        "gh",
+        "label",
+        "edit",
+        "surface/cli",
+        "--color",
+        "1d76db",
+        "--description",
+        "CLI issues.",
+    ] in calls
+
+
+def test_apply_and_live_modes_are_mutually_exclusive() -> None:
+    """Prevent an inspect-only command from being combined with mutation mode."""
+    module = _load_script_module()
+
+    with pytest.raises(module.LabelSyncError, match="--apply and --live"):
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=True,
+            live=True,
+            runner=lambda command: subprocess.CompletedProcess(command, 0, stdout="[]", stderr=""),
+        )
+
+
+def test_apply_mode_reports_missing_gh_without_traceback() -> None:
+    """A maintainer without gh installed should get recovery guidance."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.LabelSyncError) as exc_info:
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=True,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+
+
+def test_live_mode_reports_missing_gh_without_apply_only_guidance() -> None:
+    """Inspect-only live mode should not tell maintainers gh is only required for --apply."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.LabelSyncError) as exc_info:
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=False,
+            live=True,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+    assert "--live" in message
+    assert "required for --apply" not in message

--- a/tests/test_github_topic_sync.py
+++ b/tests/test_github_topic_sync.py
@@ -1,0 +1,257 @@
+"""GitHub topic sync script contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_github_topics.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_github_topics", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_topic_taxonomy_preserves_order_and_rejects_invalid_names(
+    tmp_path: Path,
+) -> None:
+    """Load the checked-in topic taxonomy without relying on GitHub state."""
+    module = _load_script_module()
+    topics_file = tmp_path / "topics.yml"
+    topics_file.write_text(
+        "\n".join(
+            [
+                "# Discoverability topics",
+                "- ai-agents",
+                "- mcp",
+                "- nvidia-nim",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.load_topic_taxonomy(topics_file) == ["ai-agents", "mcp", "nvidia-nim"]
+
+    topics_file.write_text("- Invalid Topic\n", encoding="utf-8")
+    with pytest.raises(module.TopicSyncError, match="lowercase"):
+        module.load_topic_taxonomy(topics_file)
+
+
+def test_plan_topic_sync_adds_removes_and_leaves_matching_topics() -> None:
+    """Produce deterministic add/remove/noop actions from current GitHub topics."""
+    module = _load_script_module()
+
+    plan = module.plan_topic_sync(
+        desired=["ai-agents", "mcp", "python"],
+        existing=["ai-agents", "old-topic", "python"],
+    )
+
+    assert plan == [
+        {"action": "noop", "topic": "ai-agents"},
+        {"action": "add", "topic": "mcp"},
+        {"action": "noop", "topic": "python"},
+        {"action": "remove", "topic": "old-topic"},
+    ]
+
+
+def test_sync_github_topics_dry_run_outputs_json_without_gh_calls() -> None:
+    """Keep the default path safe and machine-readable for maintainers."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--topics-file",
+            str(REPO_ROOT / ".github" / "topics.yml"),
+            "--format",
+            "json",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "dry-run"
+    assert payload["topics_file"] == str(REPO_ROOT / ".github" / "topics.yml")
+    assert "--live" in payload["next_step"]
+    assert any(entry["topic"] == "mcp" for entry in payload["plan"])
+    assert all(entry["action"] == "ensure" for entry in payload["plan"])
+
+
+def test_live_dry_run_reads_gh_topics_without_applying_changes() -> None:
+    """Let maintainers inspect the real topic delta without mutating GitHub."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "nameWithOwner": "nnennandukwe/policyNIM",
+                    "repositoryTopics": [
+                        {"name": "ai-agents"},
+                        {"name": "old-topic"},
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    result = module.sync_topics(
+        desired=["ai-agents", "mcp"],
+        apply=False,
+        live=True,
+        repo="nnennandukwe/policyNIM",
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "live-dry-run"
+    assert result["plan"] == [
+        {"action": "noop", "topic": "ai-agents"},
+        {"action": "add", "topic": "mcp"},
+        {"action": "remove", "topic": "old-topic"},
+    ]
+    assert calls == [
+        [
+            "gh",
+            "repo",
+            "view",
+            "nnennandukwe/policyNIM",
+            "--json",
+            "repositoryTopics,nameWithOwner",
+        ]
+    ]
+    assert "rerun with --apply" in result["next_step"]
+
+
+def test_apply_mode_runs_gh_topic_add_and_remove_commands() -> None:
+    """Apply mode should call gh only after an explicit --apply flag."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "nnennandukwe/policyNIM",
+                        "repositoryTopics": [
+                            {"name": "ai-agents"},
+                            {"name": "old-topic"},
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = module.sync_topics(
+        desired=["ai-agents", "mcp"],
+        apply=True,
+        repo="nnennandukwe/policyNIM",
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "apply"
+    assert [entry["action"] for entry in result["plan"]] == ["noop", "add", "remove"]
+    assert [
+        "gh",
+        "repo",
+        "edit",
+        "nnennandukwe/policyNIM",
+        "--add-topic",
+        "mcp",
+    ] in calls
+    assert [
+        "gh",
+        "repo",
+        "edit",
+        "nnennandukwe/policyNIM",
+        "--remove-topic",
+        "old-topic",
+    ] in calls
+
+
+def test_apply_and_live_modes_are_mutually_exclusive() -> None:
+    """Prevent an inspect-only command from being combined with mutation mode."""
+    module = _load_script_module()
+
+    with pytest.raises(module.TopicSyncError, match="--apply and --live"):
+        module.sync_topics(
+            desired=["mcp"],
+            apply=True,
+            live=True,
+            repo=None,
+            runner=lambda command: subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"repositoryTopics": []}',
+                stderr="",
+            ),
+        )
+
+
+def test_apply_mode_reports_missing_gh_without_traceback() -> None:
+    """A maintainer without gh installed should get recovery guidance."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.TopicSyncError) as exc_info:
+        module.sync_topics(
+            desired=["mcp"],
+            apply=True,
+            repo=None,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+
+
+def test_live_mode_reports_missing_gh_without_apply_only_guidance() -> None:
+    """Inspect-only live mode should not tell maintainers gh is only required for --apply."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.TopicSyncError) as exc_info:
+        module.sync_topics(
+            desired=["mcp"],
+            apply=False,
+            live=True,
+            repo="nnennandukwe/policyNIM",
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+    assert "--live" in message
+    assert "required for --apply" not in message


### PR DESCRIPTION
## Stack position

2 of 4. Base: `codex/first-run-cli-mcp`. Previous PR: #58.

## Summary

- Add GitHub issue and PR templates, CODEOWNERS, Dependabot config, and repository metadata files.
- Add label/topic taxonomies plus dry-run-first sync scripts for maintainer workflows.
- Add contributor-facing conduct, support, security, triage, and roadmap docs.

## Validation

- `uv run pytest -q tests/test_github_label_sync.py tests/test_github_topic_sync.py` -> 16 passed
- Top of stack: `uv lock --check`, `uv run ruff check .`, `uv run pyright`, `uv run pytest -q -m "not live and not docker_live"` -> 776 passed, 10 deselected
- Top of stack: `uv run python scripts/release_check.py --format json` -> `decision: ship`
