### PR TITLE
[codex] Add public launch evidence collector

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# PolicyNIM ownership map.
+# GitHub loads CODEOWNERS from .github/, the repository root, or docs/.
+
+* @nnennandukwe
+
+/.github/workflows/ @nnennandukwe
+/.github/dependabot.yml @nnennandukwe
+/.github/labels.yml @nnennandukwe
+/.github/ISSUE_TEMPLATE/ @nnennandukwe
+/.github/PULL_REQUEST_TEMPLATE.md @nnennandukwe
+/pyproject.toml @nnennandukwe
+/uv.lock @nnennandukwe
+/scripts/release_check.py @nnennandukwe
+/scripts/release_manifest.py @nnennandukwe
+/scripts/oss_readiness_check.py @nnennandukwe
+/scripts/sync_github_labels.py @nnennandukwe
+/scripts/install.sh @nnennandukwe
+/scripts/install.ps1 @nnennandukwe
+/src/policynim/interfaces/cli.py @nnennandukwe
+/src/policynim/interfaces/mcp.py @nnennandukwe
+/docs/release.md @nnennandukwe
+/docs/public-launch-runbook.md @nnennandukwe
+/SECURITY.md @nnennandukwe

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report reproducible PolicyNIM CLI, MCP, install, or runtime behavior.
+title: "[Bug]: "
+labels: ["type/bug", "status/needs-triage", "needs/support-bundle"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a PolicyNIM issue. Do not paste API keys, bearer
+        tokens, hosted beta tokens, or private policy content.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - CLI
+        - MCP stdio
+        - Hosted MCP streamable-http
+        - Hosted beta portal
+        - Install or release artifact
+        - Runtime evidence
+        - Docs
+    validations:
+      required: true
+  - type: textarea
+    id: support_bundle
+    attributes:
+      label: policynim support-bundle output
+      description: Run `policynim support-bundle` and paste redacted output. The bundle includes `policynim doctor` diagnostics and redacts local path prefixes by default. For local MCP stdio issues, run `policynim support-bundle --include-mcp-smoke`. Use `--include-local-paths` only in private maintainer triage.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: mcp_config
+    attributes:
+      label: MCP config evidence
+      description: For hosted MCP issues, paste redacted `policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json` output and include the `hosted_url_placeholder` value. For local stdio issues, include the matching local `mcp-config` JSON when client setup is involved.
+      render: json
+    validations:
+      required: false
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Include exact commands, install channel, and MCP transport if relevant.
+      placeholder: |
+        1. Install with ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Redact tokens and private policy content before pasting logs.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: live
+    attributes:
+      label: Did this call live or hosted services?
+      options:
+        - No, offline/local only
+        - Yes, NVIDIA-hosted API
+        - Yes, hosted MCP or beta portal
+        - Yes, Docker or Railway
+        - Not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support questions
+    url: https://github.com/nnennandukwe/policyNIM/blob/main/SUPPORT.md
+    about: Read support routing and issue evidence expectations before opening a report.
+  - name: Security vulnerability
+    url: https://github.com/nnennandukwe/policyNIM/security/advisories/new
+    about: Report suspected credential, token, hosted MCP, or release security issues privately.
+  - name: Community standards
+    url: https://github.com/nnennandukwe/policyNIM/blob/main/CODE_OF_CONDUCT.md
+    about: Review conduct and enforcement expectations for project participation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Propose a PolicyNIM workflow, CLI, MCP, docs, or release improvement.
+title: "[Feature]: "
+labels: ["type/feature", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        PolicyNIM prioritizes verifiable agent workflows, fail-closed behavior,
+        and docs that match command output.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Primary surface
+      options:
+        - CLI
+        - MCP
+        - Hosted beta
+        - Installability
+        - Runtime evidence
+        - Docs
+        - CI or release
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What developer or maintainer workflow is blocked or slow?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Include example commands, MCP calls, or docs shape where useful.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How should this be verified?
+      description: Name deterministic tests, `doctor`, MCP smoke, docs parity, or opt-in live gates.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/public_launch_evidence.yml
+++ b/.github/ISSUE_TEMPLATE/public_launch_evidence.yml
@@ -1,0 +1,55 @@
+name: Public Launch Evidence
+description: Attach reviewed external proof before claiming PolicyNIM is public-ready.
+title: "[Launch Evidence]: "
+labels: ["type/launch", "status/needs-triage", "needs/launch-evidence"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when a release, PR, or launch note claims public readiness.
+        Do not paste tokens, private policy content, or unredacted client transcripts.
+  - type: input
+    id: release_tag
+    attributes:
+      label: Release tag
+      description: Name the release tag or candidate under review, for example v0.1.0.
+      placeholder: v0.1.0
+    validations:
+      required: true
+  - type: textarea
+    id: strict_public
+    attributes:
+      label: Strict public readiness output
+      description: Paste `uv run python scripts/release_check.py --strict-public --external-evidence-file docs/launch-evidence.json --format json` output or the failing summary.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: launch_issue
+    attributes:
+      label: Generated launch issue
+      description: Paste the current `uv run python scripts/oss_readiness_check.py --external-evidence-file docs/launch-evidence.json --format launch-issue` output.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_records
+    attributes:
+      label: Attached evidence records
+      description: List completed proof from `scripts/collect_launch_evidence.py`, including GitHub release artifacts, attestations, PyPI, hosted MCP, hosted smoke, labels/topics, and real MCP client-session records.
+      placeholder: |
+        - github_release_artifacts: ...
+        - pypi_install_smoke: ...
+        - real_mcp_client_session: ...
+    validations:
+      required: true
+  - type: textarea
+    id: remaining_proof
+    attributes:
+      label: Remaining external proof
+      description: List any checks still marked `missing_external` or explain why this issue should stay blocked.
+      placeholder: |
+        - github_artifact_attestations: waiting on Release workflow attestation
+        - hosted_beta_live_smoke: waiting on hosted deployment secret
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+## Summary
+
+Describe the CLI, MCP, docs, release, or runtime workflow this changes.
+
+## PR Lane
+
+Choose one primary lane from
+[docs/oss-readiness-audit.md#high-value-pr-sequence](../docs/oss-readiness-audit.md#high-value-pr-sequence).
+Keep the PR scoped to one user-facing thesis, one primary evidence surface, and
+a bounded rollback story.
+
+- [ ] First-run and hosted MCP onboarding
+- [ ] Local CLI and MCP verification loop
+- [ ] Installability and release trust
+- [ ] SQLite migration and storage contract
+- [ ] Maintainer trust and public launch proof
+- [ ] Other: explain why this does not fit one high-value lane.
+
+## Verification
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run pyright`
+- [ ] `uv run pytest -q -m "not live and not docker_live"`
+- [ ] `uv lock --check`
+- [ ] `uv build --out-dir dist`
+- [ ] `uv run policynim doctor --format json`
+- [ ] `uv run policynim support-bundle`
+- [ ] Release-affecting change: `uv run python scripts/release_check.py`
+- [ ] Public launch evidence changed or claimed:
+      `uv run python scripts/oss_readiness_check.py --format launch-issue`
+- [ ] Public launch is claimed ready:
+      `uv run python scripts/release_check.py --strict-public --external-evidence-file docs/launch-evidence.json`
+
+## User-Facing Evidence
+
+Include command output or screenshots for changed CLI, MCP, hosted beta, docs,
+or release behavior. If a listed check was skipped, explain why. For local MCP
+`stdio` changes, include `uv run policynim support-bundle --include-mcp-smoke`.
+When CI has run, reviewers can also inspect the `package-smoke-evidence`
+artifact; it includes `policynim-mcp-smoke.json`, generated MCP client config,
+doctor output, primary command help (`init --help`, `ingest --help`, and
+`preflight --help`), support-bundle output, local OSS-readiness JSON, and the
+paste-ready launch issue from the clean wheel install.
+
+## Live Or Hosted Checks
+
+- [ ] No live NVIDIA, Docker, hosted MCP, or Railway check is required.
+- [ ] Live or hosted check was required and the exact command/result is included.
+- [ ] Public launch proof is not being claimed, or strict public readiness returned
+      `public_ready`. If it returned `hold_external_missing`, list the remaining
+      external proof points instead of presenting the PR as launch-ready.
+
+## Safety
+
+- [ ] No API keys, bearer tokens, generated beta tokens, or private policy
+      corpus content are included.
+- [ ] Docs match the current command output and install channel state.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "surface/install-release"
+      - "surface/ci"
+      - "needs/codeowner-review"
+      - "status/needs-triage"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "surface/ci"
+      - "needs/codeowner-review"
+      - "status/needs-triage"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,99 @@
+# PolicyNIM issue and PR label taxonomy.
+# Apply these labels in GitHub before broad public triage; this file is the
+# repository source of truth even if label sync is manual at first.
+
+- name: type/bug
+  color: "d73a4a"
+  description: Reproducible broken behavior in CLI, MCP, install, hosted beta, or runtime flows.
+
+- name: type/feature
+  color: "a2eeef"
+  description: Request for a new or expanded user-facing workflow.
+
+- name: type/docs
+  color: "0075ca"
+  description: Documentation, examples, README, or release-note work.
+
+- name: type/launch
+  color: "bfdadc"
+  description: Public launch evidence review for release, PyPI, hosted MCP, and client proof.
+
+- name: type/security
+  color: "b60205"
+  description: Public placeholder only; private security reports use GitHub advisories.
+
+- name: status/needs-triage
+  color: "fbca04"
+  description: Maintainer has not yet routed priority, surface, or required evidence.
+
+- name: status/needs-repro
+  color: "fef2c0"
+  description: Maintainer needs a smaller reproduction, command output, or refreshed support bundle.
+
+- name: status/blocked-external
+  color: "cccccc"
+  description: Waiting on external service state such as PyPI, Railway, GitHub, Docker, or NVIDIA.
+
+- name: status/accepted
+  color: "0e8a16"
+  description: Maintainer agrees the issue or proposal is in scope.
+
+- name: priority/p0
+  color: "b60205"
+  description: Security, release integrity, install breakage, or data-leak risk.
+
+- name: priority/p1
+  color: "d93f0b"
+  description: Blocks first-run CLI, MCP setup, release gates, or core verification workflows.
+
+- name: priority/p2
+  color: "fbca04"
+  description: Important rough edge that affects contributor or maintainer confidence.
+
+- name: surface/cli
+  color: "1d76db"
+  description: PolicyNIM command-line behavior, flags, help text, or output contracts.
+
+- name: surface/mcp-stdio
+  color: "5319e7"
+  description: Local stdio MCP server, client config, mcp-smoke, or local agent integration.
+
+- name: surface/hosted-mcp
+  color: "5319e7"
+  description: Hosted streamable-http MCP, beta portal, auth, health, or Railway deployment.
+
+- name: surface/install-release
+  color: "006b75"
+  description: Package install, standalone installers, release artifacts, checksums, or manifests.
+
+- name: surface/runtime-evidence
+  color: "0e8a16"
+  description: Runtime decision, execution, evidence report, or audit log workflows.
+
+- name: surface/ci
+  color: "c5def5"
+  description: CI, release workflow, offline/live gate, Pyright, Ruff, or test infrastructure.
+
+- name: surface/docs
+  color: "0075ca"
+  description: README, docs pages, examples, roadmap, support, or maintainer guidance.
+
+- name: needs/support-bundle
+  color: "fef2c0"
+  description: Needs policynim support-bundle output before maintainers can reproduce confidently.
+
+- name: needs/live-check
+  color: "fef2c0"
+  description: Needs explicit opt-in NVIDIA, hosted MCP, Docker, Railway, or PyPI evidence.
+
+- name: needs/launch-evidence
+  color: "fef2c0"
+  description: Needs external public-launch proof before launch-ready claims can be accepted.
+
+- name: needs/codeowner-review
+  color: "fef2c0"
+  description: Needs review from the listed CODEOWNERS path owner before merge.
+
+- name: good-first-issue
+  color: "7057ff"
+  description: Small, well-scoped change with deterministic verification and clear owner guidance.

--- a/.github/topics.yml
+++ b/.github/topics.yml
@@ -1,0 +1,15 @@
+# PolicyNIM repository topic taxonomy.
+# Keep this list aligned with README positioning, PyPI keywords, and OSS
+# discoverability. Apply with scripts/sync_github_topics.py only from an
+# authenticated maintainer session.
+
+- ai-agents
+- cli
+- code-quality
+- mcp
+- model-context-protocol
+- nvidia-nim
+- policy
+- preflight
+- python
+- verification

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ __pycache__/
 build/
 data/
 dist/
+docs/launch-evidence.json
+launch-notes/
 *.pyc
 .threadloop/state/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# PolicyNIM Community Standards
+
+PolicyNIM is an open-source verification tool for AI-coding-agent workflows.
+The project needs direct technical disagreement, but it also needs a review
+environment where maintainers and contributors can reason clearly about code,
+docs, releases, MCP workflows, hosted services, and security boundaries.
+
+## Expected Behavior
+
+- Be specific about the technical issue, command output, affected surface, and
+  verification evidence.
+- Respect contributor time by using the issue and pull request templates.
+- Redact API keys, bearer tokens, hosted beta tokens, private policy content,
+  and private runtime evidence before posting.
+- Assume maintainers may ask for deterministic reproduction steps before acting.
+- Keep disagreement focused on code, docs, tests, release artifacts, and user
+  workflows.
+
+## Unacceptable Behavior
+
+- Harassment, threats, discrimination, or personal attacks.
+- Publishing secrets, tokens, private policy content, private runtime evidence,
+  or another person's private information.
+- Repeatedly ignoring maintainer review requests, issue templates, or safety
+  guidance.
+- Misrepresenting live-service status, release state, security impact, or
+  verification results.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments; close issues; reject pull
+requests; block accounts; or escalate to GitHub when behavior threatens the
+project or its users. Enforcement decisions should be proportional to the impact
+on contributor safety, maintainer review, secret safety, and project integrity.
+
+Report conduct concerns privately through the maintainer contact listed in
+[SECURITY.md](SECURITY.md) when public discussion would expose private context;
+maintainers should keep enforcement notes specific and evidence-backed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to PolicyNIM
+
+PolicyNIM is a verification tool for AI-coding-agent workflows. Contributions
+should keep the public CLI, MCP tools, docs, and release gates easy to verify.
+
+## Before Opening a PR
+
+1. Read [docs/contributor-guide.md](docs/contributor-guide.md) for local setup.
+2. Run `uv run policynim doctor --format json` and fix any setup issues it
+   reports.
+3. Run the offline quality gates:
+
+```bash
+uv run ruff check .
+uv run pyright
+uv run pytest -q -m "not live and not docker_live"
+uv lock --check
+uv build --out-dir dist
+uv run policynim support-bundle
+```
+
+4. If your change affects MCP setup, also check the relevant hosted-first client
+   example under [examples/](examples).
+5. If your change affects packaging, installers, or release automation, run
+   `uv run python scripts/release_check.py` and attach the ship/hold output.
+
+## What To Include
+
+- Explain the user-facing workflow you changed.
+- Choose one primary lane from
+  [docs/oss-readiness-audit.md#high-value-pr-sequence](docs/oss-readiness-audit.md#high-value-pr-sequence):
+  first-run and hosted MCP onboarding, local CLI and MCP verification,
+  installability and release trust, SQLite migration and storage contract, or
+  maintainer trust and public launch proof.
+- Keep the PR scoped to one user-facing thesis, one primary evidence surface,
+  and a bounded rollback story.
+- Include exact commands and test output, not just "tests pass."
+- Call out whether live NVIDIA, hosted beta, Docker, or Railway checks were not
+  run.
+- For CLI or MCP changes, include the relevant `--help`, `policynim doctor`, or
+  `policynim support-bundle` output.
+- No API keys, bearer tokens, generated hosted beta tokens, or private policy
+  corpus content should appear in issues, pull requests, screenshots, or logs.
+
+## Live And Hosted Checks
+
+Default CI is offline. Live NVIDIA, hosted MCP, and Docker checks are opt-in so
+pull requests stay reproducible for outside contributors. See
+[tests/README.md](tests/README.md) for the exact environment variables and
+commands.
+
+## Dependency And Ownership Updates
+
+PolicyNIM keeps review ownership in [.github/CODEOWNERS](.github/CODEOWNERS)
+and bounded weekly dependency updates in
+[.github/dependabot.yml](.github/dependabot.yml). Dependabot PRs are not
+auto-merge candidates. Treat updates to `uv.lock`, GitHub Actions, installers,
+release scripts, and MCP entrypoints as code changes that need deterministic
+offline gates and code-owner review before merge.
+
+## Review Bar
+
+Maintainer trust matters more than broad feature claims. Prefer small,
+evidence-backed changes with clear recovery behavior, deterministic tests, and
+docs that match the actual command output.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+PolicyNIM handles local configuration, API keys, hosted MCP bearer tokens, and
+runtime evidence artifacts. Please report security issues privately instead of
+opening a public issue.
+
+## Reporting A Vulnerability
+
+Email the maintainer listed in [pyproject.toml](pyproject.toml) or open a
+private GitHub security advisory if repository access allows it.
+
+Include:
+
+- affected version, commit, install channel, and operating system
+- whether the issue affects CLI, MCP `stdio`, hosted `streamable-http`, the
+  hosted beta portal, release installers, or runtime evidence
+- minimal reproduction steps without secrets
+- whether credentials, policy content, runtime evidence, or hosted beta tokens
+  may have been exposed
+
+Do not include real `NVIDIA_API_KEY` values, hosted bearer tokens, generated beta
+tokens, or private policy documents. Redact secrets before attaching logs.
+
+## Supported Versions
+
+PolicyNIM is currently pre-1.0. Security fixes target `main` and the latest
+GitHub release unless a release note says otherwise.
+
+## Security-Relevant Local Checks
+
+For local setup diagnostics, run:
+
+```bash
+policynim doctor --format json
+```
+
+`doctor` reports config and artifact paths without calling NVIDIA-hosted APIs or
+printing configured secret values.
+
+## Supply Chain Stewardship
+
+PolicyNIM keeps sensitive path ownership in [.github/CODEOWNERS](.github/CODEOWNERS)
+and bounded weekly dependency update checks in
+[.github/dependabot.yml](.github/dependabot.yml). Dependency, installer,
+release, and GitHub Actions updates still need the offline gates and maintainer
+review before release; update bots do not replace security review.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,87 @@
+# PolicyNIM Support
+
+PolicyNIM support works best when reports include reproducible CLI, MCP,
+release, or hosted-beta evidence. Please do not paste API keys, bearer tokens,
+hosted beta tokens, private policy content, or private runtime evidence.
+`policynim support-bundle` redacts local path prefixes by default for public
+issues; use `--include-local-paths` only for private maintainer triage.
+
+## Where To Ask
+
+- Bugs: open a bug report and include `policynim support-bundle` output.
+- Local MCP stdio launch issues: run
+  `policynim support-bundle --include-mcp-smoke` and include the output.
+- Hosted MCP or hosted beta issues: include the hosted URL shape, the failing
+  client command, the `/healthz` status when available, and whether the failure
+  was `401`, insufficient context, upstream NVIDIA failure, or service
+  unavailable. For hosted MCP client setup issues, also include redacted
+  `policynim mcp-config --target hosted-http --client codex --hosted-url
+  'https://<host>/mcp' --format json` output and the `hosted_url_placeholder`
+  value.
+- Install or release artifact issues: include the installer command, platform,
+  asset name, checksum or `RELEASE_MANIFEST.json` evidence, and exact failure
+  output.
+- Public launch evidence: use the
+  [Public launch evidence](.github/ISSUE_TEMPLATE/public_launch_evidence.yml)
+  issue form when strict public readiness, generated launch issue output,
+  attached evidence records, or remaining external proof need maintainer review.
+- Feature requests: use the feature request template and name the CLI, MCP,
+  hosted beta, docs, runtime evidence, installability, or CI/release surface.
+
+Security issues belong in [SECURITY.md](SECURITY.md), not public issues.
+Maintainer triage labels and response rules live in
+[docs/maintainer-triage.md](docs/maintainer-triage.md).
+
+## Before Opening A Bug
+
+Run the lowest-risk diagnostics first:
+
+```bash
+policynim support-bundle
+```
+
+For source checkouts, use `uv run`:
+
+```bash
+uv run policynim support-bundle
+```
+
+Attach `policynim support-bundle` output to public issues. The bundle includes
+a `first_run` section with hosted MCP, local CLI, and local MCP quickstart
+targets plus each target's `quickstart_command`, so maintainers can route setup
+reports without asking for raw quickstart output. Keep raw `policynim doctor --format json` output local unless a maintainer asks for it in a private channel, because raw doctor output can include exact filesystem paths.
+
+If a maintainer asks for exact filesystem paths in a private channel, rerun:
+
+```bash
+policynim support-bundle --include-local-paths
+```
+
+For MCP stdio issues:
+
+```bash
+uv run policynim support-bundle --include-mcp-smoke
+```
+
+For hosted MCP client setup issues:
+
+```bash
+policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json
+```
+
+If the output reports `"hosted_url_placeholder": true`, replace the placeholder
+with the deployed `/mcp` URL before debugging auth, client, or service failures.
+
+## Issue Response Expectations
+
+PolicyNIM is pre-1.0. Maintainer priority goes to:
+
+1. security, secret exposure, token handling, and hosted MCP auth issues
+2. install failures, broken release artifacts, and checksum or manifest drift
+3. first-run setup failures in `init`, `doctor`, `support-bundle`, and
+   `mcp-smoke`
+4. deterministic CLI, MCP, runtime evidence, and CI gate regressions
+5. feature requests and roadmap discussion
+
+If a report cannot be reproduced from the supplied evidence, maintainers may ask
+for a smaller reproduction or a refreshed support bundle.

--- a/docs/launch-evidence.example.json
+++ b/docs/launch-evidence.example.json
@@ -1,0 +1,62 @@
+{
+  "github_artifact_attestations": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "github_labels_applied": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "github_topics_applied": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "github_release_artifacts": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "github_release_install_smoke": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "hosted_beta_live_smoke": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "hosted_mcp_domain": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "pypi_project": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "pypi_install_smoke": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  },
+  "real_mcp_client_session": {
+    "summary": "",
+    "reference": "",
+    "verified_by": "",
+    "verified_at": ""
+  }
+}

--- a/docs/maintainer-triage.md
+++ b/docs/maintainer-triage.md
@@ -1,0 +1,199 @@
+# PolicyNIM Maintainer Triage
+
+Use this guide to route public issues and pull requests without losing the
+evidence trail that makes PolicyNIM trustworthy as an MCP and CLI verification
+tool.
+
+## Label Source Of Truth
+
+The repository label taxonomy lives in [../.github/labels.yml](../.github/labels.yml).
+Preview the GitHub label sync plan before opening broad public triage:
+
+```bash
+uv run python scripts/sync_github_labels.py --format json
+```
+
+Compare the checked-in taxonomy against live GitHub labels without changing
+anything:
+
+```bash
+uv run python scripts/sync_github_labels.py --live --format json
+```
+
+Apply the taxonomy only from an authenticated maintainer session with label
+write access:
+
+```bash
+gh auth status
+uv run python scripts/sync_github_labels.py --apply --format json
+```
+
+If `gh` is missing or not authenticated, the sync command fails without a
+traceback and tells the maintainer to install GitHub CLI, run `gh auth status`,
+rerun `--live` to inspect the GitHub delta, and use `--apply` only when ready
+to mutate labels.
+
+Do not invent one-off labels when a listed label already fits.
+
+Start every new public issue with:
+
+- one `type/*` label
+- one or more `surface/*` labels
+- one `priority/*` label after the maintainer understands blast radius
+- `status/needs-triage` until the report has enough evidence to route
+
+Use `needs/launch-evidence` when an issue or PR claims public launch readiness
+but still needs strict public launch evidence, such as GitHub artifact proof,
+artifact attestation verification, PyPI trusted-publishing evidence, hosted MCP
+domain proof, Hosted Beta Smoke output, applied labels/topics, or a real MCP
+client-session record.
+
+Use `type/launch` with
+[../.github/ISSUE_TEMPLATE/public_launch_evidence.yml](../.github/ISSUE_TEMPLATE/public_launch_evidence.yml)
+for public launch evidence reviews. The Public launch evidence form asks for the
+strict public readiness result, the generated launch issue, attached evidence
+records, and any remaining external proof so launch claims stay reviewable
+without mixing them into bug or feature reports.
+
+## Topic Source Of Truth
+
+The repository discoverability topics live in
+[../.github/topics.yml](../.github/topics.yml). Preview the topic sync plan
+before broad public promotion:
+
+```bash
+uv run python scripts/sync_github_topics.py --format json
+```
+
+Compare the checked-in taxonomy against live GitHub topics without changing
+anything:
+
+```bash
+uv run python scripts/sync_github_topics.py --live --format json
+```
+
+Apply topics only from an authenticated maintainer session with repository
+metadata write access:
+
+```bash
+gh auth status
+uv run python scripts/sync_github_topics.py --apply --format json
+```
+
+If `gh` is missing or not authenticated, the sync command fails without a
+traceback and tells the maintainer to install GitHub CLI, run `gh auth status`,
+rerun `--live` to inspect the GitHub delta, and use `--apply` only when ready
+to mutate topics.
+
+Keep topics aligned with README positioning and PyPI package keywords. Do not
+add hosted-health or public-ready topics until strict public launch evidence
+proves those claims.
+
+## Ownership And Dependency Updates
+
+The review ownership map lives in [../.github/CODEOWNERS](../.github/CODEOWNERS).
+Use `needs/codeowner-review` when a PR touches release automation, installers,
+security reporting, public MCP surfaces, or dependency-update configuration and
+the listed owner has not reviewed it yet.
+
+The dependency update policy lives in
+[../.github/dependabot.yml](../.github/dependabot.yml). Dependabot is allowed to
+open bounded weekly PRs for the `uv` dependency graph and GitHub Actions. Treat
+those PRs as normal code changes: require offline CI, code-owner review when
+the changed path is owned, and `uv run python scripts/release_check.py` before
+merging updates that affect install, release, or workflow behavior.
+
+## Evidence First
+
+For bugs, ask for:
+
+- `policynim support-bundle`
+- the bundle's `first_run` target summary when the report involves hosted MCP,
+  local CLI, or local MCP setup
+- exact install channel or source checkout command
+- exact CLI command, MCP client command, hosted URL shape, or release artifact
+- whether live NVIDIA, hosted MCP, Docker, Railway, or PyPI was involved
+
+For local MCP stdio issues, prefer:
+
+```bash
+policynim support-bundle --include-mcp-smoke
+policynim mcp-config --client codex --format json
+```
+
+Support bundles redact local path prefixes by default. Ask for exact paths only
+in private maintainer triage, using:
+
+```bash
+policynim support-bundle --include-local-paths
+```
+
+For source checkouts, ask reporters to use `uv run` for both commands and add
+`--repo-root /ABS/PATH/TO/policyNIM` when the checkout is not auto-detected.
+
+For hosted MCP client setup issues, ask for redacted generated config:
+
+```bash
+policynim mcp-config --target hosted-http --client codex --hosted-url 'https://<host>/mcp' --format json
+```
+
+If `hosted_url_placeholder` is `true`, route the report to setup guidance first:
+the client is still configured with an example or placeholder URL, not the
+deployed `/mcp` endpoint.
+
+## Priority Rules
+
+Use `priority/p0` for:
+
+- private data, API key, bearer token, hosted beta token, or policy-content leaks
+- release artifact, checksum, installer, or `RELEASE_MANIFEST.json` integrity
+  failures
+- install paths that fail before `policynim --help`, `doctor`, or
+  `support-bundle` can run
+
+Use `priority/p1` for:
+
+- first-run setup regressions in `init`, `doctor`, `support-bundle`,
+  `mcp-smoke`, or `mcp-config`
+- local or hosted MCP regressions that block `policy_preflight` or
+  `policy_search`
+- CI or release gate drift that could ship unverified artifacts
+
+Use `priority/p2` for:
+
+- docs drift, unclear recovery guidance, and non-blocking UX issues
+- feature requests that improve verification but do not block current workflows
+
+## Surface Routing
+
+- CLI command, flag, help, JSON, or exit-code issues: `surface/cli`
+- Local MCP launch, generated config, or stdio client behavior:
+  `surface/mcp-stdio`
+- Hosted MCP, beta portal, auth, `/healthz`, or Railway deployment:
+  `surface/hosted-mcp`
+- Install scripts, PyPI, release assets, checksums, or manifests:
+  `surface/install-release`
+- Runtime decision, execution, evidence, or audit logs:
+  `surface/runtime-evidence`
+- GitHub Actions, release automation, markers, Ruff, Pyright, or tests:
+  `surface/ci`
+- README, examples, support docs, roadmap, or maintainer policy:
+  `surface/docs`
+
+## Response Expectations
+
+Within maintainer capacity:
+
+- P0: acknowledge quickly, move security-sensitive details to private advisory
+  handling, and avoid asking reporters to paste secrets publicly
+- P1: request missing deterministic evidence or reproduce from the supplied
+  commands before accepting
+- P2: keep scope narrow and ask for verification evidence before implementation
+
+When evidence is incomplete, use `status/needs-repro` and ask for the smallest
+command sequence that reproduces the behavior. When progress depends on PyPI,
+Railway, Docker, NVIDIA, GitHub Actions state, or another external service, use
+`status/blocked-external` and name the external dependency in the issue.
+For public launch claims, also use `needs/launch-evidence` until
+`scripts/release_check.py --strict-public --external-evidence-file
+docs/launch-evidence.json` returns `public_ready`.

--- a/docs/mcp-client-evidence.example.json
+++ b/docs/mcp-client-evidence.example.json
@@ -1,0 +1,13 @@
+{
+  "client": "codex",
+  "transport": "hosted-http",
+  "server_name": "policynim",
+  "setup_command": "",
+  "tools": [
+    "policy_preflight",
+    "policy_search"
+  ],
+  "called_tool": "policy_preflight",
+  "reference": "",
+  "secrets_included": false
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+# PolicyNIM Roadmap
+
+This roadmap describes the current public direction without promising dates.
+PolicyNIM should earn adoption through reliable install paths, useful first-run
+diagnostics, verifiable MCP workflows, deterministic release gates, and clear
+maintainer expectations.
+
+## Now
+
+- Keep the hosted-first MCP examples current for Codex and Claude Code.
+- Keep `policynim quickstart`, `policynim doctor`, `policynim support-bundle`,
+  and `policynim mcp-smoke` aligned with the real first-run experience.
+- Keep generated-config MCP smoke working so local Codex and Claude Code stdio
+  configs can be handshaked before users paste them into a client.
+- Keep CI offline by default with Ruff, Pyright, live/Docker marker exclusion,
+  package build, clean wheel install smoke, and release manifest checks.
+- Keep GitHub release artifacts tied to `SHA256SUMS` and
+  `RELEASE_MANIFEST.json`.
+- Keep `scripts/oss_readiness_check.py` green so maintainers can distinguish
+  local readiness from missing external launch proof.
+- Keep `.github/CODEOWNERS` and `.github/dependabot.yml` aligned with release,
+  installer, MCP, and CI ownership risk.
+- Keep `scripts/sync_github_labels.py` as the offline dry-run, live dry-run,
+  and apply path for label taxonomy maintenance.
+- Keep `.github/topics.yml` and `scripts/sync_github_topics.py` aligned with
+  the MCP + CLI verification positioning before public promotion, with live
+  dry-run checks before apply.
+- Keep PyPI package installs documented while treating trusted-publishing
+  evidence and clean public install smoke as separate public-launch proof
+  points.
+
+## Next
+
+- Publish and verify the first public GitHub release artifact set.
+- Run `scripts/oss_readiness_check.py --strict-public --format json` before the
+  first broad public launch, and attach the resulting external proof status to
+  the launch issue or release notes using `docs/public-launch-runbook.md`.
+- Attach PyPI trusted-publishing evidence for the current tag so package
+  availability and release-workflow provenance are both reviewable.
+- Attach clean PyPI install smoke evidence for the current tag so the public
+  package path proves first-run CLI behavior.
+- Tighten Hosted beta smoke evidence so `/healthz`, `policy_search`, and
+  `policy_preflight` promotion status is easy to attach to release decisions.
+- Refine the applied `.github/labels.yml` taxonomy after the first external
+  issue flow shows which buckets contributors actually use.
+- Refine the applied `.github/topics.yml` taxonomy after search, install, and
+  issue traffic shows which discoverability channels are working.
+
+## Later
+
+- Broaden the sample policy corpus without weakening citation grounding.
+- Keep README's bounded public metadata badges current, and add hosted health and
+  public-ready badges only when they reflect stable, meaningful checks.
+- Expand maintained client examples beyond Codex and Claude Code when there is
+  evidence of real user demand.
+- Add observability around hosted MCP usage, upstream provider failures, and
+  first-run support-bundle patterns.
+
+## Not committed yet
+
+- Enterprise policy corpus hosting.
+- A hosted multi-tenant admin console beyond the current beta portal.
+- A default-on live NVIDIA CI gate.
+- A full compatibility matrix for every MCP client.
+- A release date for 1.0.

--- a/scripts/collect_launch_evidence.py
+++ b/scripts/collect_launch_evidence.py
@@ -1,0 +1,3244 @@
+"""Collect opt-in external launch evidence for PolicyNIM public readiness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[0]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from sync_github_labels import LabelSyncError, load_label_taxonomy, plan_label_sync  # noqa: E402
+from sync_github_topics import TopicSyncError, load_topic_taxonomy, plan_topic_sync  # noqa: E402
+
+GITHUB_RELEASE_FIELDS = "assets,isDraft,isPrerelease,publishedAt,tagName,targetCommitish,url"
+GITHUB_RUN_FIELDS = "conclusion,event,headSha,jobs,name,status,url,workflowName"
+HOSTED_SMOKE_ARTIFACT_NAME = "hosted-smoke-evidence"
+HOSTED_SMOKE_JUNIT_FILENAME = "policynim-hosted-smoke-junit.xml"
+RELEASE_METADATA_ASSET_NAMES = ("RELEASE_MANIFEST.json", "SHA256SUMS")
+EXTERNAL_CHECK_NAMES = {
+    "github_artifact_attestations",
+    "github_release_install_smoke",
+    "github_release_artifacts",
+    "pypi_install_smoke",
+    "pypi_project",
+    "hosted_mcp_domain",
+    "hosted_beta_live_smoke",
+    "github_labels_applied",
+    "github_topics_applied",
+    "real_mcp_client_session",
+}
+EVIDENCE_RECORD_FIELDS = ("summary", "reference", "verified_by", "verified_at")
+PLACEHOLDER_REFERENCE_MARKERS = (
+    "<",
+    ">",
+    "example.",
+    "example/",
+    ".invalid",
+    "todo",
+    "placeholder",
+)
+_EXPECTED_HOSTED_SMOKE_TESTS = (
+    "test_hosted_healthz_reports_ready_index_live",
+    "test_hosted_mcp_lists_tools_live",
+    "test_hosted_policy_search_live",
+    "test_hosted_policy_preflight_live",
+    "test_hosted_mcp_rejects_invalid_token_live",
+)
+PYPI_PROJECT_NAME = "policynim"
+_MERGE_INVALIDATING_PROBE_STATUSES = {
+    "command_failed",
+    "draft_release",
+    "invalid_first_run_contract",
+    "invalid_json",
+    "label_drift",
+    "metadata_download_failed",
+    "missing_first_run_command",
+    "missing_assets",
+    "missing_release_reference",
+    "release_view_failed",
+    "release_view_invalid_json",
+    "release_metadata_invalid",
+    "release_metadata_missing",
+    "topic_drift",
+}
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+UrlOpener = Callable[..., Any]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root to inspect. Defaults to this script's repository.",
+    )
+    parser.add_argument(
+        "--release-tag",
+        default="",
+        help="Release tag to inspect. Defaults to v<pyproject version>.",
+    )
+    parser.add_argument(
+        "--verified-by",
+        default=os.environ.get("USER", "local-maintainer"),
+        help="Verifier identity to place on machine-verified evidence records.",
+    )
+    parser.add_argument(
+        "--pypi-publish-run-url",
+        default="",
+        help=(
+            "Optional GitHub Actions run URL or run id for the Release workflow "
+            "that published to PyPI. When set with matching public PyPI JSON, "
+            "the collector verifies the publish-pypi job completed successfully "
+            "before filling pypi_project evidence."
+        ),
+    )
+    parser.add_argument(
+        "--pypi-install-smoke",
+        action="store_true",
+        help=(
+            "Install policynim==<release version> from public PyPI in a clean "
+            "virtualenv and run first-run help, quickstart JSON, support-bundle "
+            "JSON, doctor JSON, and local MCP config JSON before filling "
+            "pypi_install_smoke evidence."
+        ),
+    )
+    parser.add_argument(
+        "--github-install-smoke",
+        action="store_true",
+        help=(
+            "Install the GitHub release with the published install.sh in a clean "
+            "HOME and run first-run help, quickstart JSON, support-bundle JSON, "
+            "doctor JSON, and local MCP config JSON before filling "
+            "github_release_install_smoke evidence."
+        ),
+    )
+    parser.add_argument(
+        "--release-attestation-asset-name",
+        default="",
+        help=(
+            "Optional release asset filename to download and verify with "
+            "`gh attestation verify`. When set, the collector fills "
+            "github_artifact_attestations evidence only after verification passes."
+        ),
+    )
+    parser.add_argument(
+        "--hosted-mcp-url",
+        default="",
+        help=(
+            "Optional public hosted MCP /mcp URL. When set, the collector calls "
+            "the same-origin /healthz route and verifies /mcp rejects an invalid "
+            "bearer token."
+        ),
+    )
+    parser.add_argument(
+        "--hosted-smoke-run-url",
+        default="",
+        help=(
+            "Optional GitHub Actions run URL or run id for the Hosted Beta Smoke "
+            "workflow. When set, the collector verifies the run completed "
+            "successfully and validates the hosted-smoke-evidence JUnit artifact "
+            "before filling hosted_beta_live_smoke evidence."
+        ),
+    )
+    parser.add_argument(
+        "--mcp-client-evidence-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional reviewed JSON record from a real Codex or Claude Code MCP "
+            "session. When set, the collector validates the client, transport, "
+            "setup command, tool list, policy_preflight call, reference, and "
+            "redaction claim before filling real_mcp_client_session evidence."
+        ),
+    )
+    parser.add_argument(
+        "--write-mcp-client-evidence-template",
+        type=Path,
+        default=None,
+        help=(
+            "Write a safe MCP client-session evidence JSON template with blank "
+            "setup_command and reference fields, then exit without running live probes."
+        ),
+    )
+    parser.add_argument(
+        "--write-mcp-client-evidence-record",
+        type=Path,
+        default=None,
+        help=(
+            "Write a completed MCP client-session evidence JSON record after "
+            "supplying --mcp-client-reference plus either --mcp-client-setup-command "
+            "or --mcp-client-hosted-url, "
+            "then exit without running live probes."
+        ),
+    )
+    parser.add_argument(
+        "--mcp-client-template-client",
+        choices=("codex", "claude-code"),
+        default="codex",
+        help="Client value to place in MCP client evidence template or record output.",
+    )
+    parser.add_argument(
+        "--mcp-client-template-transport",
+        choices=("hosted-http", "local-stdio"),
+        default="hosted-http",
+        help="Transport value to place in MCP client evidence template or record output.",
+    )
+    parser.add_argument(
+        "--mcp-client-reference",
+        default="",
+        help=(
+            "Sanitized transcript, screenshot, issue, or release-note reference "
+            "to place in --write-mcp-client-evidence-record output."
+        ),
+    )
+    parser.add_argument(
+        "--mcp-client-setup-command",
+        default="",
+        help=(
+            "Secret-safe MCP client setup command used in the reviewed real client "
+            "session, for example the generated Codex or Claude Code add command."
+        ),
+    )
+    parser.add_argument(
+        "--mcp-client-hosted-url",
+        default="",
+        help=(
+            "Hosted /mcp URL used to generate the secret-safe setup command for "
+            "--write-mcp-client-evidence-record when the transport is hosted-http."
+        ),
+    )
+    parser.add_argument(
+        "--write-external-evidence-file",
+        type=Path,
+        default=None,
+        help=(
+            "Write only the external evidence object accepted by "
+            "scripts/oss_readiness_check.py --external-evidence-file."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow --write-external-evidence-file to overwrite an existing file.",
+    )
+    parser.add_argument(
+        "--merge-existing",
+        action="store_true",
+        help=(
+            "When --write-external-evidence-file already exists, preserve existing "
+            "nonblank records for checks this run could not verify."
+        ),
+    )
+    parser.add_argument(
+        "--require-requested-probes",
+        action="store_true",
+        help=(
+            "Exit non-zero when any explicitly requested external probe does not "
+            "pass. Defaults to partial evidence collection."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format for the collection report.",
+    )
+    args = parser.parse_args()
+    if args.write_external_evidence_file is not None and args.force and args.merge_existing:
+        parser.error("--force and --merge-existing cannot be combined.")
+    if args.write_mcp_client_evidence_template is not None and args.merge_existing:
+        parser.error("--merge-existing is only valid with --write-external-evidence-file.")
+    if args.write_mcp_client_evidence_record is not None and args.merge_existing:
+        parser.error("--merge-existing is only valid with --write-external-evidence-file.")
+    if (
+        args.write_mcp_client_evidence_template is not None
+        and args.write_mcp_client_evidence_record is not None
+    ):
+        parser.error(
+            "--write-mcp-client-evidence-template and "
+            "--write-mcp-client-evidence-record cannot be combined."
+        )
+    if args.write_mcp_client_evidence_template is not None:
+        return write_mcp_client_evidence_template(
+            args.write_mcp_client_evidence_template,
+            client=args.mcp_client_template_client,
+            transport=args.mcp_client_template_transport,
+            force=args.force,
+        )
+    if args.write_mcp_client_evidence_record is not None:
+        return write_mcp_client_evidence_record(
+            args.write_mcp_client_evidence_record,
+            client=args.mcp_client_template_client,
+            transport=args.mcp_client_template_transport,
+            setup_command=args.mcp_client_setup_command,
+            hosted_mcp_url=args.mcp_client_hosted_url,
+            reference=args.mcp_client_reference,
+            force=args.force,
+        )
+    if (
+        args.write_external_evidence_file is not None
+        and args.write_external_evidence_file.exists()
+        and not args.force
+        and not args.merge_existing
+    ):
+        print(
+            f"Error: {_existing_evidence_file_error(args.write_external_evidence_file)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo_root = args.repo_root.resolve()
+    release_tag = args.release_tag.strip() or _default_release_tag(repo_root)
+    payload = collect_launch_evidence(
+        repo_root=repo_root,
+        release_tag=release_tag,
+        verified_by=args.verified_by.strip() or "local-maintainer",
+        verified_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        pypi_payload=_fetch_pypi_payload(),
+        pypi_publish_run_url=args.pypi_publish_run_url,
+        pypi_install_smoke=args.pypi_install_smoke,
+        github_install_smoke=args.github_install_smoke,
+        release_attestation_asset_name=args.release_attestation_asset_name,
+        hosted_mcp_url=args.hosted_mcp_url,
+        hosted_smoke_run_url=args.hosted_smoke_run_url,
+        mcp_client_evidence_file=args.mcp_client_evidence_file,
+    )
+    requested_probe_failures = _requested_probe_failures(
+        payload,
+        requested_probe_names=_requested_probe_names(args),
+    )
+    if args.require_requested_probes and requested_probe_failures:
+        payload["requested_probe_failures"] = requested_probe_failures
+
+    if args.write_external_evidence_file is not None:
+        write_mode = _evidence_write_mode(
+            args.write_external_evidence_file,
+            merge_existing=args.merge_existing,
+        )
+        write_result = write_evidence_file(
+            args.write_external_evidence_file,
+            evidence=payload["evidence"],
+            force=args.force,
+            merge_existing=args.merge_existing,
+            probes=payload["probes"],
+            emit_message=args.format != "json",
+        )
+        if write_result != 0:
+            return write_result
+        payload["external_evidence_file"] = {
+            "path": str(args.write_external_evidence_file),
+            "mode": write_mode,
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2))
+        else:
+            print(_render_text(payload))
+        return 1 if args.require_requested_probes and requested_probe_failures else 0
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_render_text(payload))
+    return 1 if args.require_requested_probes and requested_probe_failures else 0
+
+
+def collect_launch_evidence(
+    *,
+    repo_root: Path,
+    release_tag: str,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner | None = None,
+    pypi_payload: dict[str, Any] | None = None,
+    pypi_publish_run_url: str = "",
+    pypi_install_smoke: bool = False,
+    github_install_smoke: bool = False,
+    release_attestation_asset_name: str = "",
+    hosted_mcp_url: str = "",
+    hosted_smoke_run_url: str = "",
+    mcp_client_evidence_file: Path | None = None,
+    urlopen: UrlOpener | None = None,
+) -> dict[str, Any]:
+    """Collect machine-verifiable launch facts without claiming manual proof."""
+    command_runner = runner or _run_command
+    evidence = blank_external_evidence()
+    probes: dict[str, dict[str, Any]] = {}
+
+    release_probe, release_record = _probe_github_release(
+        release_tag=release_tag,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["github_release_artifacts"] = release_probe
+    if release_record is not None:
+        evidence["github_release_artifacts"] = release_record
+
+    github_install_probe, github_install_record = _probe_github_release_install_smoke(
+        release_tag=release_tag,
+        requested=github_install_smoke,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["github_release_install_smoke"] = github_install_probe
+    if github_install_record is not None:
+        evidence["github_release_install_smoke"] = github_install_record
+
+    attestation_probe, attestation_record = _probe_github_artifact_attestation(
+        release_tag=release_tag,
+        asset_name=release_attestation_asset_name,
+        release_url=str(release_probe.get("reference", "")),
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["github_artifact_attestations"] = attestation_probe
+    if attestation_record is not None:
+        evidence["github_artifact_attestations"] = attestation_record
+
+    pypi_probe, pypi_record = _probe_pypi_project(
+        release_tag=release_tag,
+        release_target_commitish=str(release_probe.get("target_commitish", "")),
+        pypi_payload=pypi_payload,
+        pypi_publish_run_url=pypi_publish_run_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["pypi_project"] = pypi_probe
+    if pypi_record is not None:
+        evidence["pypi_project"] = pypi_record
+
+    pypi_install_probe, pypi_install_record = _probe_pypi_install_smoke(
+        release_tag=release_tag,
+        requested=pypi_install_smoke,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["pypi_install_smoke"] = pypi_install_probe
+    if pypi_install_record is not None:
+        evidence["pypi_install_smoke"] = pypi_install_record
+
+    labels_probe, labels_record = _probe_github_labels(
+        repo_root=repo_root,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["github_labels_applied"] = labels_probe
+    if labels_record is not None:
+        evidence["github_labels_applied"] = labels_record
+
+    topics_probe, topics_record = _probe_github_topics(
+        repo_root=repo_root,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["github_topics_applied"] = topics_probe
+    if topics_record is not None:
+        evidence["github_topics_applied"] = topics_record
+
+    hosted_probe, hosted_record = _probe_hosted_mcp_domain(
+        hosted_mcp_url=hosted_mcp_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+        urlopen=urlopen or urllib.request.urlopen,
+    )
+    probes["hosted_mcp_domain"] = hosted_probe
+    if hosted_record is not None:
+        evidence["hosted_mcp_domain"] = hosted_record
+
+    smoke_probe, smoke_record = _probe_hosted_smoke_run(
+        hosted_smoke_run_url=hosted_smoke_run_url,
+        release_target_commitish=str(release_probe.get("target_commitish", "")),
+        verified_by=verified_by,
+        verified_at=verified_at,
+        runner=command_runner,
+    )
+    probes["hosted_beta_live_smoke"] = smoke_probe
+    if smoke_record is not None:
+        evidence["hosted_beta_live_smoke"] = smoke_record
+
+    client_probe, client_record = _probe_mcp_client_evidence_file(
+        mcp_client_evidence_file=mcp_client_evidence_file,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+    probes["real_mcp_client_session"] = client_probe
+    if client_record is not None:
+        evidence["real_mcp_client_session"] = client_record
+
+    return {
+        "schema_version": "1",
+        "generated_at": verified_at,
+        "release_tag": release_tag,
+        "evidence": evidence,
+        "probes": {name: probes[name] for name in sorted(probes)},
+    }
+
+
+def blank_external_evidence() -> dict[str, dict[str, str]]:
+    """Return a blank evidence object compatible with oss_readiness_check.py."""
+    return {
+        name: {field: "" for field in EVIDENCE_RECORD_FIELDS}
+        for name in sorted(EXTERNAL_CHECK_NAMES)
+    }
+
+
+def _requested_probe_names(args: argparse.Namespace) -> list[str]:
+    requested: list[str] = []
+    if str(args.release_attestation_asset_name).strip():
+        requested.append("github_artifact_attestations")
+    if str(args.pypi_publish_run_url).strip():
+        requested.append("pypi_project")
+    if bool(args.pypi_install_smoke):
+        requested.append("pypi_install_smoke")
+    if bool(args.github_install_smoke):
+        requested.append("github_release_install_smoke")
+    if str(args.hosted_mcp_url).strip():
+        requested.append("hosted_mcp_domain")
+    if str(args.hosted_smoke_run_url).strip():
+        requested.append("hosted_beta_live_smoke")
+    if args.mcp_client_evidence_file is not None:
+        requested.append("real_mcp_client_session")
+    return requested
+
+
+def _requested_probe_failures(
+    payload: dict[str, Any],
+    *,
+    requested_probe_names: list[str],
+) -> list[dict[str, str]]:
+    probes = payload.get("probes")
+    failures: list[dict[str, str]] = []
+    for name in requested_probe_names:
+        probe = probes.get(name) if isinstance(probes, dict) else None
+        if isinstance(probe, dict) and probe.get("status") == "passed":
+            continue
+        status = "missing_probe"
+        next_step = "Rerun the collector and inspect probe output for this requested proof."
+        if isinstance(probe, dict):
+            status = str(probe.get("status") or status)
+            next_step = str(probe.get("next_step") or next_step)
+        failures.append(
+            {
+                "name": name,
+                "status": status,
+                "next_step": next_step,
+            }
+        )
+    return failures
+
+
+def mcp_client_evidence_template(
+    *,
+    client: str = "codex",
+    transport: str = "hosted-http",
+) -> dict[str, Any]:
+    """Return a safe MCP client-session evidence template."""
+    if client not in {"codex", "claude-code"}:
+        raise ValueError("MCP client evidence template client must be codex or claude-code.")
+    if transport not in {"hosted-http", "local-stdio"}:
+        raise ValueError(
+            "MCP client evidence template transport must be hosted-http or local-stdio."
+        )
+    return {
+        "client": client,
+        "transport": transport,
+        "server_name": "policynim",
+        "setup_command": "",
+        "tools": list(_expected_mcp_tools()),
+        "called_tool": "policy_preflight",
+        "reference": "",
+        "secrets_included": False,
+    }
+
+
+def mcp_client_evidence_record(
+    *,
+    client: str = "codex",
+    transport: str = "hosted-http",
+    setup_command: str,
+    hosted_mcp_url: str = "",
+    reference: str,
+) -> dict[str, Any]:
+    """Return a completed MCP client-session evidence record."""
+    payload = mcp_client_evidence_template(client=client, transport=transport)
+    payload["setup_command"] = _resolve_mcp_client_setup_command(
+        client=client,
+        transport=transport,
+        setup_command=setup_command,
+        hosted_mcp_url=hosted_mcp_url,
+    )
+    payload["reference"] = reference.strip()
+    validation_error = _validate_mcp_client_evidence_payload(payload)
+    if validation_error is not None:
+        raise ValueError(validation_error["next_step"])
+    return payload
+
+
+def _resolve_mcp_client_setup_command(
+    *,
+    client: str,
+    transport: str,
+    setup_command: str,
+    hosted_mcp_url: str,
+) -> str:
+    raw_setup_command = setup_command.strip()
+    raw_hosted_url = hosted_mcp_url.strip()
+    if raw_hosted_url and transport != "hosted-http":
+        raise ValueError("--mcp-client-hosted-url is only valid with hosted-http transport.")
+    if raw_setup_command:
+        return raw_setup_command
+    if not raw_hosted_url:
+        return raw_setup_command
+
+    hosted_url = _normalize_hosted_mcp_url(raw_hosted_url)
+    if _contains_placeholder_reference(hosted_url):
+        raise ValueError("--mcp-client-hosted-url must be a real hosted /mcp URL.")
+    if client == "codex":
+        return f"codex mcp add policynim --url {hosted_url} --bearer-token-env-var POLICYNIM_TOKEN"
+    return (
+        f"claude mcp add --transport http policynim {hosted_url} "
+        '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+    )
+
+
+def write_mcp_client_evidence_template(
+    path: Path,
+    *,
+    client: str,
+    transport: str,
+    force: bool,
+) -> int:
+    """Write a safe client-session evidence template for maintainers to complete."""
+    if path.exists() and not force:
+        print(
+            f"Error: {path} already exists. Pass --force only when replacing a template.",
+            file=sys.stderr,
+        )
+        return 1
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = mcp_client_evidence_template(client=client, transport=transport)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote MCP client evidence template: {path}")
+    return 0
+
+
+def write_mcp_client_evidence_record(
+    path: Path,
+    *,
+    client: str,
+    transport: str,
+    setup_command: str,
+    hosted_mcp_url: str = "",
+    reference: str,
+    force: bool,
+) -> int:
+    """Write a completed client-session evidence record for maintainer review."""
+    if (
+        path.exists()
+        and not force
+        and not _is_replacable_mcp_client_template(
+            path,
+            client=client,
+            transport=transport,
+        )
+    ):
+        print(
+            (f"Error: {path} already exists. Pass --force only when replacing a nonblank record."),
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        payload = mcp_client_evidence_record(
+            client=client,
+            transport=transport,
+            setup_command=setup_command,
+            hosted_mcp_url=hosted_mcp_url,
+            reference=reference,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote MCP client evidence record: {path}")
+    return 0
+
+
+def _is_replacable_mcp_client_template(
+    path: Path,
+    *,
+    client: str,
+    transport: str,
+) -> bool:
+    try:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return existing == mcp_client_evidence_template(client=client, transport=transport)
+
+
+def expected_release_assets(release_tag: str) -> list[str]:
+    """Return the public release asset contract for a tag."""
+    version = release_tag.removeprefix("v")
+    return [
+        "RELEASE_MANIFEST.json",
+        "SHA256SUMS",
+        "install.ps1",
+        "install.sh",
+        f"policynim-{version}-py3-none-any.whl",
+        f"policynim-{version}.tar.gz",
+        f"policynim-{release_tag}-darwin-amd64.tar.gz",
+        f"policynim-{release_tag}-darwin-arm64.tar.gz",
+        f"policynim-{release_tag}-linux-amd64.tar.gz",
+        f"policynim-{release_tag}-windows-amd64.zip",
+    ]
+
+
+def expected_hosted_smoke_tests() -> tuple[str, ...]:
+    """Return the hosted live tests required for launch evidence."""
+    return _EXPECTED_HOSTED_SMOKE_TESTS
+
+
+def write_evidence_file(
+    path: Path,
+    *,
+    evidence: dict[str, dict[str, str]],
+    force: bool,
+    merge_existing: bool = False,
+    probes: dict[str, dict[str, Any]] | None = None,
+    emit_message: bool = True,
+) -> int:
+    """Write collected external evidence in the readiness-check input format."""
+    path_existed = path.exists()
+    output_evidence = evidence
+    if path_existed and merge_existing:
+        existing_evidence, error = _load_mergeable_evidence(path)
+        if error:
+            print(f"Error: {error}", file=sys.stderr)
+            return 1
+        output_evidence = _merge_external_evidence(
+            existing_evidence,
+            evidence,
+            probes=probes,
+        )
+    elif path_existed and not force:
+        print(
+            f"Error: {_existing_evidence_file_error(path)}",
+            file=sys.stderr,
+        )
+        return 1
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(output_evidence, indent=2) + "\n", encoding="utf-8")
+    if emit_message:
+        if merge_existing and path_existed:
+            print(f"Merged collected external evidence: {path}")
+        else:
+            print(f"Wrote collected external evidence: {path}")
+    return 0
+
+
+def _evidence_write_mode(path: Path, *, merge_existing: bool) -> str:
+    if merge_existing and path.exists():
+        return "merged"
+    return "written"
+
+
+def _existing_evidence_file_error(path: Path) -> str:
+    return (
+        f"{path} already exists. Pass --merge-existing to preserve current "
+        "records or --force to overwrite it."
+    )
+
+
+def _load_mergeable_evidence(
+    path: Path,
+) -> tuple[dict[str, dict[str, str]], str]:
+    try:
+        raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, (f"{path} could not be loaded for --merge-existing: {type(exc).__name__}: {exc}")
+    normalized, errors = _normalize_evidence_object(raw_payload, allow_missing_checks=True)
+    if errors:
+        return {}, (
+            f"{path} cannot be merged because it is invalid: {_format_validation_errors(errors)}."
+        )
+    return normalized, ""
+
+
+def _merge_external_evidence(
+    existing: dict[str, dict[str, str]],
+    collected: dict[str, dict[str, str]],
+    *,
+    probes: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, dict[str, str]]:
+    merged = blank_external_evidence()
+    for name in sorted(EXTERNAL_CHECK_NAMES):
+        collected_record = collected.get(name, {})
+        existing_record = existing.get(name, {})
+        if _is_complete_evidence_record(collected_record):
+            merged[name] = {
+                field: collected_record[field].strip() for field in EVIDENCE_RECORD_FIELDS
+            }
+        elif _is_complete_evidence_record(existing_record):
+            if _probe_invalidates_existing_record(probes, name):
+                continue
+            merged[name] = {
+                field: existing_record[field].strip() for field in EVIDENCE_RECORD_FIELDS
+            }
+    return merged
+
+
+def _probe_invalidates_existing_record(
+    probes: dict[str, dict[str, Any]] | None,
+    name: str,
+) -> bool:
+    """Return whether a current probe proves an existing record has drifted."""
+    if probes is None:
+        return False
+    probe = probes.get(name)
+    if not isinstance(probe, dict):
+        return False
+    return str(probe.get("status", "")).strip() in _MERGE_INVALIDATING_PROBE_STATUSES
+
+
+def _normalize_evidence_object(
+    raw_payload: object,
+    *,
+    allow_missing_checks: bool = False,
+) -> tuple[dict[str, dict[str, str]], list[str]]:
+    if not isinstance(raw_payload, dict):
+        return {}, ["evidence file must contain a JSON object"]
+
+    loaded_names = {key for key in raw_payload if isinstance(key, str)}
+    unknown_names = sorted(loaded_names - EXTERNAL_CHECK_NAMES)
+    missing_names = sorted(EXTERNAL_CHECK_NAMES - loaded_names)
+    errors: list[str] = []
+    if unknown_names:
+        errors.append(f"unknown checks: {', '.join(unknown_names)}")
+    if missing_names and not allow_missing_checks:
+        errors.append(f"missing checks: {', '.join(missing_names)}")
+
+    normalized = blank_external_evidence()
+    for name in sorted(EXTERNAL_CHECK_NAMES):
+        if name not in raw_payload:
+            continue
+        record, record_errors = _normalize_evidence_record(name, raw_payload.get(name))
+        if record_errors:
+            errors.extend(record_errors)
+            continue
+        normalized[name] = record
+    return normalized, errors
+
+
+def _normalize_evidence_record(
+    check_name: str,
+    raw_value: object,
+) -> tuple[dict[str, str], list[str]]:
+    if not isinstance(raw_value, dict):
+        return {}, [(f"{check_name} must be an object with {', '.join(EVIDENCE_RECORD_FIELDS)}")]
+
+    unknown_fields = sorted(
+        field
+        for field in raw_value
+        if isinstance(field, str) and field not in EVIDENCE_RECORD_FIELDS
+    )
+    missing_fields = [field for field in EVIDENCE_RECORD_FIELDS if field not in raw_value]
+    errors: list[str] = []
+    if unknown_fields:
+        errors.append(f"{check_name} has unknown fields: {', '.join(unknown_fields)}")
+    if missing_fields:
+        errors.append(f"{check_name} is missing fields: {', '.join(missing_fields)}")
+    if errors:
+        return {}, errors
+
+    normalized: dict[str, str] = {}
+    non_string_fields: list[str] = []
+    for field in EVIDENCE_RECORD_FIELDS:
+        raw_field_value = raw_value.get(field)
+        if not isinstance(raw_field_value, str):
+            non_string_fields.append(field)
+            continue
+        normalized[field] = raw_field_value.strip()
+    if non_string_fields:
+        errors.append(f"{check_name} has non-string fields: {', '.join(non_string_fields)}")
+        return {}, errors
+    if _is_blank_evidence_record(normalized):
+        return {field: "" for field in EVIDENCE_RECORD_FIELDS}, []
+    if not _is_complete_evidence_record(normalized):
+        empty_fields = [field for field in EVIDENCE_RECORD_FIELDS if not normalized.get(field, "")]
+        return {}, [f"{check_name} has partial evidence fields: {', '.join(empty_fields)}"]
+    if not _is_timezone_aware_iso_timestamp(normalized["verified_at"]):
+        return {}, [f"{check_name}.verified_at must be an ISO 8601 timestamp with timezone"]
+    return normalized, []
+
+
+def _is_blank_evidence_record(record: dict[str, str]) -> bool:
+    return all(not record.get(field, "").strip() for field in EVIDENCE_RECORD_FIELDS)
+
+
+def _is_complete_evidence_record(record: dict[str, str]) -> bool:
+    return all(
+        isinstance(record.get(field), str) and bool(record[field].strip())
+        for field in EVIDENCE_RECORD_FIELDS
+    )
+
+
+def _is_timezone_aware_iso_timestamp(value: str) -> bool:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
+
+
+def _format_validation_errors(errors: list[str]) -> str:
+    if len(errors) <= 3:
+        return "; ".join(errors)
+    shown_errors = "; ".join(errors[:3])
+    return f"{shown_errors}; ... {len(errors) - 3} more error(s)"
+
+
+def _probe_github_release(
+    *,
+    release_tag: str,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    command = ["gh", "release", "view", release_tag, "--json", GITHUB_RELEASE_FIELDS]
+    completed = runner(command)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        return {
+            "status": "release_view_failed",
+            "command": command,
+            "next_step": f"Fix `gh release view {release_tag}` before collecting release evidence.",
+            "detail": detail or f"gh exited with status {completed.returncode}",
+        }, None
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "release_view_invalid_json",
+            "command": command,
+            "next_step": "Return valid JSON from gh release view.",
+            "detail": str(exc),
+        }, None
+
+    assets = payload.get("assets", [])
+    if not isinstance(assets, list):
+        assets = []
+    asset_names = {
+        str(asset.get("name", ""))
+        for asset in assets
+        if isinstance(asset, dict) and asset.get("name")
+    }
+    missing_assets = sorted(set(expected_release_assets(release_tag)) - asset_names)
+    release_url = str(payload.get("url", ""))
+    if payload.get("isDraft") is True:
+        return {
+            "status": "draft_release",
+            "reference": release_url,
+            "next_step": "Publish the GitHub release before using it as public launch evidence.",
+        }, None
+    if missing_assets:
+        return {
+            "status": "missing_assets",
+            "reference": release_url,
+            "missing_assets": missing_assets,
+            "next_step": "Attach every required release asset, then rerun this collector.",
+        }, None
+
+    metadata_probe = _probe_github_release_metadata(
+        release_tag=release_tag,
+        release_url=release_url,
+        expected_assets=expected_release_assets(release_tag),
+        runner=runner,
+    )
+    if metadata_probe["status"] != "passed":
+        return metadata_probe, None
+
+    summary = (
+        f"GitHub release {release_tag} contains required assets: "
+        f"{', '.join(expected_release_assets(release_tag))}; manifest and "
+        f"SHA256SUMS metadata cross-check {metadata_probe['payload_asset_count']} "
+        "payload assets."
+    )
+    return {
+        "status": "passed",
+        "reference": release_url,
+        "asset_count": len(asset_names),
+        "payload_asset_count": metadata_probe["payload_asset_count"],
+        "target_commitish": str(payload.get("targetCommitish", "")),
+    }, _evidence_record(
+        summary=summary,
+        reference=release_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_github_release_metadata(
+    *,
+    release_tag: str,
+    release_url: str,
+    expected_assets: list[str],
+    runner: Runner,
+) -> dict[str, Any]:
+    try:
+        repo_slug = _repo_slug_from_release_url(release_url)
+    except ValueError as exc:
+        return {
+            "status": "missing_release_reference",
+            "reference": release_url,
+            "next_step": str(exc),
+        }
+
+    with tempfile.TemporaryDirectory(prefix="policynim-release-metadata.") as temp_dir:
+        command = [
+            "gh",
+            "release",
+            "download",
+            release_tag,
+            "--pattern",
+            "RELEASE_MANIFEST.json",
+            "--pattern",
+            "SHA256SUMS",
+            "--dir",
+            temp_dir,
+            "--repo",
+            repo_slug,
+        ]
+        completed = runner(command)
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            return {
+                "status": "metadata_download_failed",
+                "command": command,
+                "reference": release_url,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Download RELEASE_MANIFEST.json and SHA256SUMS from the "
+                    "GitHub release before collecting release evidence."
+                ),
+                "detail": detail or f"gh exited with status {completed.returncode}",
+            }
+
+        manifest_path = Path(temp_dir) / "RELEASE_MANIFEST.json"
+        checksums_path = Path(temp_dir) / "SHA256SUMS"
+        missing_metadata = [
+            path.name for path in (manifest_path, checksums_path) if not path.is_file()
+        ]
+        if missing_metadata:
+            return {
+                "status": "release_metadata_missing",
+                "command": command,
+                "reference": release_url,
+                "download_dir": temp_dir,
+                "missing_assets": missing_metadata,
+                "next_step": (
+                    "Ensure the release includes downloadable RELEASE_MANIFEST.json "
+                    "and SHA256SUMS files."
+                ),
+            }
+
+        errors = _validate_release_metadata_files(
+            manifest_path=manifest_path,
+            checksums_path=checksums_path,
+            release_tag=release_tag,
+            expected_assets=expected_assets,
+        )
+        if errors:
+            return {
+                "status": "release_metadata_invalid",
+                "command": command,
+                "reference": release_url,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Regenerate RELEASE_MANIFEST.json and SHA256SUMS from the "
+                    "same release asset directory, then rerun this collector."
+                ),
+                "detail": _format_validation_errors(errors),
+            }
+
+        return {
+            "status": "passed",
+            "command": command,
+            "reference": release_url,
+            "payload_asset_count": len(_release_payload_asset_names(expected_assets)),
+        }
+
+
+def _validate_release_metadata_files(
+    *,
+    manifest_path: Path,
+    checksums_path: Path,
+    release_tag: str,
+    expected_assets: list[str],
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"RELEASE_MANIFEST.json is not valid JSON: {type(exc).__name__}: {exc}"]
+    if not isinstance(manifest, dict):
+        return ["RELEASE_MANIFEST.json must contain a JSON object"]
+    if manifest.get("schema_version") != "1":
+        errors.append("RELEASE_MANIFEST.json schema_version must be 1")
+    if manifest.get("release_tag") != release_tag:
+        errors.append(f"RELEASE_MANIFEST.json release_tag must be {release_tag}")
+
+    assets = manifest.get("assets")
+    if not isinstance(assets, list):
+        errors.append("RELEASE_MANIFEST.json assets must be a list")
+        assets = []
+    manifest_checksums: dict[str, str] = {}
+    for index, asset in enumerate(assets):
+        if not isinstance(asset, dict):
+            errors.append(f"RELEASE_MANIFEST.json assets[{index}] must be an object")
+            continue
+        name = asset.get("name")
+        sha256 = asset.get("sha256")
+        size_bytes = asset.get("size_bytes")
+        if not isinstance(name, str) or not name:
+            errors.append(f"RELEASE_MANIFEST.json assets[{index}].name must be a string")
+            continue
+        if isinstance(sha256, str) and _is_sha256_digest(sha256):
+            manifest_checksums[name] = sha256
+        else:
+            errors.append(f"RELEASE_MANIFEST.json asset {name} has invalid sha256")
+        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
+            errors.append(f"RELEASE_MANIFEST.json asset {name} has invalid size_bytes")
+
+    try:
+        checksums_text = checksums_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"SHA256SUMS could not be read: {type(exc).__name__}: {exc}"]
+    checksum_entries, checksum_errors = _parse_sha256sums(checksums_text)
+    errors.extend(checksum_errors)
+
+    expected_payload_assets = _release_payload_asset_names(expected_assets)
+    missing_manifest_assets = sorted(set(expected_payload_assets) - set(manifest_checksums))
+    missing_checksum_assets = sorted(set(expected_payload_assets) - set(checksum_entries))
+    if missing_manifest_assets:
+        errors.append(
+            "RELEASE_MANIFEST.json is missing assets: " + ", ".join(missing_manifest_assets)
+        )
+    if missing_checksum_assets:
+        errors.append("SHA256SUMS is missing assets: " + ", ".join(missing_checksum_assets))
+
+    extra_manifest_assets = sorted(set(manifest_checksums) - set(expected_payload_assets))
+    extra_checksum_assets = sorted(set(checksum_entries) - set(expected_payload_assets))
+    if extra_manifest_assets:
+        errors.append(
+            "RELEASE_MANIFEST.json has unexpected assets: " + ", ".join(extra_manifest_assets)
+        )
+    if extra_checksum_assets:
+        errors.append("SHA256SUMS has unexpected assets: " + ", ".join(extra_checksum_assets))
+
+    for name in expected_payload_assets:
+        manifest_digest = manifest_checksums.get(name)
+        checksum_digest = checksum_entries.get(name)
+        if (
+            manifest_digest is not None
+            and checksum_digest is not None
+            and manifest_digest != checksum_digest
+        ):
+            errors.append(f"{name} sha256 differs between RELEASE_MANIFEST.json and SHA256SUMS")
+    return errors
+
+
+def _parse_sha256sums(text: str) -> tuple[dict[str, str], list[str]]:
+    entries: dict[str, str] = {}
+    errors: list[str] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            errors.append(f"SHA256SUMS line {line_number} must contain digest and filename")
+            continue
+        digest, filename = parts
+        if not _is_sha256_digest(digest):
+            errors.append(f"SHA256SUMS line {line_number} has invalid sha256")
+            continue
+        filename = filename.strip()
+        if not filename:
+            errors.append(f"SHA256SUMS line {line_number} has an empty filename")
+            continue
+        entries[filename] = digest
+    return entries, errors
+
+
+def _release_payload_asset_names(expected_assets: list[str]) -> list[str]:
+    return sorted(set(expected_assets) - set(RELEASE_METADATA_ASSET_NAMES))
+
+
+def _is_sha256_digest(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    return all(character in "0123456789abcdef" for character in value.lower())
+
+
+def _probe_github_artifact_attestation(
+    *,
+    release_tag: str,
+    asset_name: str,
+    release_url: str,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    normalized_asset_name = asset_name.strip()
+    if not normalized_asset_name:
+        return {
+            "status": "manual_required",
+            "next_step": (
+                "Pass --release-attestation-asset-name with a public release asset "
+                "after the Release workflow has generated GitHub artifact attestations."
+            ),
+        }, None
+    if normalized_asset_name not in expected_release_assets(release_tag):
+        return {
+            "status": "unknown_asset",
+            "asset_name": normalized_asset_name,
+            "next_step": (
+                "Use one of the public release assets listed in RELEASE_MANIFEST.json, "
+                "for example install.sh or the Linux standalone archive."
+            ),
+        }, None
+    try:
+        repo_slug = _repo_slug_from_release_url(release_url)
+    except ValueError as exc:
+        return {
+            "status": "missing_release_reference",
+            "asset_name": normalized_asset_name,
+            "next_step": str(exc),
+        }, None
+
+    with tempfile.TemporaryDirectory(prefix="policynim-attestation-") as temp_dir:
+        download_command = [
+            "gh",
+            "release",
+            "download",
+            release_tag,
+            "--pattern",
+            normalized_asset_name,
+            "--dir",
+            temp_dir,
+            "--repo",
+            repo_slug,
+        ]
+        completed_download = runner(download_command)
+        if completed_download.returncode != 0:
+            detail = (completed_download.stderr or completed_download.stdout).strip()
+            return {
+                "status": "download_failed",
+                "command": download_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": "Download the release asset before verifying its attestation.",
+                "detail": detail or f"gh exited with status {completed_download.returncode}",
+            }, None
+
+        asset_path = Path(temp_dir) / normalized_asset_name
+        if not asset_path.is_file():
+            return {
+                "status": "download_missing_asset",
+                "command": download_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Ensure the named release asset exists and gh release download "
+                    "writes it to the requested directory."
+                ),
+            }, None
+
+        verify_command = [
+            "gh",
+            "attestation",
+            "verify",
+            str(asset_path),
+            "--repo",
+            repo_slug,
+            "--format",
+            "json",
+        ]
+        completed_verify = runner(verify_command)
+        if completed_verify.returncode != 0:
+            detail = (completed_verify.stderr or completed_verify.stdout).strip()
+            return {
+                "status": "verification_failed",
+                "command": verify_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Publish release attestations from the Release workflow, then "
+                    "rerun gh attestation verify for this asset."
+                ),
+                "detail": detail or f"gh exited with status {completed_verify.returncode}",
+            }, None
+        try:
+            attestation_payload = json.loads(completed_verify.stdout)
+        except json.JSONDecodeError as exc:
+            return {
+                "status": "invalid_attestation_json",
+                "command": verify_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": "Return valid JSON from gh attestation verify --format json.",
+                "detail": str(exc),
+            }, None
+        if not isinstance(attestation_payload, list) or not attestation_payload:
+            return {
+                "status": "empty_attestation_result",
+                "command": verify_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Use an asset with at least one verified GitHub artifact attestation."
+                ),
+            }, None
+        subject_names = _attestation_subject_names(attestation_payload)
+        if not subject_names:
+            return {
+                "status": "attestation_missing_subjects",
+                "command": verify_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "next_step": (
+                    "Use a gh attestation verify JSON result with at least one "
+                    "verificationResult.statement.subject entry."
+                ),
+            }, None
+        if normalized_asset_name not in subject_names:
+            return {
+                "status": "attestation_subject_mismatch",
+                "command": verify_command,
+                "asset_name": normalized_asset_name,
+                "download_dir": temp_dir,
+                "subject_names": subject_names,
+                "next_step": (
+                    "Use a gh attestation verify JSON result whose attested "
+                    f"subjects include {normalized_asset_name}."
+                ),
+            }, None
+
+        reference = f"{release_url}#{normalized_asset_name}"
+        subject_count = len(subject_names)
+        summary = (
+            f"GitHub artifact attestation verifies for {normalized_asset_name} "
+            f"from release {release_tag} with {subject_count} attested subject."
+        )
+        return {
+            "status": "passed",
+            "reference": reference,
+            "asset_name": normalized_asset_name,
+            "download_dir": temp_dir,
+            "attestation_count": len(attestation_payload),
+            "subject_count": subject_count,
+            "subject_names": subject_names,
+        }, _evidence_record(
+            summary=summary,
+            reference=reference,
+            verified_by=verified_by,
+            verified_at=verified_at,
+        )
+
+
+def _attestation_subject_names(attestation_payload: object) -> list[str]:
+    if not isinstance(attestation_payload, list):
+        return []
+    subject_names: list[str] = []
+    for attestation in attestation_payload:
+        if not isinstance(attestation, dict):
+            continue
+        verification = attestation.get("verificationResult")
+        if not isinstance(verification, dict):
+            continue
+        statement = verification.get("statement")
+        if not isinstance(statement, dict):
+            continue
+        subjects = statement.get("subject")
+        if not isinstance(subjects, list):
+            continue
+        for subject in subjects:
+            if not isinstance(subject, dict):
+                continue
+            name = subject.get("name")
+            if isinstance(name, str) and name:
+                subject_names.append(name)
+    return sorted(set(subject_names))
+
+
+def _repo_slug_from_release_url(release_url: str) -> str:
+    parsed = urllib.parse.urlparse(release_url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if parsed.netloc != "github.com" or len(path_parts) < 2:
+        raise ValueError(
+            "Collect GitHub release evidence first so the release URL can identify "
+            "the owner/repository for gh attestation verify."
+        )
+    return f"{path_parts[0]}/{path_parts[1]}"
+
+
+def _probe_pypi_project(
+    *,
+    release_tag: str,
+    release_target_commitish: str,
+    pypi_payload: dict[str, Any] | None,
+    pypi_publish_run_url: str,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    if pypi_payload is None:
+        return {
+            "status": "not_checked",
+            "next_step": "Run the collector with PyPI network access to inspect the project.",
+        }, None
+    info = pypi_payload.get("info")
+    if not isinstance(info, dict):
+        return {
+            "status": "error",
+            "next_step": "PyPI response did not include project info.",
+        }, None
+    version = str(info.get("version", ""))
+    project_url = str(info.get("project_url", "https://pypi.org/project/policynim/"))
+    expected_version = release_tag.removeprefix("v")
+    if version != expected_version:
+        return {
+            "status": "version_mismatch",
+            "reference": project_url,
+            "expected_version": expected_version,
+            "actual_version": version,
+            "next_step": "Publish or verify the matching PyPI version before adding evidence.",
+        }, None
+    expected_files = expected_pypi_distribution_files(release_tag)
+    filenames = _pypi_release_file_names(pypi_payload, version)
+    missing_files = [filename for filename in expected_files if filename not in filenames]
+    if missing_files:
+        return {
+            "status": "missing_distribution_files",
+            "reference": project_url,
+            "version": version,
+            "expected_files": expected_files,
+            "filenames": filenames,
+            "missing_files": missing_files,
+            "next_step": (
+                "Publish or wait for the PyPI release page to list the expected "
+                "wheel and sdist before claiming package-install availability."
+            ),
+        }, None
+    if pypi_publish_run_url.strip():
+        return _probe_pypi_publish_run(
+            pypi_publish_run_url=pypi_publish_run_url,
+            project_url=project_url,
+            release_target_commitish=release_target_commitish,
+            version=version,
+            filenames=filenames,
+            verified_by=verified_by,
+            verified_at=verified_at,
+            runner=runner,
+        )
+    return {
+        "status": "manual_required",
+        "reference": project_url,
+        "version": version,
+        "file_count": len(filenames),
+        "filenames": filenames,
+        "next_step": (
+            "PyPI project exists for the release version. Trusted publishing state "
+            "is not exposed by public PyPI JSON; pass --pypi-publish-run-url "
+            "with the successful Release workflow run before filling "
+            "pypi_project evidence."
+        ),
+    }, None
+
+
+def _probe_pypi_install_smoke(
+    *,
+    release_tag: str,
+    requested: bool,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    version = release_tag.removeprefix("v")
+    if not requested:
+        return {
+            "status": "manual_required",
+            "next_step": (
+                "Run the collector with --pypi-install-smoke after the release "
+                "version is available on PyPI."
+            ),
+        }, None
+
+    with tempfile.TemporaryDirectory(prefix="policynim-pypi-smoke-") as temp_dir:
+        venv_dir = Path(temp_dir) / "venv"
+        python_path = _venv_executable(venv_dir, "python")
+        policynim_path = _venv_executable(venv_dir, "policynim")
+        steps = [
+            ("python -m venv", [sys.executable, "-m", "venv", str(venv_dir)], False),
+            (
+                "python -m pip install --upgrade pip",
+                [str(python_path), "-m", "pip", "install", "--upgrade", "pip"],
+                False,
+            ),
+            (
+                f"python -m pip install policynim=={version}",
+                [str(python_path), "-m", "pip", "install", f"policynim=={version}"],
+                False,
+            ),
+            *_installed_cli_first_run_smoke_steps(policynim_path),
+        ]
+        completed_labels: list[str] = []
+        for label, command, expects_json in steps:
+            completed = runner(command)
+            if completed.returncode != 0:
+                return _install_smoke_failure(
+                    status="command_failed",
+                    label=label,
+                    completed=completed,
+                    channel="PyPI",
+                    rerun_flag="--pypi-install-smoke",
+                ), None
+            if expects_json:
+                try:
+                    parsed_json = json.loads(completed.stdout)
+                except json.JSONDecodeError as exc:
+                    return {
+                        "status": "invalid_json",
+                        "command": label,
+                        "detail": str(exc),
+                        "next_step": (
+                            f"Rerun the public PyPI install smoke and inspect {label} output."
+                        ),
+                    }, None
+                contract_errors = _installed_cli_first_run_json_contract_errors(
+                    label=label,
+                    payload=parsed_json,
+                )
+                if contract_errors:
+                    return {
+                        "status": "invalid_first_run_contract",
+                        "command": label,
+                        "detail": "; ".join(contract_errors),
+                        "next_step": (
+                            "Publish a new PyPI release built from the current "
+                            "first-run contract, then rerun --pypi-install-smoke."
+                        ),
+                    }, None
+            completed_labels.append(label)
+
+    version_url = f"https://pypi.org/project/policynim/{version}/"
+    return {
+        "status": "passed",
+        "reference": version_url,
+        "version": version,
+        "commands": completed_labels,
+    }, _evidence_record(
+        summary=(
+            f"Clean PyPI install smoke passed for policynim=={version} with "
+            "--help, primary command help, semantic first-run JSON, "
+            "support-bundle hosted client_commands for Codex and Claude Code, "
+            "doctor JSON, and local MCP config JSON."
+        ),
+        reference=version_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_github_release_install_smoke(
+    *,
+    release_tag: str,
+    requested: bool,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    version = release_tag.removeprefix("v")
+    release_url = f"https://github.com/nnennandukwe/policyNIM/releases/tag/{release_tag}"
+    installer_url = (
+        f"https://github.com/nnennandukwe/policyNIM/releases/download/{release_tag}/install.sh"
+    )
+    if not requested:
+        return {
+            "status": "manual_required",
+            "next_step": (
+                "Run the collector with --github-install-smoke after the release "
+                "version is available on GitHub Releases."
+            ),
+        }, None
+
+    if os.name == "nt":
+        return {
+            "status": "unsupported_platform",
+            "next_step": (
+                "--github-install-smoke currently verifies the Unix install.sh path. "
+                "Run it from macOS or Linux, or attach reviewed Windows installer smoke evidence."
+            ),
+        }, None
+
+    with tempfile.TemporaryDirectory(prefix="policynim-github-install-smoke-") as temp_dir:
+        temp_path = Path(temp_dir)
+        temp_home = temp_path / "home"
+        temp_home.mkdir()
+        installer_path = temp_path / "install.sh"
+        policynim_path = temp_home / ".local" / "bin" / "policynim"
+        steps = [
+            (
+                "download install.sh",
+                ["curl", "-fsSL", "-o", str(installer_path), installer_url],
+                False,
+            ),
+            (
+                "install.sh",
+                [
+                    "sh",
+                    "-c",
+                    (
+                        f"HOME={shlex.quote(str(temp_home))} "
+                        f"POLICYNIM_VERSION={shlex.quote(version)} "
+                        f"sh {shlex.quote(str(installer_path))}"
+                    ),
+                ],
+                False,
+            ),
+            *_installed_cli_first_run_smoke_steps(policynim_path),
+        ]
+        completed_labels: list[str] = []
+        for label, command, expects_json in steps:
+            completed = runner(command)
+            if completed.returncode != 0:
+                return _install_smoke_failure(
+                    status="command_failed",
+                    label=label,
+                    completed=completed,
+                    channel="GitHub",
+                    rerun_flag="--github-install-smoke",
+                ), None
+            if label == "install.sh":
+                guidance_errors = _installer_guidance_contract_errors(completed.stdout)
+                if guidance_errors:
+                    return {
+                        "status": "invalid_installer_guidance",
+                        "command": label,
+                        "detail": "; ".join(guidance_errors),
+                        "next_step": (
+                            "Publish a new GitHub release whose install.sh output "
+                            "matches the current hosted and local first-run guidance, "
+                            "then rerun --github-install-smoke."
+                        ),
+                    }, None
+            if expects_json:
+                try:
+                    parsed_json = json.loads(completed.stdout)
+                except json.JSONDecodeError as exc:
+                    return {
+                        "status": "invalid_json",
+                        "command": label,
+                        "detail": str(exc),
+                        "next_step": (
+                            f"Rerun the public GitHub installer smoke and inspect {label} output."
+                        ),
+                    }, None
+                contract_errors = _installed_cli_first_run_json_contract_errors(
+                    label=label,
+                    payload=parsed_json,
+                )
+                if contract_errors:
+                    return {
+                        "status": "invalid_first_run_contract",
+                        "command": label,
+                        "detail": "; ".join(contract_errors),
+                        "next_step": (
+                            "Publish a new GitHub release built from the current "
+                            "first-run contract, then rerun --github-install-smoke."
+                        ),
+                    }, None
+            completed_labels.append(label)
+
+    return {
+        "status": "passed",
+        "reference": release_url,
+        "version": version,
+        "installer_url": installer_url,
+        "commands": completed_labels,
+    }, _evidence_record(
+        summary=(
+            f"Clean GitHub release installer smoke passed for {release_tag} with "
+            "install.sh guidance, --help, primary command help, semantic first-run "
+            "JSON, support-bundle hosted client_commands for Codex and Claude Code, "
+            "doctor JSON, and local MCP config JSON."
+        ),
+        reference=release_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _installed_cli_first_run_smoke_steps(
+    policynim_path: Path,
+) -> list[tuple[str, list[str], bool]]:
+    return [
+        ("policynim --help", [str(policynim_path), "--help"], False),
+        ("policynim init --help", [str(policynim_path), "init", "--help"], False),
+        ("policynim ingest --help", [str(policynim_path), "ingest", "--help"], False),
+        (
+            "policynim preflight --help",
+            [str(policynim_path), "preflight", "--help"],
+            False,
+        ),
+        (
+            "policynim quickstart --format json",
+            [str(policynim_path), "quickstart", "--format", "json"],
+            True,
+        ),
+        (
+            "policynim quickstart --target local-cli --format json",
+            [
+                str(policynim_path),
+                "quickstart",
+                "--target",
+                "local-cli",
+                "--format",
+                "json",
+            ],
+            True,
+        ),
+        (
+            "policynim quickstart --target local-mcp --format json",
+            [
+                str(policynim_path),
+                "quickstart",
+                "--target",
+                "local-mcp",
+                "--format",
+                "json",
+            ],
+            True,
+        ),
+        (
+            "policynim doctor --format json",
+            [str(policynim_path), "doctor", "--format", "json"],
+            True,
+        ),
+        ("policynim support-bundle", [str(policynim_path), "support-bundle"], True),
+        (
+            "policynim mcp-config --client codex --target local-stdio --format json",
+            [
+                str(policynim_path),
+                "mcp-config",
+                "--client",
+                "codex",
+                "--target",
+                "local-stdio",
+                "--format",
+                "json",
+            ],
+            True,
+        ),
+        (
+            "policynim mcp-config --client claude-code --target local-stdio --format json",
+            [
+                str(policynim_path),
+                "mcp-config",
+                "--client",
+                "claude-code",
+                "--target",
+                "local-stdio",
+                "--format",
+                "json",
+            ],
+            True,
+        ),
+    ]
+
+
+def _installer_guidance_contract_errors(stdout: str) -> list[str]:
+    errors: list[str] = []
+    for token in (
+        "Run `policynim quickstart` to choose a first-run path.",
+        "Hosted MCP does not require `policynim init` or `policynim ingest`.",
+        "For local CLI or local MCP, run `policynim init` then `policynim ingest`.",
+        "Run `policynim doctor` to inspect first-run setup.",
+        "Run `policynim support-bundle` before opening an issue.",
+    ):
+        if token not in stdout:
+            errors.append(f"install.sh output must include: {token}")
+    return errors
+
+
+def _installed_cli_first_run_json_contract_errors(
+    *,
+    label: str,
+    payload: object,
+) -> list[str]:
+    if not isinstance(payload, dict):
+        return [f"{label} output must be a JSON object"]
+    if label == "policynim quickstart --format json":
+        return _hosted_quickstart_contract_errors(payload, label="hosted quickstart")
+    if label == "policynim quickstart --target local-cli --format json":
+        return _quickstart_target_contract_errors(
+            payload,
+            expected_target="local-cli",
+            expected_requires_local_setup=True,
+            label="local CLI quickstart",
+        )
+    if label == "policynim quickstart --target local-mcp --format json":
+        errors = _quickstart_target_contract_errors(
+            payload,
+            expected_target="local-mcp",
+            expected_requires_local_setup=True,
+            label="local MCP quickstart",
+        )
+        if payload.get("local_launch_mode") != "installed-cli":
+            errors.append("local MCP quickstart local_launch_mode must be 'installed-cli'")
+        return errors
+    if label == "policynim support-bundle":
+        return _support_bundle_first_run_contract_errors(payload)
+    if label in (
+        "policynim mcp-config --client codex --target local-stdio --format json",
+        "policynim mcp-config --client claude-code --target local-stdio --format json",
+    ):
+        return _local_mcp_config_contract_errors(payload, label=label)
+    return []
+
+
+def _quickstart_target_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    expected_target: str,
+    expected_requires_local_setup: bool,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("target") != expected_target:
+        errors.append(f"{label} target must be {expected_target!r}")
+    if payload.get("requires_local_setup") is not expected_requires_local_setup:
+        errors.append(f"{label} requires_local_setup must be {expected_requires_local_setup!r}")
+    if payload.get("calls_external_services") is not False:
+        errors.append(f"{label} calls_external_services must be False")
+    errors.extend(_agent_workflows_contract_errors(payload, label=f"{label}.agent_workflows"))
+    return errors
+
+
+def _hosted_quickstart_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    errors = _quickstart_target_contract_errors(
+        payload,
+        expected_target="hosted-mcp",
+        expected_requires_local_setup=False,
+        label=label,
+    )
+    errors.extend(
+        _hosted_client_commands_contract_errors(
+            payload,
+            label=f"{label}.client_commands",
+        )
+    )
+    errors.extend(_hosted_quickstart_token_flow_contract_errors(payload, label=label))
+    return errors
+
+
+def _hosted_quickstart_token_flow_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    hosted_url = payload.get("hosted_url")
+    beta_portal_url = payload.get("beta_portal_url")
+    if not (
+        isinstance(hosted_url, str)
+        and hosted_url.startswith("https://")
+        and hosted_url.endswith("/mcp")
+    ):
+        errors.append(f"{label} hosted_url must be an https /mcp URL")
+    if not (
+        isinstance(beta_portal_url, str)
+        and beta_portal_url.startswith("https://")
+        and beta_portal_url.endswith("/beta")
+    ):
+        errors.append(f"{label} beta_portal_url must be an https /beta URL")
+
+    steps = _string_list(payload.get("steps"))
+    if steps is None:
+        errors.append(f"{label} steps must be a string list")
+        errors.append(f"{label} steps must explain the browser token flow")
+        return errors
+    step_text = " ".join(steps).lower()
+    required_tokens = ["browser", "token"]
+    if isinstance(hosted_url, str):
+        required_tokens.append(hosted_url.lower())
+    if isinstance(beta_portal_url, str):
+        required_tokens.append(beta_portal_url.lower())
+    if not all(token in step_text for token in required_tokens):
+        errors.append(f"{label} steps must explain the browser token flow")
+    return errors
+
+
+def _support_bundle_first_run_contract_errors(payload: dict[Any, Any]) -> list[str]:
+    first_run = _object_dict(payload.get("first_run"))
+    if first_run is None:
+        return ["support-bundle first_run must be a JSON object"]
+    targets = _object_dict(first_run.get("targets"))
+    if targets is None:
+        return ["support-bundle first_run.targets must be a JSON object"]
+    hosted_mcp = _object_dict(targets.get("hosted_mcp"))
+    if hosted_mcp is None:
+        return ["support-bundle first_run.targets.hosted_mcp must be a JSON object"]
+
+    errors: list[str] = []
+    quickstart_command = hosted_mcp.get("quickstart_command")
+    if quickstart_command != "policynim quickstart --target hosted-mcp --format json":
+        errors.append(
+            "first_run.targets.hosted_mcp.quickstart_command must use the installed "
+            "hosted quickstart command"
+        )
+    errors.extend(
+        _hosted_all_client_commands_contract_errors(
+            hosted_mcp,
+            label="first_run.targets.hosted_mcp.client_commands",
+        )
+    )
+    errors.extend(
+        _hosted_quickstart_token_flow_contract_errors(
+            hosted_mcp,
+            label="first_run.targets.hosted_mcp",
+        )
+    )
+    errors.extend(
+        _agent_workflows_contract_errors(
+            hosted_mcp,
+            label="first_run.targets.hosted_mcp.agent_workflows",
+        )
+    )
+    return errors
+
+
+def _hosted_client_commands_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    client_commands = _string_list(payload.get("client_commands"))
+    if client_commands is None or not client_commands:
+        return [f"{label} must be a non-empty string list"]
+    command_text = " ".join(client_commands)
+    errors: list[str] = []
+    for token in ("/mcp", "POLICYNIM_TOKEN"):
+        if token not in command_text:
+            errors.append(f"{label} must include {token!r}")
+    if "<generated-beta-token>" in command_text:
+        errors.append(f"{label} must not embed generated bearer tokens")
+    if "codex mcp add policynim" in command_text:
+        for token in ("--url", "--bearer-token-env-var"):
+            if token not in command_text:
+                errors.append(f"{label} must include {token!r}")
+    elif "claude mcp add" in command_text:
+        for token in ("--transport http", "--header", "Authorization: Bearer $POLICYNIM_TOKEN"):
+            if token not in command_text:
+                errors.append(f"{label} must include {token!r}")
+    else:
+        errors.append(f"{label} must include a Codex or Claude Code MCP add command")
+    return errors
+
+
+def _hosted_all_client_commands_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    errors = _hosted_client_commands_contract_errors(payload, label=label)
+    client_commands = _string_list(payload.get("client_commands"))
+    if client_commands is None:
+        return errors
+
+    command_text = " ".join(client_commands)
+    if "codex mcp add policynim" not in command_text:
+        errors.append(f"{label} must include a Codex MCP add command")
+    if "claude mcp add" not in command_text:
+        errors.append(f"{label} must include a Claude Code MCP add command")
+    return errors
+
+
+def _agent_workflows_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    workflows = payload.get("agent_workflows")
+    if not isinstance(workflows, list) or not workflows:
+        return [f"{label} must be a non-empty list"]
+    if not all(isinstance(item, dict) for item in workflows):
+        return [f"{label} entries must be JSON objects"]
+    workflow_text = " ".join(
+        " ".join(str(item.get(field, "")) for field in ("title", "tool", "prompt"))
+        for item in workflows
+    )
+    errors: list[str] = []
+    for token in (
+        "policy_preflight",
+        "Before editing",
+        "cited constraints",
+        "insufficient_context",
+        "policy_search",
+        "cited policy lines",
+        "Verify MCP tool availability",
+        "before starting implementation",
+    ):
+        if token not in workflow_text:
+            errors.append(f"{label} must mention {token!r}")
+    return errors
+
+
+def _local_mcp_config_contract_errors(
+    payload: dict[Any, Any],
+    *,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("target") != "local-stdio":
+        errors.append(f"{label} target must be 'local-stdio'")
+    if payload.get("server_name") != "policynim":
+        errors.append(f"{label} server_name must be 'policynim'")
+    if payload.get("local_launch_mode") != "installed-cli":
+        errors.append(f"{label} local_launch_mode must be 'installed-cli'")
+    if "repo_root" in payload:
+        errors.append(f"{label} must not include repo_root for public PyPI installs")
+    return errors
+
+
+def _string_list(value: object) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    if not all(isinstance(item, str) for item in value):
+        return None
+    return value
+
+
+def _object_dict(value: object) -> dict[Any, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def _install_smoke_failure(
+    *,
+    status: str,
+    label: str,
+    completed: subprocess.CompletedProcess[str],
+    channel: str,
+    rerun_flag: str,
+) -> dict[str, Any]:
+    detail = (completed.stderr or completed.stdout).strip()
+    if not detail:
+        detail = f"command exited with status {completed.returncode}"
+    if label.startswith("policynim ") and "No such command" in detail:
+        return {
+            "status": "missing_first_run_command",
+            "command": label,
+            "detail": detail,
+            "next_step": (
+                f"Publish a new {channel} release built from the current CLI, then "
+                f"rerun {rerun_flag}."
+            ),
+        }
+    return {
+        "status": status,
+        "command": label,
+        "detail": detail,
+        "next_step": (f"Rerun the public {channel} install smoke and inspect the failing command."),
+    }
+
+
+def _venv_executable(venv_dir: Path, name: str) -> Path:
+    if os.name == "nt":
+        suffix = ".exe"
+        return venv_dir / "Scripts" / f"{name}{suffix}"
+    return venv_dir / "bin" / name
+
+
+def expected_pypi_distribution_files(release_tag: str) -> list[str]:
+    version = release_tag.removeprefix("v")
+    return [
+        f"{PYPI_PROJECT_NAME}-{version}-py3-none-any.whl",
+        f"{PYPI_PROJECT_NAME}-{version}.tar.gz",
+    ]
+
+
+def _pypi_release_file_names(pypi_payload: dict[str, Any], version: str) -> list[str]:
+    releases = pypi_payload.get("releases")
+    if not isinstance(releases, dict):
+        return []
+    release_files = releases.get(version)
+    if not isinstance(release_files, list):
+        return []
+    filenames: list[str] = []
+    for release_file in release_files:
+        if not isinstance(release_file, dict):
+            continue
+        filename = release_file.get("filename")
+        if isinstance(filename, str) and filename:
+            filenames.append(filename)
+    return sorted(set(filenames))
+
+
+def _probe_pypi_publish_run(
+    *,
+    pypi_publish_run_url: str,
+    project_url: str,
+    release_target_commitish: str,
+    version: str,
+    filenames: list[str],
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    raw_reference = pypi_publish_run_url.strip()
+    try:
+        run_id = _extract_github_run_id(raw_reference)
+    except ValueError as exc:
+        return {
+            "status": "invalid_run_url",
+            "reference": raw_reference,
+            "project_url": project_url,
+            "version": version,
+            "next_step": str(exc),
+        }, None
+
+    command = ["gh", "run", "view", run_id, "--json", GITHUB_RUN_FIELDS]
+    completed = runner(command)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        return {
+            "status": "error",
+            "command": command,
+            "project_url": project_url,
+            "version": version,
+            "next_step": "Authenticate gh and verify the PyPI publish run URL.",
+            "detail": detail or f"gh exited with status {completed.returncode}",
+        }, None
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "error",
+            "command": command,
+            "project_url": project_url,
+            "version": version,
+            "next_step": "Return valid JSON from gh run view.",
+            "detail": str(exc),
+        }, None
+
+    workflow_name = str(payload.get("workflowName", ""))
+    if workflow_name != "Release":
+        return {
+            "status": "wrong_workflow",
+            "reference": raw_reference,
+            "workflow_name": workflow_name,
+            "project_url": project_url,
+            "version": version,
+            "next_step": "Use a GitHub Actions run from the Release workflow.",
+        }, None
+    if payload.get("event") not in {"push", "workflow_dispatch"}:
+        return {
+            "status": "wrong_event",
+            "reference": raw_reference,
+            "event": payload.get("event"),
+            "project_url": project_url,
+            "version": version,
+            "next_step": "Use a tag push or manual Release workflow run.",
+        }, None
+    if payload.get("status") != "completed" or payload.get("conclusion") != "success":
+        return {
+            "status": "run_not_successful",
+            "reference": raw_reference,
+            "run_status": payload.get("status"),
+            "conclusion": payload.get("conclusion"),
+            "project_url": project_url,
+            "version": version,
+            "next_step": (
+                "Use a Release workflow run with completed status and success conclusion."
+            ),
+        }, None
+    expected_head_sha = release_target_commitish.strip()
+    actual_head_sha = str(payload.get("headSha", "")).strip()
+    if not expected_head_sha:
+        return {
+            "status": "release_sha_missing",
+            "reference": raw_reference,
+            "project_url": project_url,
+            "version": version,
+            "next_step": (
+                "Collect GitHub release evidence first so the trusted-publish run "
+                "can be matched to the release target commit."
+            ),
+        }, None
+    if actual_head_sha != expected_head_sha:
+        return {
+            "status": "release_sha_mismatch",
+            "reference": raw_reference,
+            "project_url": project_url,
+            "version": version,
+            "expected_head_sha": expected_head_sha,
+            "actual_head_sha": actual_head_sha,
+            "next_step": (
+                "Use a Release workflow run from the same commit as the GitHub "
+                "release target before filling PyPI trusted-publishing evidence."
+            ),
+        }, None
+
+    jobs = payload.get("jobs")
+    publish_job = _find_job(jobs, "publish-pypi")
+    if not _is_successful_job(publish_job):
+        result: dict[str, Any] = {
+            "status": "job_not_successful",
+            "reference": raw_reference,
+            "project_url": project_url,
+            "version": version,
+            "next_step": "Use a Release workflow run where the publish-pypi job passed.",
+        }
+        if publish_job is None:
+            result["available_jobs"] = _job_summaries(jobs)
+        else:
+            result.update(
+                {
+                    "job_name": publish_job.get("name"),
+                    "job_status": publish_job.get("status"),
+                    "job_conclusion": publish_job.get("conclusion"),
+                }
+            )
+        return result, None
+
+    reference = str(payload.get("url", "")) or raw_reference
+    file_count = len(filenames)
+    summary = (
+        f"PyPI project policynim version {version} exposes {file_count} release "
+        f"files and Release run {run_id} completed publish-pypi successfully "
+        f"with trusted publishing for release commit {expected_head_sha}."
+    )
+    return {
+        "status": "passed",
+        "reference": reference,
+        "project_url": project_url,
+        "version": version,
+        "file_count": file_count,
+        "filenames": filenames,
+        "run_id": run_id,
+        "head_sha": actual_head_sha,
+    }, _evidence_record(
+        summary=summary,
+        reference=reference,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_github_labels(
+    *,
+    repo_root: Path,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    labels_file = repo_root / ".github" / "labels.yml"
+    try:
+        desired = load_label_taxonomy(labels_file)
+    except LabelSyncError as exc:
+        return {
+            "status": "error",
+            "next_step": "Restore .github/labels.yml before collecting label evidence.",
+            "detail": str(exc),
+        }, None
+
+    command = ["gh", "label", "list", "--json", "name,color,description", "--limit", "1000"]
+    completed = runner(command)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Authenticate gh and rerun the collector from the repository root.",
+            "detail": detail or f"gh exited with status {completed.returncode}",
+        }, None
+    try:
+        raw_existing = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Return valid JSON from gh label list.",
+            "detail": str(exc),
+        }, None
+    if not isinstance(raw_existing, list):
+        raw_existing = []
+    existing = [
+        {
+            "name": str(label.get("name", "")),
+            "color": str(label.get("color", "")),
+            "description": str(label.get("description", "")),
+        }
+        for label in raw_existing
+        if isinstance(label, dict)
+    ]
+    plan = plan_label_sync(desired, existing)
+    drift = [entry for entry in plan if entry["action"] != "noop"]
+    if drift:
+        return {
+            "status": "label_drift",
+            "missing_or_changed": [entry["name"] for entry in drift],
+            "next_step": (
+                "Run `gh auth status`, then "
+                "`uv run python scripts/sync_github_labels.py --live --format json`, "
+                "then `uv run python scripts/sync_github_labels.py --apply --format json`, "
+                "then rerun this collector."
+            ),
+        }, None
+    return {
+        "status": "passed",
+        "label_count": len(desired),
+        "reference": "gh label list --json name,color,description --limit 1000",
+    }, _evidence_record(
+        summary="GitHub labels match .github/labels.yml.",
+        reference="gh label list --json name,color,description --limit 1000",
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_github_topics(
+    *,
+    repo_root: Path,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    topics_file = repo_root / ".github" / "topics.yml"
+    try:
+        desired = load_topic_taxonomy(topics_file)
+    except TopicSyncError as exc:
+        return {
+            "status": "error",
+            "next_step": "Restore .github/topics.yml before collecting topic evidence.",
+            "detail": str(exc),
+        }, None
+
+    command = ["gh", "repo", "view", "--json", "repositoryTopics,nameWithOwner"]
+    completed = runner(command)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Authenticate gh and rerun the collector from the repository root.",
+            "detail": detail or f"gh exited with status {completed.returncode}",
+        }, None
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Return valid JSON from gh repo view.",
+            "detail": str(exc),
+        }, None
+    if not isinstance(payload, dict):
+        payload = {}
+    raw_topics = payload.get("repositoryTopics")
+    if not isinstance(raw_topics, list):
+        raw_topics = []
+    existing = [
+        str(topic.get("name", ""))
+        for topic in raw_topics
+        if isinstance(topic, dict) and topic.get("name")
+    ]
+    plan = plan_topic_sync(desired, existing)
+    drift = [entry for entry in plan if entry["action"] != "noop"]
+    if drift:
+        return {
+            "status": "topic_drift",
+            "missing_or_changed": [entry["topic"] for entry in drift],
+            "next_step": (
+                "Run `gh auth status`, then "
+                "`uv run python scripts/sync_github_topics.py --live --format json`, "
+                "then `uv run python scripts/sync_github_topics.py --apply --format json`, "
+                "then rerun this collector."
+            ),
+        }, None
+    return {
+        "status": "passed",
+        "topic_count": len(desired),
+        "reference": "gh repo view --json repositoryTopics,nameWithOwner",
+    }, _evidence_record(
+        summary="GitHub repository topics match .github/topics.yml.",
+        reference="gh repo view --json repositoryTopics,nameWithOwner",
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_hosted_mcp_domain(
+    *,
+    hosted_mcp_url: str,
+    verified_by: str,
+    verified_at: str,
+    urlopen: UrlOpener,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    raw_url = hosted_mcp_url.strip()
+    if not raw_url:
+        return {
+            "status": "manual_required",
+            "next_step": _manual_next_step("hosted_mcp_domain"),
+        }, None
+
+    try:
+        mcp_url = _normalize_hosted_mcp_url(raw_url)
+    except ValueError as exc:
+        return {
+            "status": "invalid_url",
+            "reference": raw_url,
+            "next_step": str(exc),
+        }, None
+
+    health_url = _same_origin_url(mcp_url, "/healthz")
+    health_status, health_payload, health_error = _fetch_json(
+        health_url,
+        urlopen=urlopen,
+        timeout=15,
+    )
+    if health_error:
+        return {
+            "status": "error",
+            "reference": health_url,
+            "next_step": "Fix hosted /healthz before collecting hosted MCP evidence.",
+            "detail": health_error,
+        }, None
+    if health_status != 200:
+        return {
+            "status": "healthz_unhealthy",
+            "reference": health_url,
+            "status_code": health_status,
+            "next_step": "Hosted /healthz must return 200 before launch evidence is valid.",
+        }, None
+    if not isinstance(health_payload, dict):
+        return {
+            "status": "invalid_healthz_payload",
+            "reference": health_url,
+            "next_step": "Hosted /healthz must return a JSON object.",
+        }, None
+
+    row_count = health_payload.get("row_count")
+    health_mcp_url = str(health_payload.get("mcp_url", ""))
+    if (
+        health_payload.get("ready") is not True
+        or health_payload.get("status") != "ok"
+        or not isinstance(row_count, int)
+        or isinstance(row_count, bool)
+        or row_count <= 0
+        or health_mcp_url != mcp_url
+    ):
+        return {
+            "status": "healthz_not_ready",
+            "reference": health_url,
+            "next_step": (
+                "Hosted /healthz must report ready=true, status=ok, row_count > 0, "
+                "and an mcp_url matching the requested /mcp endpoint."
+            ),
+            "payload": health_payload,
+        }, None
+
+    mcp_request = urllib.request.Request(
+        mcp_url,
+        headers={
+            "Accept": "text/event-stream",
+            "Authorization": "Bearer invalid-token",
+        },
+    )
+    mcp_status, _, mcp_error = _fetch_json(mcp_request, urlopen=urlopen, timeout=15)
+    if mcp_error:
+        return {
+            "status": "error",
+            "reference": mcp_url,
+            "next_step": "Fix hosted /mcp invalid-token probing before collecting evidence.",
+            "detail": mcp_error,
+        }, None
+    if mcp_status != 401:
+        return {
+            "status": "mcp_auth_not_enforced",
+            "reference": mcp_url,
+            "status_code": mcp_status,
+            "next_step": "Hosted /mcp must return 401 for an invalid bearer token.",
+        }, None
+
+    origin = _same_origin_url(mcp_url, "")
+    summary = (
+        f"Hosted MCP domain {origin} reports ready /healthz with row_count {row_count} "
+        "and rejects invalid bearer tokens on /mcp."
+    )
+    return {
+        "status": "passed",
+        "reference": health_url,
+        "row_count": row_count,
+        "mcp_url": mcp_url,
+    }, _evidence_record(
+        summary=summary,
+        reference=health_url,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _probe_hosted_smoke_run(
+    *,
+    hosted_smoke_run_url: str,
+    release_target_commitish: str,
+    verified_by: str,
+    verified_at: str,
+    runner: Runner,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    raw_reference = hosted_smoke_run_url.strip()
+    if not raw_reference:
+        return {
+            "status": "manual_required",
+            "next_step": _manual_next_step("hosted_beta_live_smoke"),
+        }, None
+
+    try:
+        run_id = _extract_github_run_id(raw_reference)
+    except ValueError as exc:
+        return {
+            "status": "invalid_run_url",
+            "reference": raw_reference,
+            "next_step": str(exc),
+        }, None
+
+    command = ["gh", "run", "view", run_id, "--json", GITHUB_RUN_FIELDS]
+    completed = runner(command)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Authenticate gh and verify the Hosted Beta Smoke run URL.",
+            "detail": detail or f"gh exited with status {completed.returncode}",
+        }, None
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "error",
+            "command": command,
+            "next_step": "Return valid JSON from gh run view.",
+            "detail": str(exc),
+        }, None
+
+    workflow_name = str(payload.get("workflowName", ""))
+    if workflow_name != "Hosted Beta Smoke":
+        return {
+            "status": "wrong_workflow",
+            "reference": raw_reference,
+            "workflow_name": workflow_name,
+            "next_step": "Use a GitHub Actions run from the Hosted Beta Smoke workflow.",
+        }, None
+    if payload.get("event") != "workflow_dispatch":
+        return {
+            "status": "wrong_event",
+            "reference": raw_reference,
+            "event": payload.get("event"),
+            "next_step": "Use a manually dispatched Hosted Beta Smoke run.",
+        }, None
+    if payload.get("status") != "completed" or payload.get("conclusion") != "success":
+        return {
+            "status": "run_not_successful",
+            "reference": raw_reference,
+            "run_status": payload.get("status"),
+            "conclusion": payload.get("conclusion"),
+            "next_step": (
+                "Use a Hosted Beta Smoke run with completed status and success conclusion."
+            ),
+        }, None
+    expected_head_sha = release_target_commitish.strip()
+    actual_head_sha = str(payload.get("headSha", "")).strip()
+    if not expected_head_sha:
+        return {
+            "status": "release_sha_missing",
+            "reference": raw_reference,
+            "next_step": (
+                "Collect GitHub release evidence first so the hosted smoke run "
+                "can be matched to the release target commit."
+            ),
+        }, None
+    if actual_head_sha != expected_head_sha:
+        return {
+            "status": "release_sha_mismatch",
+            "reference": raw_reference,
+            "expected_head_sha": expected_head_sha,
+            "actual_head_sha": actual_head_sha,
+            "next_step": (
+                "Use a Hosted Beta Smoke run from the same commit as the GitHub "
+                "release target before filling hosted smoke evidence."
+            ),
+        }, None
+
+    jobs = payload.get("jobs")
+    if not _has_successful_hosted_smoke_job(jobs):
+        return {
+            "status": "job_not_successful",
+            "reference": raw_reference,
+            "next_step": "Use a Hosted Beta Smoke run where the hosted-smoke job passed.",
+        }, None
+
+    artifact_probe = _download_and_validate_hosted_smoke_artifact(
+        run_id=run_id,
+        runner=runner,
+    )
+    if artifact_probe["status"] != "passed":
+        artifact_probe["reference"] = raw_reference
+        return artifact_probe, None
+
+    reference = str(payload.get("url", "")) or raw_reference
+    test_count = artifact_probe["test_count"]
+    summary = (
+        f"Hosted Beta Smoke run {run_id} completed successfully with "
+        f"{HOSTED_SMOKE_ARTIFACT_NAME}/{HOSTED_SMOKE_JUNIT_FILENAME} covering "
+        f"{test_count} live MCP checks from release commit {expected_head_sha}."
+    )
+    return {
+        "status": "passed",
+        "reference": reference,
+        "run_id": run_id,
+        "workflow_name": workflow_name,
+        "head_sha": actual_head_sha,
+        "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+        "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+        "test_count": test_count,
+    }, _evidence_record(
+        summary=summary,
+        reference=reference,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _download_and_validate_hosted_smoke_artifact(
+    *,
+    run_id: str,
+    runner: Runner,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="policynim-hosted-smoke.") as download_tmp:
+        download_dir = Path(download_tmp)
+        command = [
+            "gh",
+            "run",
+            "download",
+            run_id,
+            "--name",
+            HOSTED_SMOKE_ARTIFACT_NAME,
+            "--dir",
+            str(download_dir),
+        ]
+        completed = runner(command)
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            return {
+                "status": "artifact_download_failed",
+                "command": command,
+                "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+                "next_step": (
+                    "Download the hosted-smoke-evidence artifact from the Hosted "
+                    "Beta Smoke run before collecting hosted smoke evidence."
+                ),
+                "detail": detail or f"gh exited with status {completed.returncode}",
+            }
+
+        candidates = sorted(download_dir.rglob(HOSTED_SMOKE_JUNIT_FILENAME))
+        if not candidates:
+            return {
+                "status": "junit_missing",
+                "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+                "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+                "next_step": (
+                    "Use a Hosted Beta Smoke run that uploaded "
+                    f"{HOSTED_SMOKE_ARTIFACT_NAME}/{HOSTED_SMOKE_JUNIT_FILENAME}."
+                ),
+            }
+        return _validate_hosted_smoke_junit(candidates[0])
+
+
+def _validate_hosted_smoke_junit(junit_path: Path) -> dict[str, Any]:
+    try:
+        root = ET.parse(junit_path).getroot()
+    except (OSError, ET.ParseError) as exc:
+        return {
+            "status": "junit_invalid",
+            "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+            "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+            "next_step": "Use a parseable Hosted Beta Smoke JUnit XML artifact.",
+            "detail": str(exc),
+        }
+
+    testcases = [element for element in root.iter() if _xml_local_name(element.tag) == "testcase"]
+    present_tests = {
+        str(testcase.attrib.get("name", ""))
+        for testcase in testcases
+        if testcase.attrib.get("name")
+    }
+    missing_tests = [
+        test_name for test_name in expected_hosted_smoke_tests() if test_name not in present_tests
+    ]
+    if missing_tests:
+        return {
+            "status": "junit_missing_tests",
+            "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+            "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+            "missing_tests": missing_tests,
+            "next_step": (
+                "Use a Hosted Beta Smoke JUnit artifact that includes every "
+                "required live MCP smoke test."
+            ),
+        }
+
+    unsuccessful_tests = [
+        str(testcase.attrib.get("name", ""))
+        for testcase in testcases
+        if str(testcase.attrib.get("name", "")) in expected_hosted_smoke_tests()
+        and any(
+            _xml_local_name(child.tag) in {"failure", "error", "skipped"}
+            for child in list(testcase)
+        )
+    ]
+    if unsuccessful_tests:
+        return {
+            "status": "junit_not_successful",
+            "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+            "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+            "unsuccessful_tests": unsuccessful_tests,
+            "next_step": "Use a Hosted Beta Smoke JUnit artifact where every live test passed.",
+        }
+
+    return {
+        "status": "passed",
+        "artifact": HOSTED_SMOKE_ARTIFACT_NAME,
+        "junit_file": HOSTED_SMOKE_JUNIT_FILENAME,
+        "test_count": len(expected_hosted_smoke_tests()),
+    }
+
+
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _probe_mcp_client_evidence_file(
+    *,
+    mcp_client_evidence_file: Path | None,
+    verified_by: str,
+    verified_at: str,
+) -> tuple[dict[str, Any], dict[str, str] | None]:
+    if mcp_client_evidence_file is None:
+        return {
+            "status": "manual_required",
+            "next_step": _manual_next_step("real_mcp_client_session"),
+        }, None
+    try:
+        payload = json.loads(mcp_client_evidence_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return {
+            "status": "error",
+            "reference": str(mcp_client_evidence_file),
+            "next_step": "Read the MCP client-session evidence JSON file.",
+            "detail": str(exc),
+        }, None
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "error",
+            "reference": str(mcp_client_evidence_file),
+            "next_step": "Provide valid JSON for MCP client-session evidence.",
+            "detail": str(exc),
+        }, None
+    if not isinstance(payload, dict):
+        return {
+            "status": "invalid_evidence",
+            "reference": str(mcp_client_evidence_file),
+            "next_step": "MCP client-session evidence must be a JSON object.",
+        }, None
+
+    validation_error = _validate_mcp_client_evidence_payload(payload)
+    if validation_error is not None:
+        return {
+            "status": validation_error["status"],
+            "reference": str(mcp_client_evidence_file),
+            "next_step": validation_error["next_step"],
+        }, None
+
+    client = str(payload["client"])
+    transport = str(payload["transport"])
+    reference = str(payload["reference"])
+    client_label = "Codex" if client == "codex" else "Claude Code"
+    summary = (
+        f"{client_label} loaded the policynim MCP server over {transport} using a "
+        "reviewed setup command, listed policy_preflight and policy_search, and "
+        "called policy_preflight."
+    )
+    return {
+        "status": "passed",
+        "reference": reference,
+        "client": client,
+        "transport": transport,
+    }, _evidence_record(
+        summary=summary,
+        reference=reference,
+        verified_by=verified_by,
+        verified_at=verified_at,
+    )
+
+
+def _validate_mcp_client_evidence_payload(payload: dict[str, Any]) -> dict[str, str] | None:
+    client = payload.get("client")
+    if client not in {"codex", "claude-code"}:
+        return {
+            "status": "unsupported_client",
+            "next_step": "Use client 'codex' or 'claude-code' in MCP client evidence.",
+        }
+    transport = payload.get("transport")
+    if transport not in {"hosted-http", "local-stdio"}:
+        return {
+            "status": "unsupported_transport",
+            "next_step": "Use transport 'hosted-http' or 'local-stdio' in MCP client evidence.",
+        }
+    if payload.get("server_name") != "policynim":
+        return {
+            "status": "wrong_server",
+            "next_step": "MCP client evidence must show the policynim server entry.",
+        }
+    reference = payload.get("reference")
+    if not isinstance(reference, str) or not reference.strip():
+        return {
+            "status": "missing_reference",
+            "next_step": "MCP client evidence must include a non-empty sanitized reference.",
+        }
+    if _contains_placeholder_reference(reference):
+        return {
+            "status": "placeholder_reference",
+            "next_step": (
+                "MCP client evidence must include a real, sanitized reference "
+                "instead of an example or placeholder value."
+            ),
+        }
+    setup_error = _validate_mcp_client_setup_command(
+        client=str(client),
+        transport=str(transport),
+        setup_command=payload.get("setup_command"),
+    )
+    if setup_error is not None:
+        return setup_error
+    tools = payload.get("tools")
+    if not isinstance(tools, list) or any(not isinstance(tool, str) for tool in tools):
+        return {
+            "status": "invalid_tools",
+            "next_step": "MCP client evidence must include a tools string list.",
+        }
+    missing_tools = [tool for tool in _expected_mcp_tools() if tool not in tools]
+    if missing_tools:
+        return {
+            "status": "missing_tools",
+            "next_step": f"MCP client evidence is missing tools: {', '.join(missing_tools)}.",
+        }
+    if payload.get("called_tool") != "policy_preflight":
+        return {
+            "status": "preflight_not_called",
+            "next_step": "MCP client evidence must show a policy_preflight call.",
+        }
+    if payload.get("secrets_included") is not False:
+        return {
+            "status": "secrets_included",
+            "next_step": (
+                "Attach a redacted MCP client-session reference with secrets_included=false."
+            ),
+        }
+    return None
+
+
+def _validate_mcp_client_setup_command(
+    *,
+    client: str,
+    transport: str,
+    setup_command: object,
+) -> dict[str, str] | None:
+    if not isinstance(setup_command, str) or not setup_command.strip():
+        return {
+            "status": "missing_setup_command",
+            "next_step": (
+                "MCP client evidence must include the secret-safe setup command "
+                "used to add the policynim MCP server."
+            ),
+        }
+
+    normalized = " ".join(setup_command.split())
+    if _contains_placeholder_reference(normalized):
+        return {
+            "status": "placeholder_setup_command",
+            "next_step": (
+                "MCP client evidence must include a real setup command instead "
+                "of a placeholder hosted URL, example reference, or TODO value."
+            ),
+        }
+
+    secret_markers = (
+        "<generated-beta-token>",
+        "<issued-beta-token>",
+        "generated-beta-token",
+        "issued-beta-token",
+        "POLICYNIM_TOKEN=",
+        "POLICYNIM_BETA_MCP_TOKEN=",
+    )
+    if any(marker in normalized for marker in secret_markers):
+        return {
+            "status": "setup_command_secrets_included",
+            "next_step": (
+                "Use a redacted setup command with token environment-variable "
+                "references instead of token values."
+            ),
+        }
+
+    missing_tokens = _mcp_client_setup_command_missing_tokens(
+        client=client,
+        transport=transport,
+        normalized_command=normalized,
+    )
+    if missing_tokens:
+        return {
+            "status": "setup_command_mismatch",
+            "next_step": (
+                "MCP client setup command does not match the declared client and "
+                f"transport. Missing: {', '.join(missing_tokens)}."
+            ),
+        }
+    return None
+
+
+def _mcp_client_setup_command_missing_tokens(
+    *,
+    client: str,
+    transport: str,
+    normalized_command: str,
+) -> list[str]:
+    if client == "codex" and transport == "hosted-http":
+        required = (
+            "codex mcp add",
+            "policynim",
+            "--url",
+            "/mcp",
+            "--bearer-token-env-var",
+            "POLICYNIM_TOKEN",
+        )
+    elif client == "claude-code" and transport == "hosted-http":
+        required = (
+            "claude mcp add",
+            "--transport http",
+            "policynim",
+            "/mcp",
+            "--header",
+            "Authorization: Bearer $POLICYNIM_TOKEN",
+        )
+    elif client == "codex" and transport == "local-stdio":
+        required = (
+            "codex mcp add",
+            "policynim",
+            "NVIDIA_API_KEY",
+            "mcp",
+            "--transport",
+            "stdio",
+        )
+    else:
+        required = (
+            "claude mcp add-json",
+            "policynim",
+            "stdio",
+            "command",
+            "args",
+            "NVIDIA_API_KEY",
+        )
+    return [token for token in required if token not in normalized_command]
+
+
+def _contains_placeholder_reference(value: str) -> bool:
+    normalized = value.casefold()
+    return any(marker in normalized for marker in PLACEHOLDER_REFERENCE_MARKERS)
+
+
+def _expected_mcp_tools() -> tuple[str, str]:
+    return ("policy_preflight", "policy_search")
+
+
+def _extract_github_run_id(value: str) -> str:
+    if value.isdigit():
+        return value
+    parts = urllib.parse.urlsplit(value)
+    path_parts = [part for part in parts.path.split("/") if part]
+    if parts.scheme != "https" or parts.netloc != "github.com" or len(path_parts) < 5:
+        raise ValueError(
+            "Hosted Beta Smoke evidence requires a GitHub run URL like "
+            "https://github.com/<owner>/<repo>/actions/runs/<run-id> or a run id."
+        )
+    try:
+        actions_index = path_parts.index("actions")
+    except ValueError as exc:
+        raise ValueError("Hosted Beta Smoke evidence requires a GitHub Actions run URL.") from exc
+    if (
+        actions_index + 2 >= len(path_parts)
+        or path_parts[actions_index + 1] != "runs"
+        or not path_parts[actions_index + 2].isdigit()
+    ):
+        raise ValueError(
+            "Hosted Beta Smoke evidence requires a GitHub Actions run URL ending "
+            "in /actions/runs/<run-id>."
+        )
+    return path_parts[actions_index + 2]
+
+
+def _has_successful_hosted_smoke_job(jobs: object) -> bool:
+    return _has_successful_job(jobs, "hosted-smoke")
+
+
+def _has_successful_job(jobs: object, name: str) -> bool:
+    return _is_successful_job(_find_job(jobs, name))
+
+
+def _find_job(jobs: object, name: str) -> dict[str, Any] | None:
+    if not isinstance(jobs, list):
+        return None
+    for job in jobs:
+        if isinstance(job, dict) and job.get("name") == name:
+            return job
+    return None
+
+
+def _is_successful_job(job: dict[str, Any] | None) -> bool:
+    return (
+        job is not None and job.get("status") == "completed" and job.get("conclusion") == "success"
+    )
+
+
+def _job_summaries(jobs: object) -> list[dict[str, object]]:
+    if not isinstance(jobs, list):
+        return []
+    summaries: list[dict[str, object]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        summaries.append(
+            {
+                "conclusion": job.get("conclusion"),
+                "name": job.get("name"),
+                "status": job.get("status"),
+            }
+        )
+    return summaries
+
+
+def _normalize_hosted_mcp_url(value: str) -> str:
+    parts = urllib.parse.urlsplit(value)
+    if parts.scheme != "https" or not parts.netloc:
+        raise ValueError("Hosted MCP launch evidence requires an absolute https://.../mcp URL.")
+    if parts.path.rstrip("/") != "/mcp":
+        raise ValueError("Hosted MCP launch evidence URL must point to the /mcp route.")
+    if parts.query or parts.fragment:
+        raise ValueError("Hosted MCP launch evidence URL must not include a query or fragment.")
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, "/mcp", "", ""))
+
+
+def _same_origin_url(url: str, path: str) -> str:
+    parts = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+def _fetch_json(
+    request: urllib.request.Request | str,
+    *,
+    urlopen: UrlOpener,
+    timeout: float,
+) -> tuple[int, object | None, str]:
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return int(response.status), json.load(response), ""
+    except urllib.error.HTTPError as exc:
+        return exc.code, _load_json_bytes(exc.read()), ""
+    except json.JSONDecodeError as exc:
+        return 0, None, f"Invalid JSON response: {exc}"
+    except (OSError, urllib.error.URLError) as exc:
+        return 0, None, str(exc)
+
+
+def _load_json_bytes(payload: bytes) -> object | None:
+    if not payload:
+        return None
+    try:
+        return json.loads(payload.decode())
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _fetch_pypi_payload() -> dict[str, Any] | None:
+    url = "https://pypi.org/pypi/policynim/json"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as response:
+            payload = json.load(response)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _evidence_record(
+    *,
+    summary: str,
+    reference: str,
+    verified_by: str,
+    verified_at: str,
+) -> dict[str, str]:
+    return {
+        "summary": summary,
+        "reference": reference,
+        "verified_by": verified_by,
+        "verified_at": verified_at,
+    }
+
+
+def _default_release_tag(repo_root: Path) -> str:
+    project = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    version = str(project["project"]["version"])
+    return f"v{version}"
+
+
+def _manual_next_step(name: str) -> str:
+    return {
+        "hosted_mcp_domain": (
+            "Attach public /healthz and /mcp evidence from the deployed hosted MCP domain."
+        ),
+        "hosted_beta_live_smoke": (
+            "Run Hosted Beta Smoke with secrets and attach the GitHub Actions run URL."
+        ),
+        "real_mcp_client_session": (
+            "Attach a real Codex or Claude Code MCP client session transcript or screenshot "
+            "showing the secret-safe setup command and policy_preflight call."
+        ),
+    }[name]
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "PolicyNIM launch evidence collection",
+        f"Release tag: {payload['release_tag']}",
+        "",
+        "Probes:",
+    ]
+    probes = payload.get("probes", {})
+    if isinstance(probes, dict):
+        for name, probe in probes.items():
+            if isinstance(probe, dict):
+                lines.append(f"- {name}: {probe.get('status', 'unknown')}")
+                job_detail = _render_probe_job_detail(probe)
+                if job_detail:
+                    lines.append(f"  job: {job_detail}")
+                available_jobs = _render_available_jobs(probe.get("available_jobs"))
+                if available_jobs:
+                    lines.append(f"  available jobs: {available_jobs}")
+                detail = probe.get("detail")
+                if isinstance(detail, str) and detail:
+                    lines.append(f"  detail: {detail}")
+                next_step = probe.get("next_step")
+                if next_step:
+                    lines.append(f"  next: {next_step}")
+    requested_failures = _render_requested_probe_failures(payload.get("requested_probe_failures"))
+    if requested_failures:
+        lines.extend(["", "Requested probe failures:", *requested_failures])
+    return "\n".join(lines)
+
+
+def _render_requested_probe_failures(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    lines: list[str] = []
+    for failure in value:
+        if not isinstance(failure, dict):
+            continue
+        name = failure.get("name")
+        status = failure.get("status")
+        next_step = failure.get("next_step")
+        if not isinstance(name, str) or not isinstance(status, str):
+            continue
+        lines.append(f"- {name}: {status}")
+        if isinstance(next_step, str) and next_step:
+            lines.append(f"  next: {next_step}")
+    return lines
+
+
+def _render_probe_job_detail(probe: dict[str, Any]) -> str:
+    job_name = probe.get("job_name")
+    job_status = probe.get("job_status")
+    job_conclusion = probe.get("job_conclusion")
+    job_fields = (job_name, job_status, job_conclusion)
+    if not all(isinstance(value, str) and value for value in job_fields):
+        return ""
+    return f"{job_name} {job_status}/{job_conclusion}"
+
+
+def _render_available_jobs(value: object) -> str:
+    if not isinstance(value, list):
+        return ""
+    rendered_jobs: list[str] = []
+    for job in value:
+        if not isinstance(job, dict):
+            continue
+        name = job.get("name")
+        status = job.get("status")
+        conclusion = job.get("conclusion")
+        if not all(isinstance(item, str) and item for item in (name, status, conclusion)):
+            continue
+        rendered_jobs.append(f"{name} {status}/{conclusion}")
+    return ", ".join(rendered_jobs)
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -1,0 +1,298 @@
+"""Dry-run or apply the PolicyNIM GitHub label taxonomy with gh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LABELS_FILE = REPO_ROOT / ".github" / "labels.yml"
+GITHUB_LABEL_LIST_COMMAND = "gh label list --json name,color,description --limit 1000"
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+Action = Literal["create", "update", "noop"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--labels-file",
+        type=Path,
+        default=DEFAULT_LABELS_FILE,
+        help="Path to the repository label taxonomy.",
+    )
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply create/update operations with gh. Defaults to dry-run.",
+    )
+    mode_group.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Compare against current GitHub labels without applying changes. "
+            "Defaults to offline dry-run."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for the sync plan.",
+    )
+    args = parser.parse_args()
+
+    try:
+        desired = load_label_taxonomy(args.labels_file)
+        result = sync_labels(
+            desired=desired,
+            apply=args.apply,
+            live=args.live,
+            labels_file=args.labels_file.resolve(strict=False),
+        )
+    except LabelSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+    return 0
+
+
+class LabelSyncError(Exception):
+    """GitHub label sync failed."""
+
+
+def load_label_taxonomy(path: Path) -> list[dict[str, str]]:
+    """Load the limited YAML label taxonomy used by this repository."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise LabelSyncError(f"Could not read label taxonomy {path}: {exc}") from exc
+
+    labels: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- name:"):
+            if current is not None:
+                labels.append(_validate_label(current))
+            current = {"name": _unquote(stripped.removeprefix("- name:").strip())}
+            continue
+        if current is None:
+            raise LabelSyncError(f"Unexpected label taxonomy line before a name: {raw_line}")
+        key, separator, raw_value = stripped.partition(":")
+        if not separator:
+            raise LabelSyncError(f"Invalid label taxonomy line: {raw_line}")
+        if key not in {"color", "description"}:
+            raise LabelSyncError(f"Unsupported label field {key!r} in {raw_line!r}.")
+        current[key] = _unquote(raw_value.strip())
+    if current is not None:
+        labels.append(_validate_label(current))
+    if not labels:
+        raise LabelSyncError(f"No labels found in {path}.")
+    return labels
+
+
+def plan_label_sync(
+    desired: list[dict[str, str]],
+    existing: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Return deterministic create/update/noop actions for desired labels."""
+    existing_by_name = {label["name"]: label for label in existing}
+    plan: list[dict[str, Any]] = []
+    for label in desired:
+        current = existing_by_name.get(label["name"])
+        if current is None:
+            plan.append({"action": "create", **label})
+            continue
+        updates: dict[str, dict[str, str]] = {}
+        for key in ("color", "description"):
+            if current.get(key, "") != label[key]:
+                updates[key] = {"from": current.get(key, ""), "to": label[key]}
+        if updates:
+            plan.append({"action": "update", **label, "updates": updates})
+        else:
+            plan.append({"action": "noop", **label})
+    return plan
+
+
+def sync_labels(
+    *,
+    desired: list[dict[str, str]],
+    apply: bool,
+    live: bool = False,
+    labels_file: Path | None = None,
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Build or apply a GitHub label sync plan."""
+    if apply and live:
+        raise LabelSyncError("--apply and --live cannot be used together.")
+    command_runner = runner or _run_command
+    existing = _load_existing_labels(command_runner) if apply or live else []
+    plan = plan_label_sync(desired, existing)
+    if apply:
+        for entry in plan:
+            _apply_plan_entry(entry, command_runner)
+    mode = "apply" if apply else "live-dry-run" if live else "dry-run"
+    return {
+        "schema_version": "1",
+        "mode": mode,
+        "labels_file": str(labels_file) if labels_file is not None else None,
+        "plan": plan,
+        "next_step": _next_step_for_mode(apply=apply, live=live, plan=plan),
+    }
+
+
+def _load_existing_labels(runner: Runner) -> list[dict[str, str]]:
+    command = ["gh", "label", "list", "--json", "name,color,description", "--limit", "1000"]
+    completed = _run_gh(command, runner, failure="list existing GitHub labels")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise LabelSyncError(f"Could not parse gh label list JSON: {exc}") from exc
+    if not isinstance(payload, list):
+        raise LabelSyncError("gh label list returned JSON that was not a list.")
+    labels: list[dict[str, str]] = []
+    for raw_label in payload:
+        if not isinstance(raw_label, dict):
+            raise LabelSyncError("gh label list returned a non-object label entry.")
+        labels.append(
+            {
+                "name": str(raw_label.get("name", "")),
+                "color": str(raw_label.get("color", "")),
+                "description": str(raw_label.get("description", "")),
+            }
+        )
+    return labels
+
+
+def _apply_plan_entry(entry: dict[str, Any], runner: Runner) -> None:
+    action = entry["action"]
+    if action == "noop":
+        return
+    if action == "create":
+        command = [
+            "gh",
+            "label",
+            "create",
+            str(entry["name"]),
+            "--color",
+            str(entry["color"]),
+            "--description",
+            str(entry["description"]),
+        ]
+    elif action == "update":
+        command = [
+            "gh",
+            "label",
+            "edit",
+            str(entry["name"]),
+            "--color",
+            str(entry["color"]),
+            "--description",
+            str(entry["description"]),
+        ]
+    else:
+        raise LabelSyncError(f"Unsupported label sync action: {action}")
+
+    _run_gh(command, runner, failure=f"{action} label {entry['name']}")
+
+
+def _run_gh(
+    command: list[str],
+    runner: Runner,
+    *,
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = runner(command)
+    except OSError as exc:
+        raise LabelSyncError(_gh_recovery_message("GitHub CLI is required")) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        if not detail:
+            detail = f"gh exited with status {completed.returncode}"
+        raise LabelSyncError(f"Could not {failure}: {detail}. {_gh_recovery_message('Recovery')}")
+    return completed
+
+
+def _gh_recovery_message(prefix: str) -> str:
+    return (
+        f"{prefix} for live/apply label sync. Install `gh`, run `gh auth status`, "
+        "rerun with `--live` to inspect the GitHub delta, then rerun with "
+        "`--apply` only when ready to mutate labels."
+    )
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _next_step_for_mode(
+    *,
+    apply: bool,
+    live: bool,
+    plan: list[dict[str, Any]],
+) -> str:
+    if apply:
+        return "Applied non-noop label changes with gh."
+    if live:
+        if any(entry["action"] != "noop" for entry in plan):
+            return "Review the live label plan, then rerun with --apply when ready."
+        return "GitHub labels already match .github/labels.yml."
+    return (
+        "Run with --live to compare against current GitHub state "
+        f"(`{GITHUB_LABEL_LIST_COMMAND}`), or rerun with --apply when ready."
+    )
+
+
+def _validate_label(label: dict[str, str]) -> dict[str, str]:
+    required = ("name", "color", "description")
+    missing = [key for key in required if not label.get(key)]
+    if missing:
+        raise LabelSyncError(
+            f"Label entry {label.get('name') or '<unknown>'} is missing: {', '.join(missing)}"
+        )
+    color = label["color"].strip().removeprefix("#")
+    if len(color) != 6 or any(character not in "0123456789abcdefABCDEF" for character in color):
+        raise LabelSyncError(f"Label {label['name']} has invalid hex color: {label['color']}")
+    return {
+        "name": label["name"].strip(),
+        "color": color.lower(),
+        "description": label["description"].strip(),
+    }
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines = [
+        "PolicyNIM GitHub label sync",
+        f"Mode: {result['mode']}",
+        f"Labels file: {result['labels_file']}",
+        "",
+        "Plan:",
+    ]
+    for entry in result["plan"]:
+        lines.append(f"- {entry['action']}: {entry['name']}")
+    lines.extend(["", f"Next step: {result['next_step']}"])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_github_topics.py
+++ b/scripts/sync_github_topics.py
@@ -1,0 +1,261 @@
+"""Dry-run or apply the PolicyNIM GitHub repository topic taxonomy with gh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TOPICS_FILE = REPO_ROOT / ".github" / "topics.yml"
+GITHUB_TOPIC_LIST_COMMAND = "gh repo view --json repositoryTopics,nameWithOwner"
+TOPIC_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,49}$")
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+Action = Literal["add", "remove", "noop", "ensure"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--topics-file",
+        type=Path,
+        default=DEFAULT_TOPICS_FILE,
+        help="Path to the repository topic taxonomy.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repository in OWNER/REPO form. Defaults to gh's current repo.",
+    )
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply add/remove topic operations with gh. Defaults to dry-run.",
+    )
+    mode_group.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Compare against current GitHub topics without applying changes. "
+            "Defaults to offline dry-run."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for the sync plan.",
+    )
+    args = parser.parse_args()
+
+    try:
+        desired = load_topic_taxonomy(args.topics_file)
+        result = sync_topics(
+            desired=desired,
+            apply=args.apply,
+            live=args.live,
+            repo=args.repo,
+            topics_file=args.topics_file.resolve(strict=False),
+        )
+    except TopicSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+    return 0
+
+
+class TopicSyncError(Exception):
+    """GitHub topic sync failed."""
+
+
+def load_topic_taxonomy(path: Path) -> list[str]:
+    """Load the limited YAML topic taxonomy used by this repository."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise TopicSyncError(f"Could not read topic taxonomy {path}: {exc}") from exc
+
+    topics: list[str] = []
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not stripped.startswith("- "):
+            raise TopicSyncError(f"Invalid topic taxonomy line: {raw_line}")
+        topic = stripped.removeprefix("- ").strip()
+        topics.append(_validate_topic(topic))
+    if not topics:
+        raise TopicSyncError(f"No topics found in {path}.")
+    duplicates = sorted({topic for topic in topics if topics.count(topic) > 1})
+    if duplicates:
+        raise TopicSyncError(f"Duplicate topics found: {', '.join(duplicates)}")
+    return topics
+
+
+def plan_topic_sync(desired: list[str], existing: list[str]) -> list[dict[str, str]]:
+    """Return deterministic add/remove/noop actions for desired topics."""
+    existing_topics = set(existing)
+    desired_topics = set(desired)
+    plan: list[dict[str, str]] = []
+    for topic in desired:
+        action: Action = "noop" if topic in existing_topics else "add"
+        plan.append({"action": action, "topic": topic})
+    for topic in sorted(existing_topics - desired_topics):
+        plan.append({"action": "remove", "topic": topic})
+    return plan
+
+
+def sync_topics(
+    *,
+    desired: list[str],
+    apply: bool,
+    live: bool = False,
+    repo: str | None = None,
+    topics_file: Path | None = None,
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Build or apply a GitHub topic sync plan."""
+    if apply and live:
+        raise TopicSyncError("--apply and --live cannot be used together.")
+    command_runner = runner or _run_command
+    if apply or live:
+        existing = _load_existing_topics(command_runner, repo=repo)
+        plan = plan_topic_sync(desired, existing)
+    else:
+        plan = [{"action": "ensure", "topic": topic} for topic in desired]
+    if apply:
+        for entry in plan:
+            _apply_plan_entry(entry, command_runner, repo=repo)
+    mode = "apply" if apply else "live-dry-run" if live else "dry-run"
+    return {
+        "schema_version": "1",
+        "mode": mode,
+        "repo": repo,
+        "topics_file": str(topics_file) if topics_file is not None else None,
+        "plan": plan,
+        "next_step": _next_step_for_mode(apply=apply, live=live, plan=plan),
+    }
+
+
+def _load_existing_topics(runner: Runner, *, repo: str | None) -> list[str]:
+    command = ["gh", "repo", "view"]
+    if repo:
+        command.append(repo)
+    command.extend(["--json", "repositoryTopics,nameWithOwner"])
+    completed = _run_gh(command, runner, failure="list existing GitHub topics")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise TopicSyncError(f"Could not parse gh repo view JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise TopicSyncError("gh repo view returned JSON that was not an object.")
+    raw_topics = payload.get("repositoryTopics")
+    if not isinstance(raw_topics, list):
+        raise TopicSyncError("gh repo view did not return a repositoryTopics list.")
+    topics: list[str] = []
+    for raw_topic in raw_topics:
+        if not isinstance(raw_topic, dict):
+            raise TopicSyncError("gh repo view returned a non-object topic entry.")
+        topics.append(_validate_topic(str(raw_topic.get("name", ""))))
+    return topics
+
+
+def _apply_plan_entry(entry: dict[str, str], runner: Runner, *, repo: str | None) -> None:
+    action = entry["action"]
+    if action == "noop":
+        return
+    if action not in {"add", "remove"}:
+        raise TopicSyncError(f"Unsupported topic sync action: {action}")
+    flag = "--add-topic" if action == "add" else "--remove-topic"
+    command = ["gh", "repo", "edit"]
+    if repo:
+        command.append(repo)
+    command.extend([flag, entry["topic"]])
+    _run_gh(command, runner, failure=f"{action} topic {entry['topic']}")
+
+
+def _run_gh(
+    command: list[str],
+    runner: Runner,
+    *,
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = runner(command)
+    except OSError as exc:
+        raise TopicSyncError(_gh_recovery_message("GitHub CLI is required")) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        if not detail:
+            detail = f"gh exited with status {completed.returncode}"
+        raise TopicSyncError(f"Could not {failure}: {detail}. {_gh_recovery_message('Recovery')}")
+    return completed
+
+
+def _gh_recovery_message(prefix: str) -> str:
+    return (
+        f"{prefix} for live/apply topic sync. Install `gh`, run `gh auth status`, "
+        "rerun with `--live` to inspect the GitHub delta, then rerun with "
+        "`--apply` only when ready to mutate topics."
+    )
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _next_step_for_mode(
+    *,
+    apply: bool,
+    live: bool,
+    plan: list[dict[str, str]],
+) -> str:
+    if apply:
+        return "Applied non-noop topic changes with gh."
+    if live:
+        if any(entry["action"] != "noop" for entry in plan):
+            return "Review the live topic plan, then rerun with --apply when ready."
+        return "GitHub repository topics already match .github/topics.yml."
+    return (
+        "Run with --live to compare against current GitHub state "
+        f"(`{GITHUB_TOPIC_LIST_COMMAND}`), or rerun with --apply when ready."
+    )
+
+
+def _validate_topic(value: str) -> str:
+    topic = value.strip()
+    if not TOPIC_PATTERN.fullmatch(topic):
+        raise TopicSyncError(
+            f"Topic {value!r} must be lowercase, start with a letter or digit, "
+            "and contain only letters, digits, or hyphens."
+        )
+    return topic
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines = [
+        "PolicyNIM GitHub topic sync",
+        f"Mode: {result['mode']}",
+        f"Topics file: {result['topics_file']}",
+        "",
+        "Plan:",
+    ]
+    for entry in result["plan"]:
+        lines.append(f"- {entry['action']}: {entry['topic']}")
+    lines.extend(["", f"Next step: {result['next_step']}"])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/policynim/agent_workflows.py
+++ b/src/policynim/agent_workflows.py
@@ -1,0 +1,78 @@
+"""Copyable coding-agent workflow prompts for first-run surfaces."""
+
+from __future__ import annotations
+
+from typing import TypedDict, cast
+
+
+class AgentWorkflow(TypedDict):
+    """Structured prompt shown by quickstart and support diagnostics."""
+
+    title: str
+    tool: str
+    prompt: str
+
+
+class AgentWorkflowCard(AgentWorkflow):
+    """Hosted portal workflow prompt with explanatory card text."""
+
+    description: str
+
+
+_AGENT_WORKFLOW_CARDS: tuple[AgentWorkflowCard, ...] = (
+    {
+        "title": "Preflight before implementation",
+        "tool": "policy_preflight",
+        "description": (
+            "Ask your coding agent to retrieve policy evidence and produce grounded "
+            "implementation guidance before it edits code."
+        ),
+        "prompt": (
+            "Before editing, call policy_preflight for: Implement a refresh-token cleanup "
+            "background job. Use the cited constraints in your implementation plan. If the "
+            "result is insufficient_context, stop and call policy_search with a narrower "
+            "query before changing files."
+        ),
+    },
+    {
+        "title": "Retrieve policy evidence while debugging",
+        "tool": "policy_search",
+        "description": (
+            "Use raw policy search when a review comment, failing gate, or unclear "
+            "constraint needs the underlying source text."
+        ),
+        "prompt": (
+            "Use policy_search for: release installer checksum verification. Summarize "
+            "the relevant cited policy lines before proposing a fix."
+        ),
+    },
+    {
+        "title": "Verify MCP tool availability",
+        "tool": "list_tools",
+        "description": (
+            "After adding the hosted server, ask your client to confirm it can see the "
+            "PolicyNIM tools before you start a longer coding session."
+        ),
+        "prompt": (
+            "List the PolicyNIM MCP tools and confirm policy_preflight and policy_search "
+            "are available before starting implementation."
+        ),
+    },
+)
+
+
+def agent_workflows() -> list[AgentWorkflow]:
+    """Return copyable first-use prompts without hosted portal descriptions."""
+    return [
+        {
+            "title": workflow["title"],
+            "tool": workflow["tool"],
+            "prompt": workflow["prompt"],
+        }
+        for workflow in _AGENT_WORKFLOW_CARDS
+    ]
+
+
+def agent_workflow_cards() -> list[AgentWorkflowCard]:
+    """Return copyable first-use prompts with hosted portal descriptions."""
+    return [cast(AgentWorkflowCard, dict(workflow)) for workflow in _AGENT_WORKFLOW_CARDS]

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import platform
+import shlex
 import sys
-from datetime import datetime
+from collections.abc import Sequence
+from datetime import datetime, timedelta
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Annotated, Literal, NoReturn
+from tempfile import NamedTemporaryFile, TemporaryFile
+from typing import Annotated, Literal, NoReturn, cast
+from urllib.parse import urlparse
 
 import typer
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
 from pydantic import TypeAdapter, ValidationError
 
 import policynim.config_discovery as config_discovery
+from policynim.agent_workflows import agent_workflows
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
 from policynim.runtime_paths import resolve_runtime_path
@@ -35,6 +43,7 @@ from policynim.services import (
     create_search_service,
 )
 from policynim.settings import Settings, get_settings
+from policynim.storage import create_index_store
 from policynim.types import (
     MAX_TOP_K,
     CompileRequest,
@@ -57,6 +66,7 @@ _RUNTIME_REQUEST_ADAPTER = TypeAdapter(RuntimeActionRequest)
 _STANDALONE_MISSING_INDEX_MESSAGE = (
     "Local PolicyNIM data is not built yet. Run `policynim ingest` to build the local policy index."
 )
+_EXPECTED_MCP_TOOLS = ("policy_preflight", "policy_search")
 
 app = typer.Typer(
     add_completion=False,
@@ -146,6 +156,99 @@ def init() -> None:
     typer.echo(f"Wrote PolicyNIM config to {config_path}.")
     typer.echo(f"Corpus: {corpus_message}")
     typer.echo("Next step: run `policynim ingest`.")
+
+
+@app.command(
+    help=(
+        "Print the first-run path for hosted MCP, local CLI, or local MCP "
+        "without calling external services."
+    ),
+)
+def quickstart(
+    target: Annotated[
+        Literal["hosted-mcp", "local-cli", "local-mcp"],
+        typer.Option(
+            "--target",
+            help="First-run path to show. Supported values: hosted-mcp, local-cli, local-mcp.",
+        ),
+    ] = "hosted-mcp",
+    client: Annotated[
+        Literal["codex", "claude-code"],
+        typer.Option(
+            "--client",
+            help="MCP client to show when the target uses MCP.",
+        ),
+    ] = "codex",
+    hosted_url: Annotated[
+        str,
+        typer.Option(
+            "--hosted-url",
+            help="Hosted PolicyNIM MCP URL to include in generated setup commands.",
+        ),
+    ] = "https://<railway-domain>/mcp",
+    bearer_token_env_var: Annotated[
+        str,
+        typer.Option(
+            "--bearer-token-env-var",
+            help="Environment variable that stores the hosted MCP bearer token.",
+        ),
+    ] = "POLICYNIM_TOKEN",
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help="PolicyNIM source checkout root to include for local MCP config.",
+        ),
+    ] = None,
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Quickstart output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print the safest first-run path for the selected user workflow."""
+    try:
+        payload = _build_quickstart_payload(
+            target=target,
+            client=client,
+            hosted_url=hosted_url,
+            bearer_token_env_var=bearer_token_env_var,
+            repo_root=repo_root,
+        )
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    for line in _render_quickstart_payload(payload):
+        typer.echo(line)
+
+
+@app.command(
+    help=(
+        "Inspect local setup, index artifacts, and MCP launch hints without "
+        "calling NVIDIA-hosted APIs."
+    ),
+)
+def doctor(
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Diagnostic output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print a safe local setup diagnostic report."""
+    report = _build_doctor_report()
+    if output_format == "json":
+        typer.echo(json.dumps(report, indent=2))
+        return
+    for line in _render_doctor_report(report):
+        typer.echo(line)
 
 
 @app.command()
@@ -627,12 +730,216 @@ def mcp(
 ) -> None:
     """Run the MCP server."""
     try:
-        _load_setup_dependent_settings()
+        if transport != "stdio":
+            _load_setup_dependent_settings()
         run_server(transport=transport)
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
         _exit_with_error(str(exc))
+
+
+@app.command("mcp-config")
+def mcp_config(
+    client: Annotated[
+        Literal["codex", "claude-code"],
+        typer.Option(
+            "--client",
+            help="Client config shape to print. Supported values: codex, claude-code.",
+        ),
+    ] = "codex",
+    target: Annotated[
+        Literal["local-stdio", "hosted-http"],
+        typer.Option(
+            "--target",
+            help="MCP target to configure. Supported values: local-stdio, hosted-http.",
+        ),
+    ] = "local-stdio",
+    hosted_url: Annotated[
+        str | None,
+        typer.Option(
+            "--hosted-url",
+            help=(
+                "Hosted PolicyNIM MCP URL, for example https://<host>/mcp. "
+                "Required with --target hosted-http."
+            ),
+        ),
+    ] = None,
+    bearer_token_env_var: Annotated[
+        str,
+        typer.Option(
+            "--bearer-token-env-var",
+            help=(
+                "Environment variable that stores the hosted MCP bearer token. "
+                "Used with --target hosted-http."
+            ),
+        ),
+    ] = "POLICYNIM_TOKEN",
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help=(
+                "Optional PolicyNIM source checkout root. When omitted, local stdio "
+                "config uses a discovered checkout or the installed policynim command."
+            ),
+        ),
+    ] = None,
+    server_name: Annotated[
+        str,
+        typer.Option(
+            "--server-name",
+            help="MCP server name to use in the generated client config.",
+        ),
+    ] = "policynim",
+    uv_command: Annotated[
+        str,
+        typer.Option(
+            "--uv-command",
+            help=(
+                "uv executable or absolute path to use in generated stdio config. "
+                "Used only when local stdio config targets a source checkout."
+            ),
+        ),
+    ] = "uv",
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Config output format. Supported values: text, json.",
+        ),
+    ] = "text",
+) -> None:
+    """Print hosted HTTP or local stdio MCP client config without writing client files."""
+    try:
+        payload = _build_mcp_config_payload(
+            client=client,
+            target=target,
+            hosted_url=hosted_url,
+            bearer_token_env_var=bearer_token_env_var,
+            repo_root=repo_root,
+            server_name=server_name,
+            uv_command=uv_command,
+        )
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    for line in _render_mcp_config_payload(payload):
+        typer.echo(line)
+
+
+@app.command("mcp-smoke")
+def mcp_smoke(
+    output_format: Annotated[
+        Literal["text", "json"],
+        typer.Option(
+            "--format",
+            help="Smoke output format. Supported values: text, json.",
+        ),
+    ] = "text",
+    timeout_seconds: Annotated[
+        float,
+        typer.Option(
+            "--timeout-seconds",
+            min=1.0,
+            help="Read timeout for MCP initialize and list-tools calls.",
+        ),
+    ] = 5.0,
+    mcp_config_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--mcp-config-file",
+            help=(
+                "Optional JSON output from `policynim mcp-config --format json`. "
+                "When set, local stdio smoke launches with that generated config."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Launch the local stdio MCP server and verify the public tools are listed."""
+    try:
+        if mcp_config_file is None:
+            report = asyncio.run(_run_mcp_stdio_smoke(timeout_seconds=timeout_seconds))
+        else:
+            command, cwd = _mcp_stdio_smoke_command_from_config_file(mcp_config_file)
+            report = asyncio.run(
+                _run_mcp_stdio_smoke(
+                    timeout_seconds=timeout_seconds,
+                    command=command,
+                    cwd=cwd,
+                )
+            )
+            report["config_source"] = str(mcp_config_file)
+    except PolicyNIMError as exc:
+        _exit_with_error(_cli_error_message(exc))
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    if output_format == "json":
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        for line in _render_mcp_smoke_report(report):
+            typer.echo(line)
+
+    if report["status"] != "ok":
+        raise typer.Exit(code=1)
+
+
+@app.command("support-bundle")
+def support_bundle(
+    output_format: Annotated[
+        Literal["json", "markdown"],
+        typer.Option(
+            "--format",
+            help="Support bundle output format. Supported values: json, markdown.",
+        ),
+    ] = "json",
+    include_mcp_smoke: Annotated[
+        bool,
+        typer.Option(
+            "--include-mcp-smoke",
+            help="Also launch local stdio MCP and verify public tool registration.",
+        ),
+    ] = False,
+    mcp_timeout_seconds: Annotated[
+        float,
+        typer.Option(
+            "--mcp-timeout-seconds",
+            min=1.0,
+            help="Read timeout for the optional MCP smoke check.",
+        ),
+    ] = 5.0,
+    include_local_paths: Annotated[
+        bool,
+        typer.Option(
+            "--include-local-paths",
+            help=(
+                "Include exact local filesystem paths for private maintainer triage. "
+                "By default, local path prefixes are redacted for public issues."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Print redacted diagnostics suitable for issues and maintainer triage."""
+    try:
+        bundle = asyncio.run(
+            _build_support_bundle(
+                include_mcp_smoke=include_mcp_smoke,
+                mcp_timeout_seconds=mcp_timeout_seconds,
+                include_local_paths=include_local_paths,
+            )
+        )
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    rendered = json.dumps(bundle, indent=2)
+    if output_format == "markdown":
+        typer.echo(_render_support_bundle_markdown(rendered))
+        return
+    typer.echo(rendered)
 
 
 @beta_admin_app.command("list-accounts")
@@ -973,6 +1280,1670 @@ def _load_setup_dependent_settings() -> Settings:
 def _missing_setup_message() -> str:
     config_path = config_discovery.resolve_init_config_file()
     return f"PolicyNIM is not set up yet. Run `policynim init` to create {config_path}."
+
+
+def _build_quickstart_payload(
+    *,
+    target: Literal["hosted-mcp", "local-cli", "local-mcp"],
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+    repo_root: Path | None,
+) -> dict[str, object]:
+    """Build offline first-run guidance for the requested workflow target."""
+    normalized_hosted_url = _normalize_hosted_mcp_url(
+        _normalize_quickstart_value(hosted_url, label="Hosted MCP URL")
+    )
+    normalized_token_env_var = _normalize_env_var_name(bearer_token_env_var)
+
+    if target == "hosted-mcp":
+        hosted_url_placeholder = _is_placeholder_hosted_url(normalized_hosted_url)
+        beta_portal_url = _hosted_beta_portal_url(normalized_hosted_url)
+        alternate_client = _alternate_mcp_client(client)
+        alternate_client_name = _mcp_client_display_name(alternate_client)
+        alternate_client_quickstart = _quickstart_installed_cli_command(
+            ["quickstart", "--target", target, "--client", alternate_client]
+        )
+        next_steps = [
+            (f"For {alternate_client_name} setup commands, rerun `{alternate_client_quickstart}`."),
+            "Ask your client to call `policy_preflight` for the main workflow.",
+            "Use `policy_search` first when you need raw retrieval/debugging context.",
+        ]
+        if hosted_url_placeholder:
+            next_steps.insert(
+                0,
+                "Replace the hosted URL placeholder with the deployed /mcp URL.",
+            )
+        return {
+            "schema_version": "1",
+            "target": target,
+            "client": client,
+            "requires_local_setup": False,
+            "calls_external_services": False,
+            "hosted_url": normalized_hosted_url,
+            "hosted_url_placeholder": hosted_url_placeholder,
+            "beta_portal_url": beta_portal_url,
+            "description": "Shortest path: use the hosted MCP endpoint without cloning.",
+            "prerequisites": [
+                "Access to the hosted beta portal.",
+                f"A shell environment variable named {normalized_token_env_var}.",
+            ],
+            "steps": [
+                (
+                    f"Open {normalized_hosted_url} in a browser; it routes to "
+                    f"{beta_portal_url} for token creation."
+                ),
+                "Sign in with GitHub.",
+                "Generate or rotate a hosted API key.",
+                "Export the token and add the hosted MCP server to your client.",
+            ],
+            "commands": [
+                f"export {normalized_token_env_var}='<generated-beta-token>'",
+                _quickstart_installed_cli_command(
+                    [
+                        "mcp-config",
+                        "--target",
+                        "hosted-http",
+                        "--client",
+                        client,
+                        "--hosted-url",
+                        normalized_hosted_url,
+                        "--bearer-token-env-var",
+                        normalized_token_env_var,
+                    ]
+                ),
+            ],
+            "client_commands": _quickstart_hosted_client_commands(
+                client=client,
+                hosted_url=normalized_hosted_url,
+                bearer_token_env_var=normalized_token_env_var,
+            ),
+            "agent_workflows": _quickstart_agent_workflows(),
+            "next_steps": next_steps,
+            "safety": [
+                "This command does not call hosted or NVIDIA services.",
+                (
+                    "Keep bearer tokens in environment variables; "
+                    "do not paste token values into issues."
+                ),
+            ],
+        }
+
+    if target == "local-cli":
+        local_cli_command = _quickstart_cli_command
+        source_checkout = _doctor_runtime_mode() == "source_checkout"
+        local_cli_description = (
+            "Local CLI path for running preflight from a source checkout."
+            if source_checkout
+            else "Local CLI path for running preflight from an installed package."
+        )
+        local_cli_prerequisites = (
+            [
+                "PolicyNIM source checkout with uv dependencies synced.",
+                "NVIDIA_API_KEY for ingest, search, route, compile, preflight, and eval.",
+            ]
+            if source_checkout
+            else [
+                "Python 3.11 or 3.12 for PyPI package installs.",
+                "NVIDIA_API_KEY for ingest, search, route, compile, preflight, and eval.",
+                "PyPI trusted-publishing evidence is tracked separately from installability.",
+            ]
+        )
+        entrypoint_step = (
+            "Check the source-checkout entrypoint."
+            if source_checkout
+            else "Check the installed entrypoint."
+        )
+        return {
+            "schema_version": "1",
+            "target": target,
+            "client": client,
+            "requires_local_setup": True,
+            "calls_external_services": False,
+            "description": local_cli_description,
+            "prerequisites": local_cli_prerequisites,
+            "steps": [
+                entrypoint_step,
+                "Create local config.",
+                "Build the bundled policy index.",
+                "Run a citation-backed preflight.",
+            ],
+            "commands": [
+                local_cli_command(["--help"]),
+                local_cli_command(["doctor"]),
+                local_cli_command(["init"]),
+                local_cli_command(["ingest"]),
+                local_cli_command(
+                    [
+                        "preflight",
+                        "--task",
+                        "Implement a refresh-token cleanup background job",
+                        "--top-k",
+                        "5",
+                    ]
+                ),
+            ],
+            "agent_workflows": _quickstart_agent_workflows(),
+            "next_steps": [
+                (
+                    f"Run `{local_cli_command(['quickstart', '--target', 'hosted-mcp'])}` "
+                    "if you want MCP without local setup."
+                ),
+                (
+                    f"Run `{local_cli_command(['support-bundle'])}` when attaching public setup "
+                    "evidence or opening an issue."
+                ),
+                (
+                    f"Keep `{local_cli_command(['doctor', '--format', 'json'])}` "
+                    "local unless a maintainer "
+                    "asks for raw paths in private triage."
+                ),
+            ],
+            "safety": [
+                "This command only prints guidance; it does not write config.",
+                "Secret values are not printed.",
+            ],
+        }
+
+    local_command = _quickstart_local_mcp_command
+    local_config = _quickstart_local_mcp_config(
+        client=client,
+        repo_root=repo_root,
+    )
+    local_config_command = cast(list[str], local_config["command"])
+    local_launch_mode = str(local_config["mode"])
+    config_step = (
+        "Generate client config from the checkout path."
+        if local_launch_mode == "source-checkout"
+        else "Generate client config from the installed entrypoint."
+    )
+    local_mcp_description = (
+        "Local MCP path for Codex or Claude Code from a source checkout."
+        if local_launch_mode == "source-checkout"
+        else "Local MCP path for Codex or Claude Code from an installed CLI."
+    )
+    local_mcp_prerequisites = (
+        [
+            "PolicyNIM source checkout with uv dependencies synced.",
+            "NVIDIA_API_KEY available in the shell that launches the MCP client.",
+        ]
+        if local_launch_mode == "source-checkout"
+        else [
+            "An installed PolicyNIM CLI.",
+            "NVIDIA_API_KEY available in the shell that launches the MCP client.",
+        ]
+    )
+    return {
+        "schema_version": "1",
+        "target": target,
+        "client": client,
+        "local_launch_mode": local_launch_mode,
+        "requires_local_setup": True,
+        "calls_external_services": False,
+        "description": local_mcp_description,
+        "prerequisites": local_mcp_prerequisites,
+        "steps": [
+            "Confirm local setup state.",
+            "Create local config if needed.",
+            "Build the policy index.",
+            "Verify the stdio MCP server lists public tools.",
+            config_step,
+        ],
+        "commands": [
+            local_command("doctor"),
+            local_command("init"),
+            local_command("ingest"),
+            local_command("mcp-smoke"),
+            _shell_join(local_config_command),
+        ],
+        "agent_workflows": _quickstart_agent_workflows(),
+        "next_steps": [
+            "Load the generated config in your MCP client.",
+            "Ask the client to list `policy_preflight` and `policy_search`.",
+        ],
+        "safety": [
+            "This command does not launch the MCP server.",
+            "Keep NVIDIA_API_KEY in environment variables.",
+            (
+                "Local MCP setup commands can include exact local filesystem paths; "
+                "do not paste them into public issues."
+            ),
+            "Use `policynim support-bundle` for public diagnostics.",
+        ],
+    }
+
+
+def _quickstart_cli_command(parts: Sequence[str]) -> str:
+    """Render a shell command for the active local CLI runtime."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return _shell_join(["uv", "run", "policynim", *parts])
+    return _shell_join(["policynim", *parts])
+
+
+def _quickstart_agent_workflows() -> list[dict[str, str]]:
+    """Return copyable first-use prompts for coding-agent workflows."""
+    return [
+        {
+            "title": workflow["title"],
+            "tool": workflow["tool"],
+            "prompt": workflow["prompt"],
+        }
+        for workflow in agent_workflows()
+    ]
+
+
+def _alternate_mcp_client(
+    client: Literal["codex", "claude-code"],
+) -> Literal["codex", "claude-code"]:
+    """Return the other supported MCP client for first-run hints."""
+    if client == "codex":
+        return "claude-code"
+    return "codex"
+
+
+def _mcp_client_display_name(client: Literal["codex", "claude-code"]) -> str:
+    """Render supported MCP client names for user-facing guidance."""
+    if client == "claude-code":
+        return "Claude Code"
+    return "Codex"
+
+
+def _quickstart_hosted_client_commands(
+    *,
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> list[str]:
+    """Return the direct hosted MCP client command for quickstart output."""
+    payload = _build_hosted_mcp_config_payload(
+        client=client,
+        hosted_url=hosted_url,
+        bearer_token_env_var=bearer_token_env_var,
+        server_name="policynim",
+    )
+    command_key = "cli_shell_command" if client == "claude-code" else "codex_cli_shell_command"
+    return [str(payload[command_key])]
+
+
+def _quickstart_all_hosted_client_commands(
+    *,
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> list[str]:
+    """Return hosted MCP setup commands for every supported client."""
+    commands: list[str] = []
+    for client in ("codex", "claude-code"):
+        commands.extend(
+            _quickstart_hosted_client_commands(
+                client=client,
+                hosted_url=hosted_url,
+                bearer_token_env_var=bearer_token_env_var,
+            )
+        )
+    return commands
+
+
+def _quickstart_installed_cli_command(parts: Sequence[str]) -> str:
+    """Render a shell command that always targets the installed CLI."""
+    return _shell_join(["policynim", *parts])
+
+
+def _quickstart_local_mcp_command(command: str) -> str:
+    """Render a local MCP setup command for quickstart output."""
+    return _doctor_cli_command(command)
+
+
+def _quickstart_local_mcp_config(
+    *,
+    client: Literal["codex", "claude-code"],
+    repo_root: Path | None,
+) -> dict[str, object]:
+    """Build a local stdio MCP config command description for quickstart."""
+    command = [
+        *_doctor_cli_command("mcp-config").split(),
+        "--target",
+        "local-stdio",
+        "--client",
+        client,
+    ]
+    if repo_root is not None:
+        return {
+            "mode": "source-checkout",
+            "command": [
+                *command,
+                "--repo-root",
+                str(repo_root.expanduser().resolve(strict=False)),
+            ],
+        }
+    discovered = config_discovery.find_source_checkout_root()
+    if discovered is not None:
+        return {"mode": "source-checkout", "command": [*command, "--repo-root", str(discovered)]}
+    return {"mode": "installed-cli", "command": command}
+
+
+def _hosted_beta_portal_url(hosted_mcp_url: str) -> str:
+    """Derive the hosted beta portal URL from a hosted MCP URL."""
+    parsed = urlparse(hosted_mcp_url)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}/beta"
+    return "https://<railway-domain>/beta"
+
+
+def _build_mcp_config_payload(
+    *,
+    client: Literal["codex", "claude-code"],
+    target: Literal["local-stdio", "hosted-http"],
+    hosted_url: str | None,
+    bearer_token_env_var: str,
+    repo_root: Path | None,
+    server_name: str,
+    uv_command: str,
+) -> dict[str, object]:
+    """Build client-specific MCP configuration without writing client files."""
+    _validate_mcp_config_target_options(
+        target=target,
+        repo_root=repo_root,
+        hosted_url=hosted_url,
+        bearer_token_env_var=bearer_token_env_var,
+        uv_command=uv_command,
+    )
+    normalized_server_name = _normalize_mcp_config_value(
+        server_name,
+        label="MCP server name",
+    )
+    if target == "hosted-http":
+        return _build_hosted_mcp_config_payload(
+            client=client,
+            hosted_url=_normalize_hosted_mcp_url(hosted_url),
+            bearer_token_env_var=_normalize_env_var_name(bearer_token_env_var),
+            server_name=normalized_server_name,
+        )
+
+    launch = _resolve_local_mcp_launch(repo_root=repo_root, uv_command=uv_command)
+    launch_mode = str(launch["mode"])
+    command = str(launch["command"])
+    args = cast(list[str], launch["args"])
+    repo_root_value = cast(str | None, launch.get("repo_root"))
+    next_steps = cast(list[str], launch["next_steps"])
+    safety = _local_mcp_config_safety()
+
+    if client == "claude-code":
+        server_config = {
+            "type": "stdio",
+            "command": command,
+            "args": args,
+            "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+        }
+        config = {"mcpServers": {normalized_server_name: server_config}}
+        compact_config = json.dumps(server_config, separators=(",", ":"))
+        payload = {
+            "schema_version": "1",
+            "client": client,
+            "target": target,
+            "server_name": normalized_server_name,
+            "local_launch_mode": launch_mode,
+            "config": config,
+            "cli_command": [
+                "claude",
+                "mcp",
+                "add-json",
+                normalized_server_name,
+                compact_config,
+            ],
+            "cli_shell_command": _shell_join(
+                ["claude", "mcp", "add-json", normalized_server_name, compact_config]
+            ),
+            "next_steps": next_steps,
+            "safety": safety,
+        }
+        if repo_root_value is not None:
+            payload["repo_root"] = repo_root_value
+        return payload
+
+    codex_command = [
+        "codex",
+        "mcp",
+        "add",
+        normalized_server_name,
+        "--env",
+        "NVIDIA_API_KEY=$NVIDIA_API_KEY",
+        "--",
+        command,
+        *args,
+    ]
+    codex_app = {
+        "name": normalized_server_name,
+        "transport": "STDIO",
+        "command": command,
+        "arguments": args,
+        "environment_variable_passthrough": ["NVIDIA_API_KEY"],
+    }
+    if repo_root_value is not None:
+        codex_app["working_directory"] = repo_root_value
+    payload = {
+        "schema_version": "1",
+        "client": client,
+        "target": target,
+        "server_name": normalized_server_name,
+        "local_launch_mode": launch_mode,
+        "codex_cli_command": codex_command,
+        "codex_cli_shell_command": _codex_cli_shell_command(
+            server_name=normalized_server_name,
+            command=command,
+            args=args,
+        ),
+        "codex_app": codex_app,
+        "next_steps": next_steps,
+        "safety": safety,
+    }
+    if repo_root_value is not None:
+        payload["repo_root"] = repo_root_value
+    return payload
+
+
+def _local_mcp_config_safety() -> list[str]:
+    """Return safety notes shared by local MCP config payloads."""
+    return [
+        (
+            "Generated local stdio config can include exact local filesystem paths; "
+            "do not paste it into public issues."
+        ),
+        "Use `policynim support-bundle` for public diagnostics.",
+    ]
+
+
+def _resolve_local_mcp_launch(
+    *,
+    repo_root: Path | None,
+    uv_command: str,
+) -> dict[str, object]:
+    """Resolve whether local MCP should launch from a checkout or installed CLI."""
+    discovered_repo_root = _resolve_mcp_config_repo_root(repo_root)
+    if discovered_repo_root is None:
+        if uv_command != "uv":
+            raise PolicyNIMError(
+                "--uv-command requires a PolicyNIM source checkout. "
+                "Pass --repo-root /ABS/PATH/TO/policyNIM."
+            )
+        return {
+            "mode": "installed-cli",
+            "command": "policynim",
+            "args": ["mcp", "--transport", "stdio"],
+            "next_steps": [
+                "policynim doctor",
+                "policynim mcp-smoke",
+                "policynim ingest",
+            ],
+        }
+
+    normalized_uv_command = _normalize_mcp_config_value(uv_command, label="uv command")
+    return {
+        "mode": "source-checkout",
+        "command": normalized_uv_command,
+        "args": [
+            "run",
+            "--directory",
+            str(discovered_repo_root),
+            "policynim",
+            "mcp",
+            "--transport",
+            "stdio",
+        ],
+        "repo_root": str(discovered_repo_root),
+        "next_steps": [
+            "uv run policynim doctor",
+            "uv run policynim mcp-smoke",
+            "uv run policynim ingest",
+        ],
+    }
+
+
+def _validate_mcp_config_target_options(
+    *,
+    target: Literal["local-stdio", "hosted-http"],
+    repo_root: Path | None,
+    hosted_url: str | None,
+    bearer_token_env_var: str,
+    uv_command: str,
+) -> None:
+    """Reject option combinations that would produce misleading MCP config."""
+    if target == "hosted-http":
+        if repo_root is not None:
+            raise PolicyNIMError("--repo-root is only valid with --target local-stdio.")
+        if uv_command != "uv":
+            raise PolicyNIMError("--uv-command is only valid with --target local-stdio.")
+        return
+
+    if hosted_url is not None:
+        raise PolicyNIMError("--hosted-url is only valid with --target hosted-http.")
+    if bearer_token_env_var != "POLICYNIM_TOKEN":
+        raise PolicyNIMError("--bearer-token-env-var is only valid with --target hosted-http.")
+
+
+def _build_hosted_mcp_config_payload(
+    *,
+    client: Literal["codex", "claude-code"],
+    hosted_url: str,
+    bearer_token_env_var: str,
+    server_name: str,
+) -> dict[str, object]:
+    """Build hosted HTTP MCP config for Codex or Claude Code."""
+    hosted_url_placeholder = _is_placeholder_hosted_url(hosted_url)
+    beta_portal_url = _hosted_beta_portal_url(hosted_url)
+    next_steps = [
+        f"Open {beta_portal_url} to generate or rotate a hosted API key.",
+        f"Export {bearer_token_env_var}='<generated-beta-token>'",
+        "Ask your client to call `policy_preflight` for the main workflow.",
+        "Use `policy_search` first when you need raw retrieval/debugging context.",
+    ]
+    if hosted_url_placeholder:
+        next_steps.insert(
+            0,
+            "Replace the hosted URL placeholder with the deployed /mcp URL.",
+        )
+    if client == "claude-code":
+        header = f"Authorization: Bearer ${bearer_token_env_var}"
+        command = [
+            "claude",
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            server_name,
+            hosted_url,
+            "--header",
+            header,
+        ]
+        return {
+            "schema_version": "1",
+            "client": client,
+            "target": "hosted-http",
+            "server_name": server_name,
+            "hosted_url": hosted_url,
+            "beta_portal_url": beta_portal_url,
+            "hosted_url_placeholder": hosted_url_placeholder,
+            "bearer_token_env_var": bearer_token_env_var,
+            "cli_command": command,
+            "cli_shell_command": _claude_hosted_shell_command(
+                server_name=server_name,
+                hosted_url=hosted_url,
+                bearer_token_env_var=bearer_token_env_var,
+            ),
+            "next_steps": next_steps,
+        }
+
+    command = [
+        "codex",
+        "mcp",
+        "add",
+        server_name,
+        "--url",
+        hosted_url,
+        "--bearer-token-env-var",
+        bearer_token_env_var,
+    ]
+    return {
+        "schema_version": "1",
+        "client": client,
+        "target": "hosted-http",
+        "server_name": server_name,
+        "hosted_url": hosted_url,
+        "beta_portal_url": beta_portal_url,
+        "hosted_url_placeholder": hosted_url_placeholder,
+        "bearer_token_env_var": bearer_token_env_var,
+        "codex_cli_command": command,
+        "codex_cli_shell_command": _shell_join(command),
+        "next_steps": [
+            *next_steps,
+            f"Run `codex mcp get {server_name}` to inspect the saved server entry.",
+        ],
+    }
+
+
+def _resolve_mcp_config_repo_root(repo_root: Path | None) -> Path | None:
+    """Resolve and validate an optional source checkout root."""
+    if repo_root is None:
+        discovered = config_discovery.find_source_checkout_root()
+        if discovered is None:
+            return None
+        candidate = discovered
+    else:
+        candidate = repo_root
+    resolved = candidate.expanduser().resolve(strict=False)
+    if not _looks_like_policynim_checkout(resolved):
+        raise PolicyNIMError(
+            "--repo-root must point to a PolicyNIM source checkout. "
+            "Omit --repo-root to launch the installed CLI."
+        )
+    return resolved
+
+
+def _looks_like_policynim_checkout(path: Path) -> bool:
+    """Return whether a path has the expected PolicyNIM checkout shape."""
+    return (path / "pyproject.toml").is_file() and (path / "src" / "policynim").is_dir()
+
+
+def _normalize_mcp_config_value(value: str, *, label: str) -> str:
+    """Trim and validate a required MCP config string value."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError(f"{label} cannot be empty.")
+    return stripped
+
+
+def _normalize_hosted_mcp_url(value: str | None) -> str:
+    """Normalize a hosted MCP URL and enforce the /mcp endpoint shape."""
+    if value is None or not value.strip():
+        raise PolicyNIMError("Hosted MCP config requires --hosted-url https://<host>/mcp.")
+    stripped = value.strip()
+    parsed = urlparse(stripped)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise PolicyNIMError(
+            "Hosted MCP URL must start with http:// or https:// and include a host."
+        )
+    if parsed.path.rstrip("/") != "/mcp":
+        raise PolicyNIMError("Hosted MCP URL must point to the /mcp endpoint.")
+    return stripped
+
+
+def _normalize_env_var_name(value: str) -> str:
+    """Normalize and validate an environment variable name."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError("Bearer token env var cannot be empty.")
+    if not (stripped[0].isalpha() or stripped[0] == "_"):
+        raise PolicyNIMError("Bearer token env var must not start with a number.")
+    if any(not (character.isalnum() or character == "_") for character in stripped):
+        raise PolicyNIMError(
+            "Bearer token env var must contain only letters, numbers, and underscores."
+        )
+    return stripped
+
+
+def _normalize_quickstart_value(value: str, *, label: str) -> str:
+    """Trim and validate a required quickstart string value."""
+    stripped = value.strip()
+    if not stripped:
+        raise PolicyNIMError(f"{label} cannot be empty.")
+    return stripped
+
+
+def _is_placeholder_hosted_url(value: str) -> bool:
+    """Return whether a hosted URL still contains unresolved placeholder text."""
+    normalized = value.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "<",
+            ">",
+            "example.",
+            ".example/",
+            ".invalid",
+            "todo",
+            "placeholder",
+        )
+    )
+
+
+def _render_mcp_config_payload(payload: dict[str, object]) -> list[str]:
+    """Render an MCP config payload as terminal-friendly text."""
+    if payload.get("target") == "hosted-http":
+        return _render_hosted_mcp_config(payload)
+    client = str(payload["client"])
+    if client == "claude-code":
+        return _render_claude_code_mcp_config(payload)
+    return _render_codex_mcp_config(payload)
+
+
+def _render_quickstart_payload(payload: dict[str, object]) -> list[str]:
+    """Render a quickstart payload as terminal-friendly text."""
+    return [
+        "PolicyNIM quickstart",
+        f"Target: {payload['target']}",
+        f"Client: {payload['client']}",
+        str(payload["description"]),
+        "",
+        "Prerequisites:",
+        *_render_quickstart_list(payload, "prerequisites"),
+        "",
+        "Steps:",
+        *_render_quickstart_numbered_list(payload, "steps"),
+        "",
+        "Commands:",
+        *_render_quickstart_list(payload, "commands"),
+        *_render_quickstart_client_commands(payload),
+        "",
+        "Agent workflows:",
+        *_render_quickstart_agent_workflows(payload),
+        "",
+        "Next:",
+        *_render_quickstart_list(payload, "next_steps"),
+        "",
+        "Safety:",
+        *_render_quickstart_list(payload, "safety"),
+    ]
+
+
+def _render_quickstart_list(payload: dict[str, object], key: str) -> list[str]:
+    """Render one quickstart list field as bullet lines."""
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        return []
+    return [f"- {value}" for value in values]
+
+
+def _render_quickstart_numbered_list(payload: dict[str, object], key: str) -> list[str]:
+    """Render one quickstart list field as numbered steps."""
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        return []
+    return [f"{index}. {value}" for index, value in enumerate(values, start=1)]
+
+
+def _render_quickstart_client_commands(payload: dict[str, object]) -> list[str]:
+    """Render optional direct MCP client setup commands."""
+    lines = _render_quickstart_list(payload, "client_commands")
+    if not lines:
+        return []
+    return ["", "Client setup:", *lines]
+
+
+def _render_quickstart_agent_workflows(payload: dict[str, object]) -> list[str]:
+    """Render quickstart agent workflow cards as terminal-friendly prompts."""
+    values = payload.get("agent_workflows", [])
+    if not isinstance(values, list):
+        return []
+    lines: list[str] = []
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        title = value.get("title")
+        prompt = value.get("prompt")
+        if isinstance(title, str) and isinstance(prompt, str):
+            lines.append(f"- {title}: {prompt}")
+    return lines
+
+
+def _render_hosted_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render hosted HTTP MCP client setup guidance."""
+    client_label = "Claude Code" if payload["client"] == "claude-code" else "Codex"
+    command_label = "Claude Code CLI" if payload["client"] == "claude-code" else "Codex CLI"
+    lines = [
+        f"PolicyNIM hosted MCP config for {client_label}",
+        f"Hosted URL: {payload['hosted_url']}",
+        f"Bearer token env var: {payload['bearer_token_env_var']}",
+        "",
+        f"{command_label}:",
+        str(payload["cli_shell_command"])
+        if payload["client"] == "claude-code"
+        else str(payload["codex_cli_shell_command"]),
+    ]
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_claude_code_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render local stdio MCP setup guidance for Claude Code."""
+    config = payload["config"]
+    lines = [
+        "PolicyNIM MCP config for Claude Code",
+        f"Launch mode: {payload['local_launch_mode']}",
+    ]
+    if "repo_root" in payload:
+        lines.append(f"Repo root: {payload['repo_root']}")
+    lines.extend(
+        [
+            "",
+            "Project-scoped .mcp.json:",
+            json.dumps(config, indent=2),
+            "",
+            "Claude Code CLI:",
+            str(payload["cli_shell_command"]),
+        ]
+    )
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_codex_mcp_config(payload: dict[str, object]) -> list[str]:
+    """Render local stdio MCP setup guidance for Codex."""
+    codex_app = payload["codex_app"]
+    if not isinstance(codex_app, dict):
+        raise PolicyNIMError("Generated Codex app config was malformed.")
+    arguments = codex_app.get("arguments", [])
+    if not isinstance(arguments, list):
+        raise PolicyNIMError("Generated Codex app arguments were malformed.")
+    lines = [
+        "PolicyNIM MCP config for Codex",
+        f"Launch mode: {payload['local_launch_mode']}",
+    ]
+    if "repo_root" in payload:
+        lines.append(f"Repo root: {payload['repo_root']}")
+    lines.extend(
+        [
+            "",
+            "Codex CLI:",
+            str(payload["codex_cli_shell_command"]),
+            "",
+            "Codex App:",
+            f"Name: {codex_app.get('name')}",
+            f"Transport: {codex_app.get('transport')}",
+            f"Command to launch: {codex_app.get('command')}",
+            "Arguments:",
+            *[f"- {argument}" for argument in arguments],
+        ]
+    )
+    working_directory = codex_app.get("working_directory")
+    if working_directory is not None:
+        lines.append(f"Working directory: {working_directory}")
+    lines.append("Environment variable passthrough: NVIDIA_API_KEY")
+    return [*lines, *_render_mcp_config_next_steps(payload)]
+
+
+def _render_mcp_config_next_steps(payload: dict[str, object]) -> list[str]:
+    """Render shared MCP config next-step and safety sections."""
+    next_steps = payload.get("next_steps", [])
+    safety = payload.get("safety", [])
+    lines: list[str] = []
+    if not isinstance(next_steps, list):
+        next_steps = []
+    if next_steps:
+        lines.extend(["", "Before using this config:", *[f"- {step}" for step in next_steps]])
+    if isinstance(safety, list) and safety:
+        lines.extend(["", "Safety:", *[f"- {item}" for item in safety]])
+    return lines
+
+
+def _shell_join(command: Sequence[str]) -> str:
+    """Render argv as a shell-safe command string."""
+    return shlex.join(command)
+
+
+def _claude_hosted_shell_command(
+    *,
+    server_name: str,
+    hosted_url: str,
+    bearer_token_env_var: str,
+) -> str:
+    """Render the hosted Claude Code MCP command without exposing token values."""
+    prefix = _shell_join(
+        [
+            "claude",
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            server_name,
+            hosted_url,
+            "--header",
+        ]
+    )
+    return f'{prefix} "Authorization: Bearer ${bearer_token_env_var}"'
+
+
+def _codex_cli_shell_command(
+    *,
+    server_name: str,
+    command: str,
+    args: Sequence[str],
+) -> str:
+    """Render the Codex CLI command for a local stdio MCP server."""
+    prefix = _shell_join(["codex", "mcp", "add", server_name, "--env"])
+    launch = _shell_join([command, *args])
+    return f"{prefix} NVIDIA_API_KEY=$NVIDIA_API_KEY -- {launch}"
+
+
+async def _build_support_bundle(
+    *,
+    include_mcp_smoke: bool,
+    mcp_timeout_seconds: float,
+    include_local_paths: bool,
+) -> dict[str, object]:
+    """Build public or private diagnostics for maintainer support."""
+    bundle: dict[str, object] = {
+        "schema_version": "1",
+        "generated_at": datetime.now().astimezone().isoformat(),
+        "policynim_version": _safe_installed_version(),
+        "python": {
+            "version": platform.python_version(),
+            "executable": sys.executable,
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "first_run": _build_support_bundle_first_run_report(),
+        "doctor": _build_doctor_report(),
+        "mcp_smoke": {
+            "status": "skipped",
+            "reason": ("Pass --include-mcp-smoke to verify stdio tool registration."),
+        },
+        "redaction": {
+            "secrets_included": False,
+            "local_paths": "included" if include_local_paths else "redacted",
+            "path_markers": [],
+            "note": (
+                "Secret values are not printed. Local paths are included for private "
+                "maintainer triage."
+                if include_local_paths
+                else (
+                    "Secret values are not printed; local path prefixes are redacted "
+                    "for public issues. Pass --include-local-paths only for private "
+                    "maintainer triage."
+                )
+            ),
+        },
+    }
+    if include_mcp_smoke:
+        bundle["mcp_smoke"] = await _run_mcp_stdio_smoke(timeout_seconds=mcp_timeout_seconds)
+    if include_local_paths:
+        return bundle
+
+    redacted_bundle, markers = _redact_support_bundle_paths(bundle)
+    redaction = redacted_bundle.get("redaction")
+    if isinstance(redaction, dict):
+        redaction["path_markers"] = markers
+    return redacted_bundle
+
+
+def _build_support_bundle_first_run_report() -> dict[str, object]:
+    """Build quickstart summaries for all first-run targets."""
+    targets: dict[str, object] = {}
+    target_specs: tuple[
+        tuple[str, Literal["hosted-mcp", "local-cli", "local-mcp"]],
+        ...,
+    ] = (
+        ("hosted_mcp", "hosted-mcp"),
+        ("local_cli", "local-cli"),
+        ("local_mcp", "local-mcp"),
+    )
+    for key, target in target_specs:
+        payload = _build_quickstart_payload(
+            target=target,
+            client="codex",
+            hosted_url="https://<railway-domain>/mcp",
+            bearer_token_env_var="POLICYNIM_TOKEN",
+            repo_root=None,
+        )
+        targets[key] = _support_bundle_quickstart_summary(
+            payload,
+            quickstart_command=_support_bundle_quickstart_command(target),
+        )
+
+    return {
+        "runtime_mode": _doctor_runtime_mode(),
+        "default_target": "hosted-mcp",
+        "targets": targets,
+    }
+
+
+def _support_bundle_quickstart_command(
+    target: Literal["hosted-mcp", "local-cli", "local-mcp"],
+) -> str:
+    """Return the command that reproduces one quickstart target."""
+    command = f"quickstart --target {target}"
+    if target == "local-mcp":
+        command = f"{command} --client codex"
+    if target == "hosted-mcp":
+        return _quickstart_installed_cli_command([*command.split(), "--format", "json"])
+    return _doctor_cli_command(f"{command} --format json")
+
+
+def _support_bundle_quickstart_summary(
+    payload: dict[str, object],
+    *,
+    quickstart_command: str,
+) -> dict[str, object]:
+    """Extract support-bundle-safe quickstart fields."""
+    summary: dict[str, object] = {
+        "target": payload["target"],
+        "description": payload["description"],
+        "quickstart_command": quickstart_command,
+        "requires_local_setup": payload["requires_local_setup"],
+        "calls_external_services": payload["calls_external_services"],
+        "steps": payload["steps"],
+        "commands": payload["commands"],
+        "agent_workflows": payload["agent_workflows"],
+        "next_steps": payload["next_steps"],
+        "safety": payload["safety"],
+    }
+    for optional_key in (
+        "hosted_url",
+        "beta_portal_url",
+        "hosted_url_placeholder",
+        "local_launch_mode",
+        "client_commands",
+    ):
+        if optional_key in payload:
+            summary[optional_key] = payload[optional_key]
+    if payload["target"] == "hosted-mcp":
+        summary["client_commands"] = _quickstart_all_hosted_client_commands(
+            hosted_url=str(payload["hosted_url"]),
+            bearer_token_env_var="POLICYNIM_TOKEN",
+        )
+    return summary
+
+
+def _redact_support_bundle_paths(bundle: dict[str, object]) -> tuple[dict[str, object], list[str]]:
+    """Redact local path prefixes from a support bundle."""
+    replacements = _support_bundle_path_replacements()
+    redacted = _replace_local_path_prefixes(bundle, replacements)
+    markers = sorted({marker for _, marker in replacements})
+    return cast(dict[str, object], redacted), markers
+
+
+def _support_bundle_path_replacements() -> list[tuple[str, str]]:
+    """Return local path prefixes and the markers that should replace them."""
+    candidates: list[tuple[Path, str]] = [
+        (Path(sys.executable), "<python-executable>"),
+        (Path.home(), "<home>"),
+    ]
+    source_root = config_discovery.find_source_checkout_root()
+    if source_root is not None:
+        candidates.append((source_root, "<repo-root>"))
+
+    standalone = config_discovery.standalone_paths()
+    candidates.extend(
+        [
+            (standalone.config_file.parent, "<config-dir>"),
+            (standalone.data_root, "<data-dir>"),
+        ]
+    )
+
+    replacements: dict[str, str] = {}
+    if sys.executable:
+        replacements[sys.executable] = "<python-executable>"
+    for path, marker in candidates:
+        for candidate in (
+            path.expanduser().as_posix(),
+            path.expanduser().resolve(strict=False).as_posix(),
+        ):
+            if candidate and candidate != "/":
+                replacements[candidate] = marker
+    return sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True)
+
+
+def _replace_local_path_prefixes(value: object, replacements: Sequence[tuple[str, str]]) -> object:
+    """Recursively replace local path prefixes in support-bundle values."""
+    if isinstance(value, str):
+        redacted = value
+        for path_prefix, marker in replacements:
+            redacted = redacted.replace(path_prefix, marker)
+        return redacted
+    if isinstance(value, list):
+        return [_replace_local_path_prefixes(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _replace_local_path_prefixes(item, replacements) for key, item in value.items()
+        }
+    return value
+
+
+def _safe_installed_version() -> str:
+    """Return the installed package version without failing diagnostics."""
+    try:
+        return _resolve_installed_version()
+    except PolicyNIMError:
+        return "unknown"
+
+
+def _render_support_bundle_markdown(rendered_json: str) -> str:
+    """Wrap rendered support-bundle JSON in a Markdown code fence."""
+    return "\n".join(
+        [
+            "## PolicyNIM Support Bundle",
+            "",
+            "```json",
+            rendered_json,
+            "```",
+        ]
+    )
+
+
+async def _run_mcp_stdio_smoke(
+    *,
+    timeout_seconds: float,
+    command: list[str] | None = None,
+    cwd: Path | None = None,
+) -> dict[str, object]:
+    """Launch local stdio MCP and report public tool registration."""
+    command = command or _mcp_stdio_smoke_command()
+    report: dict[str, object] = {
+        "status": "error",
+        "transport": "stdio",
+        "command": command,
+        "tools": [],
+        "missing_tools": list(_EXPECTED_MCP_TOOLS),
+    }
+    with TemporaryFile(mode="w+", encoding="utf-8") as errlog:
+        try:
+            parameters = StdioServerParameters(
+                command=command[0],
+                args=command[1:],
+                env=_mcp_stdio_smoke_env(),
+                cwd=cwd or Path.cwd(),
+            )
+            async with stdio_client(parameters, errlog=errlog) as (read_stream, write_stream):
+                async with ClientSession(
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                ) as session:
+                    await session.initialize()
+                    tool_result = await session.list_tools()
+        except Exception as exc:
+            report["message"] = f"MCP stdio smoke failed: {type(exc).__name__}: {exc}"
+            report["next_steps"] = _mcp_stdio_recovery_steps()
+            errlog.seek(0)
+            stderr_tail = errlog.read().strip()[-2000:]
+            if stderr_tail:
+                report["server_stderr_tail"] = stderr_tail
+            return report
+
+    tool_names = sorted(tool.name for tool in tool_result.tools)
+    missing_tools = [tool for tool in _EXPECTED_MCP_TOOLS if tool not in tool_names]
+    report["tools"] = tool_names
+    report["missing_tools"] = missing_tools
+    report["status"] = "ok" if not missing_tools else "error"
+    if missing_tools:
+        report["message"] = "MCP stdio server did not list all expected public tools."
+        report["next_steps"] = _mcp_stdio_recovery_steps()
+    return report
+
+
+def _mcp_stdio_smoke_command_from_config_file(path: Path) -> tuple[list[str], Path | None]:
+    """Extract a local stdio launch command from generated mcp-config JSON."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise PolicyNIMError(f"Could not read MCP config file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyNIMError(f"MCP config file {path} must contain JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PolicyNIMError("MCP config file must contain a JSON object.")
+    if payload.get("target") != "local-stdio":
+        raise PolicyNIMError(
+            "mcp-smoke --mcp-config-file only supports local-stdio configs. "
+            "Use hosted launch evidence for hosted-http configs."
+        )
+
+    client = payload.get("client")
+    if client == "codex":
+        return _codex_stdio_command_from_config_payload(payload)
+    if client == "claude-code":
+        return _claude_stdio_command_from_config_payload(payload)
+    raise PolicyNIMError("MCP config file client must be codex or claude-code.")
+
+
+def _codex_stdio_command_from_config_payload(
+    payload: dict[object, object],
+) -> tuple[list[str], Path | None]:
+    codex_app = payload.get("codex_app")
+    if not isinstance(codex_app, dict):
+        raise PolicyNIMError("Codex MCP config file is missing codex_app.")
+    if codex_app.get("transport") != "STDIO":
+        raise PolicyNIMError("Codex MCP config file must use STDIO transport.")
+    command = codex_app.get("command")
+    arguments = codex_app.get("arguments")
+    launch_command = _mcp_stdio_launch_command(command, arguments)
+    cwd = _optional_path(codex_app.get("working_directory")) or _optional_path(
+        payload.get("repo_root")
+    )
+    return launch_command, cwd
+
+
+def _claude_stdio_command_from_config_payload(
+    payload: dict[object, object],
+) -> tuple[list[str], Path | None]:
+    config = payload.get("config")
+    server_name = payload.get("server_name")
+    if not isinstance(config, dict) or not isinstance(server_name, str):
+        raise PolicyNIMError("Claude Code MCP config file is missing config or server_name.")
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        raise PolicyNIMError("Claude Code MCP config file is missing mcpServers.")
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        raise PolicyNIMError(f"Claude Code MCP config file is missing {server_name!r}.")
+    if server.get("type") != "stdio":
+        raise PolicyNIMError("Claude Code MCP config file must use stdio transport.")
+    launch_command = _mcp_stdio_launch_command(server.get("command"), server.get("args"))
+    return launch_command, _optional_path(payload.get("repo_root"))
+
+
+def _mcp_stdio_launch_command(command: object, arguments: object) -> list[str]:
+    if not isinstance(command, str) or not command:
+        raise PolicyNIMError("MCP config file must include a non-empty stdio command.")
+    if not isinstance(arguments, list) or any(
+        not isinstance(argument, str) for argument in arguments
+    ):
+        raise PolicyNIMError("MCP config file stdio arguments must be a string list.")
+    return [command, *cast(list[str], arguments)]
+
+
+def _optional_path(value: object) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return Path(value)
+
+
+def _mcp_stdio_smoke_command() -> list[str]:
+    """Return the command used to re-enter the local MCP stdio server."""
+    if getattr(sys, "frozen", False):
+        return [sys.executable, "mcp", "--transport", "stdio"]
+    return [sys.executable, "-m", "policynim.interfaces.cli", "mcp", "--transport", "stdio"]
+
+
+def _mcp_stdio_smoke_env() -> dict[str, str]:
+    """Return an env that can resolve the current installed policynim entrypoint."""
+    env = os.environ.copy()
+    executable_dir = str(Path(sys.executable).parent)
+    existing_path = env.get("PATH", "")
+    env["PATH"] = (
+        f"{executable_dir}{os.pathsep}{existing_path}" if existing_path else executable_dir
+    )
+    return env
+
+
+def _mcp_stdio_recovery_steps() -> list[str]:
+    """Return setup steps for failed local MCP stdio smoke checks."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return [
+            "Run `uv run policynim doctor` to inspect config, credentials, and local index state.",
+            "Run `uv run policynim ingest` before calling policy_preflight or policy_search.",
+            "Run `uv run policynim mcp-smoke --format json` after changing local setup.",
+            (
+                "Regenerate client config with `uv run policynim mcp-config --target "
+                "local-stdio --client codex --repo-root /ABS/PATH/TO/policyNIM --format json` "
+                "or the same command with `--client claude-code`."
+            ),
+            (
+                "If the MCP client cannot find `uv`, rerun mcp-config with "
+                "`--uv-command /ABS/PATH/TO/uv`."
+            ),
+        ]
+    return [
+        "Run `policynim doctor` to inspect config, credentials, and local index state.",
+        "Run `policynim ingest` before calling policy_preflight or policy_search.",
+        "Run `policynim mcp-smoke --format json` after changing local setup.",
+        (
+            "Regenerate client config with `policynim mcp-config --target local-stdio "
+            "--client codex --format json` or the same command with `--client claude-code`."
+        ),
+    ]
+
+
+def _render_mcp_smoke_report(report: dict[str, object]) -> list[str]:
+    """Render an MCP smoke report as terminal-friendly text."""
+    lines = [
+        "PolicyNIM MCP smoke",
+        f"Status: {report['status']}",
+        f"Transport: {report['transport']}",
+    ]
+    command = report.get("command")
+    if isinstance(command, list):
+        lines.append(f"Command: {' '.join(str(part) for part in command)}")
+    tools = report.get("tools")
+    if isinstance(tools, list):
+        lines.append(f"Tools: {', '.join(str(tool) for tool in tools) or 'none'}")
+    missing_tools = report.get("missing_tools")
+    if isinstance(missing_tools, list) and missing_tools:
+        lines.append(f"missing_tools: {', '.join(str(tool) for tool in missing_tools)}")
+    message = report.get("message")
+    if isinstance(message, str) and message:
+        lines.append(f"Message: {message}")
+    next_steps = report.get("next_steps")
+    if isinstance(next_steps, list) and next_steps:
+        lines.append("")
+        lines.append("Next steps:")
+        for step in next_steps:
+            lines.append(f"- {step}")
+    return lines
+
+
+def _build_doctor_report() -> dict[str, object]:
+    """Build a setup diagnostic report without calling hosted APIs."""
+    discovery = config_discovery.discover_config_files()
+    expected_config_file = config_discovery.resolve_init_config_file()
+    report: dict[str, object] = {
+        "status": "ok",
+        "runtime_mode": _doctor_runtime_mode(),
+        "config": {
+            "active_config_file": _path_text(discovery.active_config_file),
+            "discovered_env_files": [_path_text(path) for path in discovery.env_files],
+            "expected_init_config_file": expected_config_file.as_posix(),
+        },
+        "checks": [],
+        "paths": {},
+        "mcp": {},
+        "next_steps": [],
+    }
+    checks: list[dict[str, str]] = []
+    next_steps: list[str] = []
+
+    if config_discovery.standalone_setup_missing():
+        message = f"Run `policynim init` to create {expected_config_file}."
+        checks.append({"name": "setup", "status": "action_required", "message": message})
+        report["status"] = "action_required"
+        report["checks"] = checks
+        report["next_steps"] = [message]
+        return report
+
+    try:
+        settings = get_settings()
+    except PolicyNIMError as exc:
+        checks.append(
+            {
+                "name": "configuration",
+                "status": "error",
+                "message": _cli_error_message(exc),
+            }
+        )
+        report["status"] = "error"
+        report["checks"] = checks
+        report["next_steps"] = ["Fix the configuration error above, then rerun `policynim doctor`."]
+        return report
+
+    checks.append(
+        {
+            "name": "configuration",
+            "status": "ok",
+            "message": "Settings loaded without validation errors.",
+        }
+    )
+    if settings.nvidia_api_key:
+        checks.append(
+            {"name": "nvidia_api_key", "status": "ok", "message": "NVIDIA_API_KEY is set."}
+        )
+    else:
+        checks.append(
+            {
+                "name": "nvidia_api_key",
+                "status": "action_required",
+                "message": "NVIDIA_API_KEY is not set.",
+            }
+        )
+        next_steps.append(
+            f"Run `{_doctor_cli_command('init')}` or set `NVIDIA_API_KEY` before ingest/search."
+        )
+
+    index_path = resolve_runtime_path(settings.index_db_path)
+    runtime_rules_path = resolve_runtime_path(settings.runtime_rules_artifact_path)
+    report["paths"] = {
+        "index_db_path": index_path.as_posix(),
+        "runtime_rules_artifact_path": runtime_rules_path.as_posix(),
+        "runtime_evidence_db_path": resolve_runtime_path(
+            settings.runtime_evidence_db_path
+        ).as_posix(),
+        "eval_workspace_dir": resolve_runtime_path(settings.eval_workspace_dir).as_posix(),
+    }
+
+    legacy_lancedb_alias_configured = _doctor_legacy_lancedb_alias_configured(discovery)
+    index_recovery_step_added = False
+    if index_path.is_dir():
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": (
+                    "Configured local SQLite index path points to a directory. "
+                    "Set POLICYNIM_INDEX_DB_PATH to a SQLite file path such as "
+                    "data/index.sqlite3."
+                ),
+            }
+        )
+        next_steps.append(
+            _doctor_index_directory_next_step(
+                legacy_lancedb_alias_configured=legacy_lancedb_alias_configured
+            )
+        )
+        index_recovery_step_added = True
+    elif index_path.exists():
+        if _doctor_local_index_ready(settings):
+            checks.append(
+                {
+                    "name": "local_index_path",
+                    "status": "ok",
+                    "message": "A populated local SQLite index exists.",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "local_index_path",
+                    "status": "action_required",
+                    "message": (
+                        "Configured local SQLite index file is not a populated "
+                        "PolicyNIM sqlite-vec index."
+                    ),
+                }
+            )
+            next_steps.append(_doctor_ingest_next_step())
+            index_recovery_step_added = True
+    else:
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": "No local index path exists yet.",
+            }
+        )
+        next_steps.append(_doctor_ingest_next_step())
+
+    if runtime_rules_path.exists():
+        checks.append(
+            {
+                "name": "runtime_rules_artifact",
+                "status": "ok",
+                "message": "Runtime rules artifact exists.",
+            }
+        )
+    else:
+        checks.append(
+            {
+                "name": "runtime_rules_artifact",
+                "status": "action_required",
+                "message": "Runtime rules artifact is missing.",
+            }
+        )
+        ingest_next_step = _doctor_ingest_next_step()
+        if not index_recovery_step_added and ingest_next_step not in next_steps:
+            next_steps.append(ingest_next_step)
+
+    report["mcp"] = {
+        "stdio_command": _doctor_mcp_command("mcp --transport stdio"),
+        "smoke_command": _doctor_mcp_command("mcp-smoke --format json"),
+        "local_stdio_config_commands": _doctor_mcp_config_commands(),
+        "streamable_http_url": f"http://{settings.mcp_host}:{settings.mcp_port}/mcp",
+        "auth_required": settings.mcp_require_auth,
+    }
+    if not next_steps:
+        search_command = _doctor_cli_command('search --query "refresh token cleanup" --top-k 5')
+        mcp_command = _doctor_cli_command("mcp --transport stdio")
+        next_steps.append(f"Run `{search_command}` or `{mcp_command}`.")
+
+    if any(check["status"] == "error" for check in checks):
+        report["status"] = "error"
+    elif any(check["status"] == "action_required" for check in checks):
+        report["status"] = "action_required"
+    report["checks"] = checks
+    report["next_steps"] = next_steps
+    return report
+
+
+def _doctor_runtime_mode() -> str:
+    """Return the current runtime mode for diagnostic output."""
+    if config_discovery.is_hosted_process_environment():
+        return "hosted"
+    if config_discovery.is_source_checkout():
+        return "source_checkout"
+    return "standalone"
+
+
+def _doctor_cli_command(command: str) -> str:
+    """Render a CLI command for the current diagnostic runtime."""
+    if _doctor_runtime_mode() == "source_checkout":
+        return f"uv run policynim {command}"
+    return f"policynim {command}"
+
+
+def _doctor_ingest_next_step() -> str:
+    """Return the standard ingest recovery step for doctor output."""
+    return (
+        f"Run `{_doctor_cli_command('ingest')}` to build the local policy index "
+        "and runtime rules artifact."
+    )
+
+
+def _doctor_local_index_ready(settings: Settings) -> bool:
+    """Return whether the configured local SQLite index is ready for runtime use."""
+    try:
+        return create_index_store(settings).exists()
+    except Exception:
+        return False
+
+
+def _doctor_index_directory_next_step(*, legacy_lancedb_alias_configured: bool) -> str:
+    """Return recovery guidance for SQLite index paths that point at directories."""
+    if legacy_lancedb_alias_configured:
+        return (
+            "Replace deprecated `POLICYNIM_LANCEDB_URI` with "
+            f"`POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run "
+            f"`{_doctor_cli_command('ingest')}`."
+        )
+    return (
+        "Set `POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run "
+        f"`{_doctor_cli_command('ingest')}`."
+    )
+
+
+def _doctor_legacy_lancedb_alias_configured(
+    discovery: config_discovery.ConfigDiscovery,
+) -> bool:
+    """Return true when the deprecated LanceDB env alias is still configured."""
+    if "POLICYNIM_LANCEDB_URI" in os.environ:
+        return True
+    for env_file in discovery.env_files:
+        try:
+            for line in env_file.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped.startswith("POLICYNIM_LANCEDB_URI="):
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _doctor_mcp_command(command: str) -> str:
+    """Render an MCP-related command for doctor output."""
+    return _doctor_cli_command(command)
+
+
+def _doctor_mcp_config_commands() -> dict[str, str]:
+    """Return shell-safe local stdio MCP config commands by client."""
+    if _doctor_runtime_mode() != "source_checkout":
+        return {
+            "codex": _shell_join(
+                [
+                    "policynim",
+                    "mcp-config",
+                    "--target",
+                    "local-stdio",
+                    "--client",
+                    "codex",
+                    "--format",
+                    "json",
+                ]
+            ),
+            "claude-code": _shell_join(
+                [
+                    "policynim",
+                    "mcp-config",
+                    "--target",
+                    "local-stdio",
+                    "--client",
+                    "claude-code",
+                    "--format",
+                    "json",
+                ]
+            ),
+        }
+
+    repo_root = config_discovery.find_source_checkout_root()
+    return {
+        "codex": _doctor_local_stdio_mcp_config_command("codex", repo_root=repo_root),
+        "claude-code": _doctor_local_stdio_mcp_config_command(
+            "claude-code",
+            repo_root=repo_root,
+        ),
+    }
+
+
+def _doctor_local_stdio_mcp_config_command(
+    client: Literal["codex", "claude-code"],
+    *,
+    repo_root: Path | None,
+) -> str:
+    """Render a shell-safe local stdio MCP config command for doctor output."""
+    parts = [
+        "uv",
+        "run",
+        "policynim",
+        "mcp-config",
+        "--target",
+        "local-stdio",
+        "--client",
+        client,
+    ]
+    if repo_root is not None:
+        parts.extend(["--repo-root", str(repo_root)])
+    parts.extend(["--format", "json"])
+    return _shell_join(parts)
+
+
+def _render_doctor_report(report: dict[str, object]) -> list[str]:
+    """Render a doctor report as terminal-friendly text."""
+    lines = [
+        "PolicyNIM doctor",
+        f"Status: {report['status']}",
+        f"Runtime mode: {report['runtime_mode']}",
+    ]
+    config = report["config"]
+    if isinstance(config, dict):
+        lines.append(f"Config file: {config.get('active_config_file') or 'not found'}")
+    checks = report["checks"]
+    if isinstance(checks, list):
+        lines.append("")
+        lines.append("Checks:")
+        for check in checks:
+            if isinstance(check, dict):
+                lines.append(
+                    f"- {check.get('name')}: {check.get('status')} - {check.get('message')}"
+                )
+    mcp = report["mcp"]
+    if isinstance(mcp, dict) and mcp:
+        lines.append("")
+        lines.append("MCP:")
+        lines.append(f"- stdio: {mcp.get('stdio_command')}")
+        smoke_command = mcp.get("smoke_command")
+        if isinstance(smoke_command, str):
+            lines.append(f"- smoke: {smoke_command}")
+        config_commands = mcp.get("local_stdio_config_commands")
+        if isinstance(config_commands, dict):
+            for client, command in config_commands.items():
+                lines.append(f"- {client} config: {command}")
+        lines.append(f"- streamable-http: {mcp.get('streamable_http_url')}")
+    next_steps = report["next_steps"]
+    if isinstance(next_steps, list) and next_steps:
+        lines.append("")
+        lines.append("Next steps:")
+        for step in next_steps:
+            lines.append(f"- {step}")
+    return lines
+
+
+def _path_text(path: Path | None) -> str | None:
+    """Return a POSIX path string for optional paths."""
+    return None if path is None else path.as_posix()
 
 
 def _cli_error_message(error: PolicyNIMError) -> str:

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -24,6 +24,7 @@ from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from policynim.agent_workflows import agent_workflow_cards
 from policynim.errors import (
     ConfigurationError,
     InvalidPolicyDocumentError,
@@ -609,8 +610,10 @@ def _beta_command_card_context(
     description: str,
     command: str,
     button_label: str = "Copy command",
+    eyebrow: str = "Client setup",
 ) -> dict[str, str]:
     return {
+        "eyebrow": eyebrow,
         "title": title,
         "description": description,
         "command": command,
@@ -755,7 +758,7 @@ def _render_beta_dashboard(
         )
     new_key_context: dict[str, str] | None = None
     if new_api_key is not None:
-        export_command = f"export POLICYNIM_TOKEN={new_api_key}"
+        export_command = f"export POLICYNIM_TOKEN='{new_api_key}'"
         new_key_context = {
             "button_label": "Copy export",
             "export_command": export_command,
@@ -801,6 +804,16 @@ def _render_beta_dashboard(
                     ),
                     command=claude_command,
                 ),
+            ],
+            "workflow_cards": [
+                _beta_command_card_context(
+                    eyebrow="Agent workflow",
+                    title=workflow["title"],
+                    description=workflow["description"],
+                    command=workflow["prompt"],
+                    button_label="Copy prompt",
+                )
+                for workflow in agent_workflow_cards()
             ],
         }
     )
@@ -889,11 +902,13 @@ class _BearerProtectedASGIApp:
         protected_path: str,
         valid_tokens: list[str],
         beta_auth_service: BetaAuthService | None,
+        beta_portal_url: str | None,
     ) -> None:
         self._app = app
         self._protected_path = protected_path
         self._valid_tokens = set(valid_tokens)
         self._beta_auth_service = beta_auth_service
+        self._beta_portal_url = beta_portal_url
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Authorize protected MCP HTTP requests before delegating to the app."""
@@ -903,7 +918,7 @@ class _BearerProtectedASGIApp:
 
         token = _extract_bearer_token(scope)
         auth_result: str | None = None
-        response: JSONResponse | None = None
+        response: Response | None = None
         if token is not None and token in self._valid_tokens:
             auth_result = "authorized"
         elif self._beta_auth_service is not None:
@@ -918,14 +933,12 @@ class _BearerProtectedASGIApp:
                 response = JSONResponse({"error": "Quota exceeded."}, status_code=429)
             else:
                 auth_result = "unauthorized"
-                response = JSONResponse({"error": "Unauthorized."}, status_code=401)
         else:
             auth_result = "unauthorized"
-            response = JSONResponse({"error": "Unauthorized."}, status_code=401)
 
         if auth_result != "authorized":
             if response is None:
-                response = JSONResponse({"error": "Unauthorized."}, status_code=401)
+                response = self._unauthorized_response(scope)
             _emit_hosted_event(
                 "mcp.auth",
                 auth_result=auth_result or "unauthorized",
@@ -943,6 +956,12 @@ class _BearerProtectedASGIApp:
         finally:
             _HOSTED_AUTH_RESULT.reset(token_state)
 
+    def _unauthorized_response(self, scope: Scope) -> Response:
+        """Return onboarding for browser visits and JSON for MCP clients."""
+        if self._beta_portal_url is not None and _is_browser_mcp_visit(scope):
+            return RedirectResponse(self._beta_portal_url, status_code=303)
+        return JSONResponse({"error": "Unauthorized."}, status_code=401)
+
 
 def _extract_bearer_token(scope: Scope) -> str | None:
     """Return the bearer token from the HTTP Authorization header, if valid."""
@@ -958,6 +977,14 @@ def _extract_bearer_token(scope: Scope) -> str | None:
     if scheme.lower() != "bearer":
         return None
     return token.strip() or None
+
+
+def _is_browser_mcp_visit(scope: Scope) -> bool:
+    """Return true when a human likely opened /mcp in a browser."""
+    headers = Headers(scope=scope)
+    if headers.get("authorization") is not None:
+        return False
+    return "text/html" in headers.get("accept", "")
 
 
 def _build_streamable_http_app(settings: Settings) -> ASGIApp:
@@ -985,6 +1012,7 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
         protected_path=server.settings.streamable_http_path,
         valid_tokens=settings.mcp_bearer_tokens,
         beta_auth_service=beta_auth_service,
+        beta_portal_url=_derive_beta_url(settings) if settings.beta_signup_enabled else None,
     )
 
 

--- a/src/policynim/templates/beta/dashboard.html.j2
+++ b/src/policynim/templates/beta/dashboard.html.j2
@@ -126,5 +126,19 @@
       {% endfor %}
     </div>
   </section>
+
+  <section class="beta-section">
+    <div class="beta-section__header">
+      <p class="beta-kicker">Agent workflows</p>
+      <h2 class="beta-section-title">Use PolicyNIM where policy context changes the code</h2>
+    </div>
+    <div class="beta-card-grid beta-card-grid--commands">
+      {% for command_card in workflow_cards %}
+        {% with command=command_card %}
+          {% include "beta/partials/command_card.html.j2" %}
+        {% endwith %}
+      {% endfor %}
+    </div>
+  </section>
 </main>
 {% endblock %}

--- a/src/policynim/templates/beta/partials/command_card.html.j2
+++ b/src/policynim/templates/beta/partials/command_card.html.j2
@@ -1,7 +1,7 @@
 <section class="beta-card">
   <div class="beta-command-header">
     <div>
-      <p class="beta-eyebrow">Client setup</p>
+      <p class="beta-eyebrow">{{ command.eyebrow }}</p>
       <h2 class="beta-card-title">{{ command.title }}</h2>
     </div>
     <div class="beta-command-actions">

--- a/tests/test_beta_portal.py
+++ b/tests/test_beta_portal.py
@@ -152,6 +152,40 @@ def test_beta_portal_login_flow_sets_session_and_renders_dashboard(monkeypatch) 
     assert "claude mcp add --transport http policynim" in dashboard.text
 
 
+def test_beta_portal_dashboard_shows_agent_workflow_prompts(monkeypatch) -> None:
+    """Show hosted users what to ask their coding agent after setup."""
+    stub = StubBetaAuthService()
+    monkeypatch.setattr(mcp_module, "create_beta_auth_service", lambda settings: stub)
+
+    app = mcp_module._build_streamable_http_app(_signup_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        client.get("/auth/github/start", follow_redirects=False)
+        client.get(
+            f"/auth/github/callback?state={stub.oauth_states[0]}&code=oauth-code",
+            follow_redirects=False,
+        )
+        dashboard = client.get("/beta")
+
+    assert dashboard.status_code == 200
+    for token in (
+        "Agent workflows",
+        "Preflight before implementation",
+        "Retrieve policy evidence while debugging",
+        "Verify MCP tool availability",
+        "Before editing, call policy_preflight for: Implement a refresh-token cleanup",
+        "cited constraints",
+        "insufficient_context",
+        "Use policy_search for: release installer checksum verification.",
+        "cited policy lines",
+        (
+            "List the PolicyNIM MCP tools and confirm policy_preflight and "
+            "policy_search are available before starting implementation."
+        ),
+    ):
+        assert token in dashboard.text
+
+
 def test_beta_portal_rejects_invalid_oauth_state(monkeypatch) -> None:
     stub = StubBetaAuthService()
     monkeypatch.setattr(mcp_module, "create_beta_auth_service", lambda settings: stub)
@@ -222,7 +256,7 @@ def test_beta_portal_regenerate_route_shows_new_api_key_once(monkeypatch) -> Non
     assert response.status_code == 200
     assert "pnm_new_secret" in response.text
     assert "Copy export" in response.text
-    assert "export POLICYNIM_TOKEN=pnm_new_secret" in response.text
+    assert "export POLICYNIM_TOKEN=&#39;pnm_new_secret&#39;" in response.text
 
 
 def test_beta_portal_serves_packaged_logo_assets(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from collections.abc import Generator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -14,6 +16,7 @@ from click import unstyle
 from typer.testing import CliRunner
 
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
+from policynim.interfaces import cli as cli_module
 from policynim.interfaces.cli import app
 from policynim.services.runtime_evidence_report import RuntimeEvidenceReportService
 from policynim.services.runtime_execution import RuntimeExecutionService
@@ -27,6 +30,7 @@ from policynim.types import (
     CompiledPolicyPacket,
     CompileRequest,
     CompileResult,
+    EmbeddedChunk,
     EvalAggregateMetrics,
     EvalBackend,
     EvalCaseMetrics,
@@ -82,12 +86,39 @@ def write_env_file(path: Path, **values: str) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def write_ready_sqlite_index(path: Path) -> None:
+    """Write a minimal populated PolicyNIM sqlite-vec index for doctor tests."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    SQLiteVecIndexStore(path=path).replace(
+        [
+            EmbeddedChunk(
+                chunk_id="DOCTOR-READY-1",
+                path="policies/backend/doctor-ready.md",
+                section="Rules",
+                lines="1-3",
+                text="Backend services should keep request ids in logs.",
+                policy=PolicyMetadata(
+                    policy_id="BACKEND-DOCTOR-001",
+                    title="Doctor Ready",
+                    doc_type="guidance",
+                    domain="backend",
+                    tags=["setup"],
+                    grounded_in=["https://example.com/policy"],
+                ),
+                vector=[1.0, 0.0],
+            )
+        ]
+    )
+
+
 def clear_installer_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear env that would interfere with standalone installer-style tests."""
     for key in (
         "NVIDIA_API_KEY",
         "POLICYNIM_CONFIG_FILE",
         "POLICYNIM_CORPUS_DIR",
+        "POLICYNIM_INDEX_DB_PATH",
         "POLICYNIM_LANCEDB_URI",
         "POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH",
         "POLICYNIM_RUNTIME_EVIDENCE_DB_PATH",
@@ -173,7 +204,7 @@ class MockIngestService:
     def run(self) -> IngestResult:
         return IngestResult(
             corpus_path="policies",
-            index_uri="data/lancedb",
+            index_uri="data/index.sqlite3",
             table_name="policy_chunks",
             embedding_model="mock-model",
             document_count=8,
@@ -1512,6 +1543,11 @@ def test_help_includes_runtime_and_evidence_commands() -> None:
     assert result.exit_code == 0
     assert "--version" in help_output
     assert "init" in help_output
+    assert "quickstart" in help_output
+    assert "doctor" in help_output
+    assert "mcp-config" in help_output
+    assert "mcp-smoke" in help_output
+    assert "support-bundle" in help_output
     assert "runtime" in help_output
     assert "evidence" in help_output
     assert "route" in help_output
@@ -1558,6 +1594,475 @@ def test_init_help_documents_interactive_setup_flow() -> None:
     assert "interactive" in result.stdout.lower()
     assert "NVIDIA_API_KEY" in result.stdout
     assert "--non-interactive" not in result.stdout
+
+
+def test_doctor_reports_missing_standalone_setup_without_provider_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Diagnose first-run setup before settings or provider construction."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    assert payload["runtime_mode"] == "standalone"
+    assert payload["config"]["expected_init_config_file"] == str(config_root / "config.env")
+    assert payload["next_steps"] == [
+        f"Run `policynim init` to create {config_root / 'config.env'}."
+    ]
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_doctor_reports_ready_checkout_and_mcp_hints(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Report safe local setup state without exposing configured secrets."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_path = checkout_root / "data" / "index.sqlite3"
+    runtime_rules_path = checkout_root / "data" / "runtime" / "runtime_rules.json"
+    write_ready_sqlite_index(index_path)
+    runtime_rules_path.parent.mkdir(parents=True)
+    runtime_rules_path.write_text("{}", encoding="utf-8")
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index.sqlite3",
+        POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH="data/runtime/runtime_rules.json",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["runtime_mode"] == "source_checkout"
+    assert payload["config"]["active_config_file"] == str(checkout_root / ".env")
+    assert payload["paths"]["index_db_path"] == str(index_path)
+    assert payload["mcp"]["stdio_command"] == "uv run policynim mcp --transport stdio"
+    assert payload["mcp"]["smoke_command"] == "uv run policynim mcp-smoke --format json"
+    assert payload["mcp"]["local_stdio_config_commands"] == {
+        "codex": "uv run policynim mcp-config --target local-stdio --client codex "
+        f"--repo-root {checkout_root} --format json",
+        "claude-code": (
+            "uv run policynim mcp-config --target local-stdio --client claude-code "
+            f"--repo-root {checkout_root} --format json"
+        ),
+    }
+    assert payload["mcp"]["streamable_http_url"] == "http://127.0.0.1:8000/mcp"
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_doctor_source_checkout_recovery_uses_uv_run_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Give source-checkout users recovery commands that run in the uv project."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    assert (
+        "Run `uv run policynim ingest` to build the local policy index and runtime rules artifact."
+    ) in payload["next_steps"]
+    assert (
+        "Run `policynim ingest` to build the local policy index and runtime rules artifact."
+        not in payload["next_steps"]
+    )
+
+
+def test_doctor_flags_invalid_sqlite_index_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Do not report ready when the configured SQLite file is not a PolicyNIM index."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_path = checkout_root / "data" / "index.sqlite3"
+    runtime_rules_path = checkout_root / "data" / "runtime" / "runtime_rules.json"
+    index_path.parent.mkdir(parents=True)
+    index_path.write_text("placeholder", encoding="utf-8")
+    runtime_rules_path.parent.mkdir(parents=True)
+    runtime_rules_path.write_text("{}", encoding="utf-8")
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index.sqlite3",
+        POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH="data/runtime/runtime_rules.json",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check == {
+        "name": "local_index_path",
+        "status": "action_required",
+        "message": (
+            "Configured local SQLite index file is not a populated PolicyNIM sqlite-vec index."
+        ),
+    }
+    assert payload["next_steps"] == [
+        (
+            "Run `uv run policynim ingest` to build the local policy index "
+            "and runtime rules artifact."
+        )
+    ]
+
+
+def test_doctor_flags_legacy_lancedb_directory_index_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide sqlite-vec upgrades away from old LanceDB directory paths."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    legacy_index_dir = checkout_root / "data" / "lancedb"
+    legacy_index_dir.mkdir(parents=True)
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_LANCEDB_URI="data/lancedb",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check == {
+        "name": "local_index_path",
+        "status": "action_required",
+        "message": (
+            "Configured local SQLite index path points to a directory. "
+            "Set POLICYNIM_INDEX_DB_PATH to a SQLite file path such as data/index.sqlite3."
+        ),
+    }
+    assert (
+        "Replace deprecated `POLICYNIM_LANCEDB_URI` with "
+        "`POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run `uv run policynim ingest`."
+    ) in payload["next_steps"]
+    assert (
+        "Run `uv run policynim ingest` to build the local policy index and runtime rules artifact."
+        not in payload["next_steps"]
+    )
+
+
+def test_doctor_flags_canonical_directory_index_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Tell users that sqlite-vec needs a file path, not a directory."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    index_dir = checkout_root / "data" / "index-dir"
+    index_dir.mkdir(parents=True)
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index-dir",
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "action_required"
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check["status"] == "action_required"
+    assert "points to a directory" in local_index_check["message"]
+    assert (
+        "Set `POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run `uv run policynim ingest`."
+    ) in payload["next_steps"]
+    assert "POLICYNIM_LANCEDB_URI" not in " ".join(payload["next_steps"])
+
+
+def test_doctor_reports_installed_mcp_config_commands_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep installed no-clone MCP setup discoverable from doctor output."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    write_env_file(config_root / "config.env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["runtime_mode"] == "standalone"
+    assert payload["mcp"]["smoke_command"] == "policynim mcp-smoke --format json"
+    assert payload["mcp"]["local_stdio_config_commands"] == {
+        "codex": "policynim mcp-config --target local-stdio --client codex --format json",
+        "claude-code": (
+            "policynim mcp-config --target local-stdio --client claude-code --format json"
+        ),
+    }
+    assert "--repo-root" not in json.dumps(payload["mcp"])
+    assert "uv run" not in json.dumps(payload["mcp"])
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_doctor_text_output_is_human_readable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the default diagnostic useful in a terminal."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "PolicyNIM doctor" in result.stdout
+    assert "Status: action_required" in result.stdout
+    assert "Next steps:" in result.stdout
+    assert "policynim init" in result.stdout
+
+
+def test_doctor_text_output_prints_mcp_config_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make local MCP client setup discoverable from the default diagnostic."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "MCP:" in result.stdout
+    assert "policynim mcp-smoke --format json" in result.stdout
+    assert (
+        "uv run policynim mcp-config --target local-stdio --client codex "
+        f"--repo-root {checkout_root} --format json"
+    ) in result.stdout
+    assert (
+        "uv run policynim mcp-config --target local-stdio --client claude-code "
+        f"--repo-root {checkout_root} --format json"
+    ) in result.stdout
+
+
+def test_doctor_mcp_config_commands_quote_checkout_paths_with_spaces(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep doctor's copyable MCP setup commands valid for spaced checkout paths."""
+    clear_installer_env(monkeypatch)
+    checkout_root = tmp_path / "checkout with spaces"
+    package_root = checkout_root / "src" / "policynim"
+    package_root.mkdir(parents=True)
+    (checkout_root / "pyproject.toml").write_text(
+        "[project]\nname = 'policynim'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(checkout_root)
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_config_path",
+        lambda *args, **kwargs: tmp_path / "user-config",
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.user_data_path",
+        lambda *args, **kwargs: tmp_path / "user-data",
+    )
+    monkeypatch.setattr(
+        "policynim.config_discovery.__file__",
+        str(package_root / "config_discovery.py"),
+    )
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    commands = payload["mcp"]["local_stdio_config_commands"]
+    assert f"--repo-root '{checkout_root}' --format json" in commands["codex"]
+    assert f"--repo-root '{checkout_root}' --format json" in commands["claude-code"]
+
+
+def test_support_bundle_reports_redacted_first_run_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Collect issue-ready diagnostics without requiring completed setup."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["policynim_version"] == "1.2.3"
+    assert payload["python"]["version"]
+    assert payload["platform"]["system"]
+    assert payload["first_run"]["runtime_mode"] == "standalone"
+    assert payload["first_run"]["default_target"] == "hosted-mcp"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["target"] == "hosted-mcp"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["requires_local_setup"] is False
+    assert payload["first_run"]["targets"]["hosted_mcp"]["hosted_url"] == (
+        "https://<railway-domain>/mcp"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["beta_portal_url"] == (
+        "https://<railway-domain>/beta"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["hosted_url_placeholder"] is True
+    assert payload["first_run"]["targets"]["local_cli"]["requires_local_setup"] is True
+    assert payload["first_run"]["targets"]["local_mcp"]["local_launch_mode"] == "installed-cli"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["quickstart_command"] == (
+        "policynim quickstart --target hosted-mcp --format json"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["agent_workflows"][0]["tool"] == (
+        "policy_preflight"
+    )
+    assert (
+        "policy_search"
+        in (payload["first_run"]["targets"]["local_mcp"]["agent_workflows"][1]["prompt"])
+    )
+    assert (
+        "policynim mcp-config --target hosted-http"
+        in (payload["first_run"]["targets"]["hosted_mcp"]["commands"][1])
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["client_commands"] == [
+        (
+            "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        ),
+        (
+            "claude mcp add --transport http policynim 'https://<railway-domain>/mcp' "
+            '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+        ),
+    ]
+    assert payload["doctor"]["status"] == "action_required"
+    assert payload["python"]["executable"] == "<python-executable>"
+    assert payload["doctor"]["config"]["expected_init_config_file"] == ("<config-dir>/config.env")
+    assert payload["redaction"]["local_paths"] == "redacted"
+    assert payload["redaction"]["path_markers"] == [
+        "<config-dir>",
+        "<data-dir>",
+        "<home>",
+        "<python-executable>",
+    ]
+    assert payload["mcp_smoke"] == {
+        "status": "skipped",
+        "reason": "Pass --include-mcp-smoke to verify stdio tool registration.",
+    }
+    assert str(tmp_path) not in result.stdout
+    assert "<repo-root>" not in result.stdout
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_support_bundle_does_not_label_installed_cwd_as_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Avoid treating an arbitrary installed-runtime CWD as a source checkout."""
+    workspace, _, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["first_run"]["runtime_mode"] == "standalone"
+    assert "<repo-root>" not in payload["redaction"]["path_markers"]
+    assert str(workspace) not in result.stdout
+    assert "workspace" not in result.stdout
+
+
+def test_support_bundle_can_include_local_paths_for_private_triage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let maintainers opt into exact paths when support happens privately."""
+    _, config_root, _ = configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle", "--include-local-paths"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["python"]["executable"] == sys.executable
+    assert payload["doctor"]["config"]["expected_init_config_file"] == str(
+        config_root / "config.env"
+    )
+    assert payload["redaction"]["local_paths"] == "included"
+    assert str(config_root) in result.stdout
+    assert "nvapi" not in result.stdout.lower()
+
+
+def test_support_bundle_can_include_mcp_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let issue reporters include local MCP launch evidence on demand."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for support-bundle output."""
+        assert timeout_seconds == 7.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(
+        app,
+        ["support-bundle", "--include-mcp-smoke", "--mcp-timeout-seconds", "7"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["doctor"]["runtime_mode"] == "source_checkout"
+    assert payload["first_run"]["runtime_mode"] == "source_checkout"
+    assert payload["first_run"]["targets"]["hosted_mcp"]["quickstart_command"] == (
+        "policynim quickstart --target hosted-mcp --format json"
+    )
+    assert payload["first_run"]["targets"]["hosted_mcp"]["commands"][1].startswith(
+        "policynim mcp-config --target hosted-http"
+    )
+    assert "uv run" not in payload["first_run"]["targets"]["hosted_mcp"]["commands"][1]
+    assert payload["first_run"]["targets"]["local_mcp"]["local_launch_mode"] == ("source-checkout")
+    assert "<repo-root>" in " ".join(payload["first_run"]["targets"]["local_mcp"]["commands"])
+    assert payload["mcp_smoke"]["status"] == "ok"
+    assert payload["mcp_smoke"]["command"][0] == "<python-executable>"
+    assert payload["mcp_smoke"]["tools"] == ["policy_preflight", "policy_search"]
+    assert str(checkout_root) not in result.stdout
+    assert "nvapi-test-key" not in result.stdout
+
+
+def test_support_bundle_markdown_wraps_json_for_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Provide a paste-friendly Markdown form for issue bodies."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setattr("policynim.interfaces.cli._resolve_installed_version", lambda: "1.2.3")
+
+    result = runner.invoke(app, ["support-bundle", "--format", "markdown"])
+
+    assert result.exit_code == 0
+    assert "## PolicyNIM Support Bundle" in result.stdout
+    assert "```json" in result.stdout
+    assert '"schema_version": "1"' in result.stdout
 
 
 def test_init_command_writes_config_and_prints_next_step(
@@ -1639,6 +2144,387 @@ def test_init_command_surfaces_unwritable_config_destination(
     assert "permission denied" in result.stderr
     assert not target_config.exists()
     assert list(target_config.parent.glob("*.tmp")) == []
+
+
+def test_quickstart_defaults_to_hosted_mcp_without_requiring_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Show the shortest no-clone path before local config exists."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["target"] == "hosted-mcp"
+    assert payload["client"] == "codex"
+    assert payload["requires_local_setup"] is False
+    assert payload["calls_external_services"] is False
+    assert payload["hosted_url"] == "https://<railway-domain>/mcp"
+    assert payload["hosted_url_placeholder"] is True
+    assert payload["steps"][0] == (
+        "Open https://<railway-domain>/mcp in a browser; it routes to "
+        "https://<railway-domain>/beta for token creation."
+    )
+    assert "POLICYNIM_TOKEN" in " ".join(payload["commands"])
+    assert "export POLICYNIM_TOKEN='<generated-beta-token>'" in payload["commands"]
+    assert "export POLICYNIM_TOKEN=<generated-beta-token>" not in payload["commands"]
+    assert payload["client_commands"] == [
+        (
+            "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        )
+    ]
+    assert "<generated-beta-token>" not in " ".join(payload["client_commands"])
+    assert "Replace the hosted URL placeholder" in " ".join(payload["next_steps"])
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+    agent_workflows = payload["agent_workflows"]
+    assert [workflow["title"] for workflow in agent_workflows] == [
+        "Preflight before implementation",
+        "Retrieve policy evidence while debugging",
+        "Verify MCP tool availability",
+    ]
+    assert agent_workflows[0]["tool"] == "policy_preflight"
+    assert "Before editing, call policy_preflight" in agent_workflows[0]["prompt"]
+    assert "cited constraints" in agent_workflows[0]["prompt"]
+    assert "insufficient_context" in agent_workflows[0]["prompt"]
+    assert agent_workflows[1]["tool"] == "policy_search"
+    assert (
+        "Use policy_search for: release installer checksum verification."
+        in (agent_workflows[1]["prompt"])
+    )
+    assert "cited policy lines" in agent_workflows[1]["prompt"]
+    assert "policy_preflight and policy_search" in agent_workflows[2]["prompt"]
+    assert "before starting implementation" in agent_workflows[2]["prompt"]
+
+
+def test_quickstart_text_renders_agent_workflows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make the human-readable first-run output show copyable agent prompts."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert "Agent workflows:" in output
+    assert "- Preflight before implementation: Before editing, call policy_preflight" in output
+    assert "- Retrieve policy evidence while debugging: Use policy_search for:" in output
+    assert "insufficient_context" in output
+    assert "cited policy lines" in output
+    assert "- Verify MCP tool availability: List the PolicyNIM MCP tools" in output
+
+
+def test_quickstart_text_renders_hosted_client_setup_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make hosted first-run output copy-pasteable without opening extra docs."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert "Client setup:" in output
+    assert (
+        "Open https://<railway-domain>/mcp in a browser; it routes to "
+        "https://<railway-domain>/beta for token creation."
+    ) in output
+    assert (
+        "codex mcp add policynim --url 'https://<railway-domain>/mcp' "
+        "--bearer-token-env-var POLICYNIM_TOKEN"
+    ) in output
+    assert "<generated-beta-token>" not in output.split("Client setup:", maxsplit=1)[1]
+
+
+def test_quickstart_text_points_to_alternate_hosted_mcp_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Make default quickstart self-guiding for non-default MCP clients."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert (
+        "For Claude Code setup commands, rerun "
+        "`policynim quickstart --target hosted-mcp --client claude-code`."
+    ) in output
+
+
+def test_quickstart_uses_installed_entrypoint_for_hosted_config_from_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the hosted path no-clone even when quickstart runs from a checkout."""
+    configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "hosted-mcp", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert "policynim mcp-config --target hosted-http --client codex" in payload["commands"][1]
+    assert payload["commands"][1].startswith("policynim mcp-config")
+    assert "uv run" not in payload["commands"][1]
+    assert "uv run" not in " ".join(payload["next_steps"])
+    assert "policynim quickstart --target hosted-mcp --client claude-code" in " ".join(
+        payload["next_steps"]
+    )
+    assert payload["requires_local_setup"] is False
+
+
+def test_quickstart_derives_beta_portal_from_hosted_mcp_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep hosted first-run guidance concrete when operators pass a real /mcp URL."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "hosted-mcp",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["hosted_url_placeholder"] is False
+    assert payload["hosted_url"] == "https://policy.policynim.dev/mcp"
+    assert payload["beta_portal_url"] == "https://policy.policynim.dev/beta"
+    assert payload["steps"][0] == (
+        "Open https://policy.policynim.dev/mcp in a browser; it routes to "
+        "https://policy.policynim.dev/beta for token creation."
+    )
+    assert payload["client_commands"] == [
+        (
+            "codex mcp add policynim --url https://policy.policynim.dev/mcp "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        )
+    ]
+    assert "https://<railway-domain>/beta" not in payload["steps"]
+    assert "Replace the hosted URL placeholder" not in " ".join(payload["next_steps"])
+
+
+def test_quickstart_prints_claude_hosted_client_setup_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Honor --client when printing the hosted MCP command to paste."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "hosted-mcp",
+            "--client",
+            "claude-code",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["client"] == "claude-code"
+    assert payload["client_commands"] == [
+        (
+            "claude mcp add --transport http policynim https://policy.policynim.dev/mcp "
+            '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+        )
+    ]
+    assert "<generated-beta-token>" not in payload["client_commands"][0]
+
+
+def test_quickstart_text_points_claude_users_back_to_codex_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the alternate-client hint symmetric when Claude Code is selected."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--client", "claude-code"])
+
+    assert result.exit_code == 0
+    output = unstyle(result.stdout)
+    assert (
+        "For Codex setup commands, rerun `policynim quickstart --target hosted-mcp --client codex`."
+    ) in output
+
+
+def test_quickstart_rejects_hosted_url_that_is_not_mcp_endpoint() -> None:
+    """Do not print hosted first-run commands that cannot work in MCP clients."""
+    result = runner.invoke(
+        app,
+        ["quickstart", "--target", "hosted-mcp", "--hosted-url", "https://policy.example"],
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted MCP URL must point to the /mcp endpoint." in result.stderr
+
+
+def test_quickstart_prints_current_pypi_local_cli_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep installed CLI first-run guidance aligned with public package state."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "local-cli", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    prerequisites = " ".join(payload["prerequisites"])
+    assert payload["target"] == "local-cli"
+    assert "Python 3.11 or 3.12 for PyPI package installs." in payload["prerequisites"]
+    assert "after publication" not in prerequisites
+    assert "trusted-publishing evidence is tracked separately" in prerequisites
+    assert "policynim quickstart" in " ".join(payload["next_steps"])
+    assert "policynim support-bundle" in " ".join(payload["next_steps"])
+    assert "attaching public setup evidence" in " ".join(payload["next_steps"])
+    assert "doctor --format json` local" in " ".join(payload["next_steps"])
+
+
+def test_quickstart_uses_source_checkout_entrypoint_for_local_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep local CLI first-run commands runnable from a source checkout."""
+    configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["quickstart", "--target", "local-cli", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["description"] == "Local CLI path for running preflight from a source checkout."
+    assert "PolicyNIM source checkout with uv dependencies synced." in payload["prerequisites"]
+    assert "PyPI package installs" not in " ".join(payload["prerequisites"])
+    assert "Check the source-checkout entrypoint." in payload["steps"]
+    assert "installed entrypoint" not in " ".join(payload["steps"])
+    commands = payload["commands"]
+    assert commands[:4] == [
+        "uv run policynim --help",
+        "uv run policynim doctor",
+        "uv run policynim init",
+        "uv run policynim ingest",
+    ]
+    assert commands[4].startswith("uv run policynim preflight --task")
+    assert "Run `uv run policynim quickstart --target hosted-mcp`" in (
+        " ".join(payload["next_steps"])
+    )
+    assert "uv run policynim support-bundle" in " ".join(payload["next_steps"])
+
+
+def test_quickstart_prints_local_mcp_path_with_source_checkout_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide local MCP users through doctor, ingest, smoke, and config generation."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "local-mcp",
+            "--client",
+            "claude-code",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "local-mcp"
+    assert payload["client"] == "claude-code"
+    assert payload["local_launch_mode"] == "source-checkout"
+    assert payload["description"] == (
+        "Local MCP path for Codex or Claude Code from a source checkout."
+    )
+    assert "PolicyNIM source checkout with uv dependencies synced." in payload["prerequisites"]
+    assert "installed PolicyNIM CLI" not in " ".join(payload["prerequisites"])
+    assert payload["requires_local_setup"] is True
+    assert "Generate client config from the checkout path." in payload["steps"]
+    assert "uv run policynim doctor" in payload["commands"]
+    assert "uv run policynim init" in payload["commands"]
+    assert "uv run policynim ingest" in payload["commands"]
+    assert "uv run policynim mcp-smoke" in payload["commands"]
+    assert "uv run policynim mcp-config --target local-stdio --client claude-code" in " ".join(
+        payload["commands"]
+    )
+    assert "policynim mcp-smoke" not in payload["commands"]
+    assert f"--repo-root {checkout_root}" in " ".join(payload["commands"])
+    assert "NVIDIA_API_KEY" in " ".join(payload["prerequisites"])
+    assert "exact local filesystem paths" in " ".join(payload["safety"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+
+
+def test_quickstart_prints_installed_local_mcp_path_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guide installed users to local stdio MCP without requiring a source checkout."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "quickstart",
+            "--target",
+            "local-mcp",
+            "--client",
+            "codex",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "local-mcp"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "installed PolicyNIM CLI" in " ".join(payload["prerequisites"])
+    assert "Generate client config from the installed entrypoint." in payload["steps"]
+    assert "checkout path" not in " ".join(payload["steps"])
+    assert "policynim mcp-config --target local-stdio --client codex" in payload["commands"]
+    assert "--repo-root" not in " ".join(payload["commands"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+
+
+def test_quickstart_help_mentions_targets_clients_and_json_output() -> None:
+    """Keep help discoverable for installed users starting from --help."""
+    result = runner.invoke(app, ["quickstart", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "Print the first-run path" in help_output
+    assert "--target" in help_output
+    assert "hosted-mcp" in help_output
+    assert "local-cli" in help_output
+    assert "local-mcp" in help_output
+    assert "--client" in help_output
+    assert "--format" in help_output
 
 
 def test_route_help_mentions_task_type_override() -> None:
@@ -1776,7 +2662,7 @@ def test_search_command_points_to_ingest_when_config_exists_but_index_is_missing
             ),
         ),
         (["evidence", "report", "--session-id", "session-123"], None),
-        (["mcp"], None),
+        (["mcp", "--transport", "streamable-http"], None),
     ],
 )
 def test_setup_dependent_commands_point_to_init_when_redirected_config_is_missing(
@@ -1799,6 +2685,26 @@ def test_setup_dependent_commands_point_to_init_when_redirected_config_is_missin
     assert "PolicyNIM is not set up yet." in result.stderr
     assert "policynim init" in result.stderr
     assert str(redirected_config) in result.stderr
+
+
+def test_mcp_stdio_launch_does_not_require_completed_standalone_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let stdio MCP launch for client discovery before API-key setup."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    launched: list[str] = []
+
+    def fake_run_server(*, transport: str) -> None:
+        """Record the selected MCP transport without starting a server."""
+        launched.append(transport)
+
+    monkeypatch.setattr("policynim.interfaces.cli.run_server", fake_run_server)
+
+    result = runner.invoke(app, ["mcp"])
+
+    assert result.exit_code == 0
+    assert launched == ["stdio"]
 
 
 def test_preflight_command_surfaces_missing_index_errors(monkeypatch) -> None:
@@ -1892,12 +2798,13 @@ def test_mcp_command_surfaces_hosted_rebuild_key_errors(monkeypatch) -> None:
         "policynim.interfaces.cli.run_server",
         lambda transport: (_ for _ in ()).throw(
             ConfigurationError(
-                "Hosted streamable-http startup requires a populated local index at "
-                "/app/data/lancedb-baked (table: policy_chunks). "
+                "Hosted streamable-http startup requires a populated local SQLite index at "
+                "/app/data/index.sqlite3 (table: policy_chunks). "
                 "Automatic hosted-index rebuild failed: ConfigurationError: "
                 "NVIDIA_API_KEY is required for embeddings. "
-                "Rebuild the image so `policynim ingest` runs during Docker build "
-                "or set `POLICYNIM_LANCEDB_URI` to a populated directory."
+                "Run `policynim ingest` before serving traffic, or bake that command "
+                "during Docker build. Configure the path with `POLICYNIM_INDEX_DB_PATH`; "
+                "`POLICYNIM_LANCEDB_URI` is only a deprecated alias for that path."
             )
         ),
     )
@@ -1906,7 +2813,643 @@ def test_mcp_command_surfaces_hosted_rebuild_key_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "NVIDIA_API_KEY is required for embeddings." in result.stderr
-    assert "Rebuild the image so `policynim ingest` runs during Docker build" in result.stderr
+    assert "Configure the path with `POLICYNIM_INDEX_DB_PATH`" in result.stderr
+
+
+def test_mcp_config_prints_claude_code_json_without_secret_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate a project-scoped Claude Code config from a verified checkout path."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-secret-value")
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "claude-code",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    server = payload["config"]["mcpServers"]["policynim"]
+    assert payload["client"] == "claude-code"
+    assert payload["repo_root"] == str(checkout_root)
+    assert server == {
+        "type": "stdio",
+        "command": "uv",
+        "args": [
+            "run",
+            "--directory",
+            str(checkout_root),
+            "policynim",
+            "mcp",
+            "--transport",
+            "stdio",
+        ],
+        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+    }
+    assert "uv run policynim doctor" in payload["next_steps"]
+    assert "uv run policynim mcp-smoke" in payload["next_steps"]
+    assert "exact local filesystem paths" in " ".join(payload["safety"])
+    assert "policynim support-bundle" in " ".join(payload["safety"])
+    assert "nvapi-secret-value" not in result.stdout
+
+
+def test_mcp_config_prints_codex_installed_stdio_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate no-clone local MCP config from an installed CLI entrypoint."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--client",
+            "codex",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["client"] == "codex"
+    assert payload["target"] == "local-stdio"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "repo_root" not in payload
+    assert payload["codex_cli_command"] == [
+        "codex",
+        "mcp",
+        "add",
+        "policynim",
+        "--env",
+        "NVIDIA_API_KEY=$NVIDIA_API_KEY",
+        "--",
+        "policynim",
+        "mcp",
+        "--transport",
+        "stdio",
+    ]
+    assert payload["codex_app"] == {
+        "name": "policynim",
+        "transport": "STDIO",
+        "command": "policynim",
+        "arguments": ["mcp", "--transport", "stdio"],
+        "environment_variable_passthrough": ["NVIDIA_API_KEY"],
+    }
+
+
+def test_mcp_config_prints_claude_installed_stdio_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate Claude Code local MCP config from an installed CLI entrypoint."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--client",
+            "claude-code",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    server = payload["config"]["mcpServers"]["policynim"]
+    assert payload["client"] == "claude-code"
+    assert payload["local_launch_mode"] == "installed-cli"
+    assert "repo_root" not in payload
+    assert server == {
+        "type": "stdio",
+        "command": "policynim",
+        "args": ["mcp", "--transport", "stdio"],
+        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+    }
+
+
+def test_mcp_config_prints_codex_cli_and_app_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate Codex CLI and app setup guidance from the same stdio contract."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(checkout_root),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PolicyNIM MCP config for Codex" in result.stdout
+    assert "codex mcp add policynim" in result.stdout
+    assert "--env NVIDIA_API_KEY=$NVIDIA_API_KEY --" in result.stdout
+    assert f"uv run --directory {checkout_root} policynim mcp --transport stdio" in result.stdout
+    assert "Command to launch: uv" in result.stdout
+    assert f"Working directory: {checkout_root}" in result.stdout
+    assert "Environment variable passthrough: NVIDIA_API_KEY" in result.stdout
+    assert "Safety:" in result.stdout
+    assert "exact local filesystem paths" in result.stdout
+    assert "policynim support-bundle" in result.stdout
+
+
+def test_mcp_config_prints_codex_hosted_http_json_without_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generate hosted Codex setup without requiring a local source checkout."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "codex",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+            "--bearer-token-env-var",
+            "POLICYNIM_TOKEN",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "hosted-http"
+    assert payload["client"] == "codex"
+    assert payload["hosted_url"] == "https://policy.policynim.dev/mcp"
+    assert payload["beta_portal_url"] == "https://policy.policynim.dev/beta"
+    assert payload["hosted_url_placeholder"] is False
+    assert payload["bearer_token_env_var"] == "POLICYNIM_TOKEN"
+    assert "repo_root" not in payload
+    assert payload["codex_cli_command"] == [
+        "codex",
+        "mcp",
+        "add",
+        "policynim",
+        "--url",
+        "https://policy.policynim.dev/mcp",
+        "--bearer-token-env-var",
+        "POLICYNIM_TOKEN",
+    ]
+    assert payload["codex_cli_shell_command"] == (
+        "codex mcp add policynim --url https://policy.policynim.dev/mcp "
+        "--bearer-token-env-var POLICYNIM_TOKEN"
+    )
+    assert "Export POLICYNIM_TOKEN='<generated-beta-token>'" in payload["next_steps"]
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+
+
+def test_mcp_config_marks_placeholder_hosted_url_without_failing() -> None:
+    """Keep offline placeholder smokes possible while warning users before setup."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "codex",
+            "--hosted-url",
+            "https://<railway-domain>/mcp",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["hosted_url"] == "https://<railway-domain>/mcp"
+    assert payload["beta_portal_url"] == "https://<railway-domain>/beta"
+    assert payload["hosted_url_placeholder"] is True
+    assert "Replace the hosted URL placeholder" in " ".join(payload["next_steps"])
+    assert "policy_preflight" in " ".join(payload["next_steps"])
+
+
+def test_mcp_config_prints_claude_hosted_http_guidance() -> None:
+    """Generate hosted Claude Code setup from the same MCP URL contract."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--client",
+            "claude-code",
+            "--hosted-url",
+            "https://policy.policynim.dev/mcp",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PolicyNIM hosted MCP config for Claude Code" in result.stdout
+    assert (
+        "claude mcp add --transport http policynim https://policy.policynim.dev/mcp "
+        '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+    ) in result.stdout
+    assert "Export POLICYNIM_TOKEN='<generated-beta-token>'" in result.stdout
+    assert "policy_search" in result.stdout
+
+
+def test_mcp_config_rejects_hosted_http_without_url() -> None:
+    """Hosted config should fail before printing unusable client commands."""
+    result = runner.invoke(app, ["mcp-config", "--target", "hosted-http"])
+
+    assert result.exit_code == 1
+    assert "Hosted MCP config requires --hosted-url" in result.stderr
+
+
+def test_mcp_config_rejects_non_http_hosted_url() -> None:
+    """Reject hosted config URLs that MCP clients cannot use as HTTP endpoints."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--hosted-url",
+            "file:///tmp/mcp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted MCP URL must start with http:// or https://" in result.stderr
+
+
+def test_mcp_config_rejects_hosted_http_with_local_only_options(tmp_path: Path) -> None:
+    """Avoid silently ignoring local stdio flags for hosted config."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "hosted-http",
+            "--hosted-url",
+            "https://policy.example/mcp",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--repo-root is only valid with --target local-stdio" in result.stderr
+
+
+def test_mcp_config_rejects_local_stdio_with_hosted_only_options() -> None:
+    """Avoid silently ignoring hosted HTTP flags for local stdio config."""
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--target",
+            "local-stdio",
+            "--hosted-url",
+            "https://policy.example/mcp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--hosted-url is only valid with --target hosted-http" in result.stderr
+
+
+def test_mcp_config_rejects_uv_command_without_source_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Avoid silently ignoring source-checkout launch flags in installed mode."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["mcp-config", "--uv-command", "/opt/uv"])
+
+    assert result.exit_code == 1
+    assert "--uv-command requires a PolicyNIM source checkout" in result.stderr
+    assert "Pass --repo-root /ABS/PATH/TO/policyNIM" in result.stderr
+
+
+def test_mcp_config_help_mentions_hosted_http_options() -> None:
+    """Keep CLI help aligned with hosted-first docs."""
+    result = runner.invoke(app, ["mcp-config", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "hosted HTTP or local stdio MCP client config" in help_output
+    assert "--target" in help_output
+    assert "local-stdio" in help_output
+    assert "hosted-http" in help_output
+    assert "--hosted-url" in help_output
+    assert "--bearer-token-env-var" in help_output
+
+
+def test_mcp_config_rejects_non_checkout_repo_root(tmp_path: Path) -> None:
+    """Avoid emitting client config that points at an arbitrary directory."""
+    not_checkout = tmp_path / "not-policyNIM"
+    not_checkout.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(not_checkout),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--repo-root must point to a PolicyNIM source checkout" in result.stderr
+    assert "Omit --repo-root to launch the installed CLI" in result.stderr
+
+
+def test_mcp_smoke_prints_stdio_tool_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Print machine-readable MCP tool discovery evidence."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for CLI rendering."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["tools"] == ["policy_preflight", "policy_search"]
+
+
+def test_mcp_smoke_can_launch_from_generated_codex_config_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Handshake with the same local stdio command emitted by mcp-config."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    config_result = runner.invoke(
+        app,
+        [
+            "mcp-config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(checkout_root),
+            "--format",
+            "json",
+        ],
+    )
+    config_file = tmp_path / "codex-mcp-config.json"
+    config_file.write_text(config_result.stdout, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    async def fake_smoke(
+        *,
+        timeout_seconds: float,
+        command: list[str] | None = None,
+        cwd: Path | None = None,
+    ) -> dict[str, object]:
+        """Capture the config-derived stdio launch command."""
+        captured["timeout_seconds"] = timeout_seconds
+        captured["command"] = command
+        captured["cwd"] = cwd
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": command,
+            "config_source": str(config_file),
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(
+        app,
+        ["mcp-smoke", "--mcp-config-file", str(config_file), "--format", "json"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["timeout_seconds"] == 5.0
+    assert captured["command"] == [
+        "uv",
+        "run",
+        "--directory",
+        str(checkout_root),
+        "policynim",
+        "mcp",
+        "--transport",
+        "stdio",
+    ]
+    assert captured["cwd"] == checkout_root
+    payload = json.loads(result.stdout)
+    assert payload["config_source"] == str(config_file)
+
+
+def test_mcp_smoke_rejects_hosted_mcp_config_file(tmp_path: Path) -> None:
+    """Do not imply that local stdio smoke proves a hosted HTTP config."""
+    config_file = tmp_path / "hosted-mcp-config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "client": "codex",
+                "target": "hosted-http",
+                "server_name": "policynim",
+                "hosted_url": "https://policy.example/mcp",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["mcp-smoke", "--mcp-config-file", str(config_file)])
+
+    assert result.exit_code == 1
+    assert "mcp-smoke --mcp-config-file only supports local-stdio configs" in result.stderr
+
+
+def test_mcp_smoke_help_mentions_generated_config_file() -> None:
+    """Keep the generated-config handshake discoverable from CLI help."""
+    result = runner.invoke(app, ["mcp-smoke", "--help"])
+    help_output = unstyle(result.stdout)
+
+    assert result.exit_code == 0
+    assert "--mcp-config-file" in help_output
+    assert "mcp-config" in help_output
+    assert "--format json" in help_output
+
+
+def test_mcp_smoke_does_not_require_completed_standalone_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Let clean installs prove MCP tool registration before API-key setup."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return successful MCP smoke evidence for a clean install."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "ok",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_preflight", "policy_search"],
+            "missing_tools": [],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["missing_tools"] == []
+
+
+def test_mcp_smoke_exits_nonzero_when_tools_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exit nonzero when local stdio smoke misses expected MCP tools."""
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    write_env_file(checkout_root / ".env", NVIDIA_API_KEY="nvapi-test-key")
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return incomplete MCP smoke evidence for CLI rendering."""
+        return {
+            "status": "error",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": ["policy_search"],
+            "missing_tools": ["policy_preflight"],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke"])
+
+    assert result.exit_code == 1
+    assert "PolicyNIM MCP smoke" in result.stdout
+    assert "missing_tools" in result.stdout
+    assert "policy_preflight" in result.stdout
+
+
+def test_mcp_smoke_failure_text_prints_recovery_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Tell users how to recover when local stdio registration fails."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    async def fake_smoke(*, timeout_seconds: float) -> dict[str, object]:
+        """Return failed MCP smoke evidence with recovery steps."""
+        assert timeout_seconds == 5.0
+        return {
+            "status": "error",
+            "transport": "stdio",
+            "command": [sys.executable, "-m", "policynim.interfaces.cli", "mcp"],
+            "tools": [],
+            "missing_tools": ["policy_preflight", "policy_search"],
+            "message": "MCP stdio smoke failed: RuntimeError: launch failed",
+            "next_steps": [
+                "Run `policynim doctor` to inspect config, credentials, and local index state.",
+                "Run `policynim ingest` before calling policy_preflight or policy_search.",
+            ],
+        }
+
+    monkeypatch.setattr("policynim.interfaces.cli._run_mcp_stdio_smoke", fake_smoke)
+
+    result = runner.invoke(app, ["mcp-smoke"])
+
+    assert result.exit_code == 1
+    assert "Next steps:" in result.stdout
+    assert "policynim doctor" in result.stdout
+    assert "policynim ingest" in result.stdout
+
+
+def test_mcp_stdio_smoke_exception_report_includes_recovery_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Include recovery steps in machine-readable stdio launch failures."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+
+    @asynccontextmanager
+    async def failing_stdio_client(*args: object, **kwargs: object):
+        """Raise during stdio client startup to exercise recovery output."""
+        raise RuntimeError("spawn failed")
+        yield
+
+    monkeypatch.setattr("policynim.interfaces.cli.stdio_client", failing_stdio_client)
+
+    report = asyncio.run(cli_module._run_mcp_stdio_smoke(timeout_seconds=1.0))
+
+    assert report["status"] == "error"
+    next_steps = cast(list[str], report["next_steps"])
+    assert "policynim doctor" in " ".join(next_steps)
+    assert "policynim ingest" in " ".join(next_steps)
+    assert "mcp-config --target local-stdio" in " ".join(next_steps)
+
+
+def test_mcp_stdio_smoke_uses_frozen_executable_for_standalone_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Re-enter PyInstaller bundles directly instead of using Python -m."""
+    configure_standalone_cli_environment(monkeypatch, tmp_path)
+    binary = tmp_path / "dist" / "policynim" / "policynim"
+    monkeypatch.setattr(cli_module.sys, "executable", str(binary))
+    monkeypatch.setattr(cli_module.sys, "frozen", True, raising=False)
+
+    @asynccontextmanager
+    async def failing_stdio_client(*args: object, **kwargs: object):
+        """Raise during frozen stdio client startup to capture the command."""
+        raise RuntimeError("spawn failed")
+        yield
+
+    monkeypatch.setattr("policynim.interfaces.cli.stdio_client", failing_stdio_client)
+
+    report = asyncio.run(cli_module._run_mcp_stdio_smoke(timeout_seconds=1.0))
+
+    assert report["status"] == "error"
+    assert report["command"] == [str(binary), "mcp", "--transport", "stdio"]
 
 
 def test_beta_admin_list_accounts_prints_json(monkeypatch) -> None:

--- a/tests/test_github_label_sync.py
+++ b/tests/test_github_label_sync.py
@@ -1,0 +1,261 @@
+"""GitHub label sync script contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_github_labels.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_github_labels", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_label_taxonomy_preserves_names_colors_and_descriptions(tmp_path: Path) -> None:
+    """Load the checked-in label taxonomy without relying on GitHub state."""
+    module = _load_script_module()
+    label_file = tmp_path / "labels.yml"
+    label_file.write_text(
+        "\n".join(
+            [
+                "- name: type/bug",
+                '  color: "d73a4a"',
+                "  description: Reproducible broken behavior.",
+                "",
+                "- name: surface/mcp-stdio",
+                '  color: "5319e7"',
+                "  description: Local stdio MCP server.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    labels = module.load_label_taxonomy(label_file)
+
+    assert [label["name"] for label in labels] == ["type/bug", "surface/mcp-stdio"]
+    assert labels[0] == {
+        "name": "type/bug",
+        "color": "d73a4a",
+        "description": "Reproducible broken behavior.",
+    }
+
+
+def test_plan_label_sync_creates_updates_and_leaves_matching_labels() -> None:
+    """Produce deterministic create/update/noop actions from current GitHub labels."""
+    module = _load_script_module()
+    desired = [
+        {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+        {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+        {"name": "priority/p1", "color": "d93f0b", "description": "Blocks first run."},
+    ]
+    existing = [
+        {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+        {"name": "surface/cli", "color": "000000", "description": "Old CLI text."},
+    ]
+
+    plan = module.plan_label_sync(desired, existing)
+
+    assert [entry["action"] for entry in plan] == ["noop", "update", "create"]
+    assert plan[0]["name"] == "type/bug"
+    assert plan[1]["updates"] == {
+        "color": {"from": "000000", "to": "1d76db"},
+        "description": {"from": "Old CLI text.", "to": "CLI issues."},
+    }
+    assert plan[2]["name"] == "priority/p1"
+
+
+def test_sync_github_labels_dry_run_outputs_json_without_gh_calls() -> None:
+    """Keep the default path safe and machine-readable for maintainers."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--labels-file",
+            str(REPO_ROOT / ".github" / "labels.yml"),
+            "--format",
+            "json",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "dry-run"
+    assert payload["labels_file"] == str(REPO_ROOT / ".github" / "labels.yml")
+    assert "--live" in payload["next_step"]
+    assert any(entry["name"] == "type/bug" for entry in payload["plan"])
+    assert all(entry["action"] == "create" for entry in payload["plan"])
+
+
+def test_live_dry_run_reads_gh_state_without_applying_label_changes() -> None:
+    """Let maintainers inspect the real GitHub delta without mutating labels."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "type/bug",
+                        "color": "d73a4a",
+                        "description": "Bug reports.",
+                    },
+                    {
+                        "name": "surface/cli",
+                        "color": "000000",
+                        "description": "Old text.",
+                    },
+                ]
+            ),
+            stderr="",
+        )
+
+    result = module.sync_labels(
+        desired=[
+            {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+            {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+            {"name": "priority/p1", "color": "d93f0b", "description": "Blocks first run."},
+        ],
+        apply=False,
+        live=True,
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "live-dry-run"
+    assert [entry["action"] for entry in result["plan"]] == ["noop", "update", "create"]
+    assert calls == [["gh", "label", "list", "--json", "name,color,description", "--limit", "1000"]]
+    assert "rerun with --apply" in result["next_step"]
+
+
+def test_apply_mode_runs_gh_create_and_update_commands(tmp_path: Path) -> None:
+    """Apply mode should call gh only after an explicit --apply flag."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "surface/cli",
+                            "color": "000000",
+                            "description": "Old text.",
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = module.sync_labels(
+        desired=[
+            {"name": "type/bug", "color": "d73a4a", "description": "Bug reports."},
+            {"name": "surface/cli", "color": "1d76db", "description": "CLI issues."},
+        ],
+        apply=True,
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "apply"
+    assert [entry["action"] for entry in result["plan"]] == ["create", "update"]
+    assert [
+        "gh",
+        "label",
+        "create",
+        "type/bug",
+        "--color",
+        "d73a4a",
+        "--description",
+        "Bug reports.",
+    ] in calls
+    assert [
+        "gh",
+        "label",
+        "edit",
+        "surface/cli",
+        "--color",
+        "1d76db",
+        "--description",
+        "CLI issues.",
+    ] in calls
+
+
+def test_apply_and_live_modes_are_mutually_exclusive() -> None:
+    """Prevent an inspect-only command from being combined with mutation mode."""
+    module = _load_script_module()
+
+    with pytest.raises(module.LabelSyncError, match="--apply and --live"):
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=True,
+            live=True,
+            runner=lambda command: subprocess.CompletedProcess(command, 0, stdout="[]", stderr=""),
+        )
+
+
+def test_apply_mode_reports_missing_gh_without_traceback() -> None:
+    """A maintainer without gh installed should get recovery guidance."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.LabelSyncError) as exc_info:
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=True,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+
+
+def test_live_mode_reports_missing_gh_without_apply_only_guidance() -> None:
+    """Inspect-only live mode should not tell maintainers gh is only required for --apply."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.LabelSyncError) as exc_info:
+        module.sync_labels(
+            desired=[{"name": "type/bug", "color": "d73a4a", "description": "Bug reports."}],
+            apply=False,
+            live=True,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+    assert "--live" in message
+    assert "required for --apply" not in message

--- a/tests/test_github_topic_sync.py
+++ b/tests/test_github_topic_sync.py
@@ -1,0 +1,257 @@
+"""GitHub topic sync script contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_github_topics.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_github_topics", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_topic_taxonomy_preserves_order_and_rejects_invalid_names(
+    tmp_path: Path,
+) -> None:
+    """Load the checked-in topic taxonomy without relying on GitHub state."""
+    module = _load_script_module()
+    topics_file = tmp_path / "topics.yml"
+    topics_file.write_text(
+        "\n".join(
+            [
+                "# Discoverability topics",
+                "- ai-agents",
+                "- mcp",
+                "- nvidia-nim",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.load_topic_taxonomy(topics_file) == ["ai-agents", "mcp", "nvidia-nim"]
+
+    topics_file.write_text("- Invalid Topic\n", encoding="utf-8")
+    with pytest.raises(module.TopicSyncError, match="lowercase"):
+        module.load_topic_taxonomy(topics_file)
+
+
+def test_plan_topic_sync_adds_removes_and_leaves_matching_topics() -> None:
+    """Produce deterministic add/remove/noop actions from current GitHub topics."""
+    module = _load_script_module()
+
+    plan = module.plan_topic_sync(
+        desired=["ai-agents", "mcp", "python"],
+        existing=["ai-agents", "old-topic", "python"],
+    )
+
+    assert plan == [
+        {"action": "noop", "topic": "ai-agents"},
+        {"action": "add", "topic": "mcp"},
+        {"action": "noop", "topic": "python"},
+        {"action": "remove", "topic": "old-topic"},
+    ]
+
+
+def test_sync_github_topics_dry_run_outputs_json_without_gh_calls() -> None:
+    """Keep the default path safe and machine-readable for maintainers."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--topics-file",
+            str(REPO_ROOT / ".github" / "topics.yml"),
+            "--format",
+            "json",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "dry-run"
+    assert payload["topics_file"] == str(REPO_ROOT / ".github" / "topics.yml")
+    assert "--live" in payload["next_step"]
+    assert any(entry["topic"] == "mcp" for entry in payload["plan"])
+    assert all(entry["action"] == "ensure" for entry in payload["plan"])
+
+
+def test_live_dry_run_reads_gh_topics_without_applying_changes() -> None:
+    """Let maintainers inspect the real topic delta without mutating GitHub."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "nameWithOwner": "nnennandukwe/policyNIM",
+                    "repositoryTopics": [
+                        {"name": "ai-agents"},
+                        {"name": "old-topic"},
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    result = module.sync_topics(
+        desired=["ai-agents", "mcp"],
+        apply=False,
+        live=True,
+        repo="nnennandukwe/policyNIM",
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "live-dry-run"
+    assert result["plan"] == [
+        {"action": "noop", "topic": "ai-agents"},
+        {"action": "add", "topic": "mcp"},
+        {"action": "remove", "topic": "old-topic"},
+    ]
+    assert calls == [
+        [
+            "gh",
+            "repo",
+            "view",
+            "nnennandukwe/policyNIM",
+            "--json",
+            "repositoryTopics,nameWithOwner",
+        ]
+    ]
+    assert "rerun with --apply" in result["next_step"]
+
+
+def test_apply_mode_runs_gh_topic_add_and_remove_commands() -> None:
+    """Apply mode should call gh only after an explicit --apply flag."""
+    module = _load_script_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "nnennandukwe/policyNIM",
+                        "repositoryTopics": [
+                            {"name": "ai-agents"},
+                            {"name": "old-topic"},
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = module.sync_topics(
+        desired=["ai-agents", "mcp"],
+        apply=True,
+        repo="nnennandukwe/policyNIM",
+        runner=fake_runner,
+    )
+
+    assert result["mode"] == "apply"
+    assert [entry["action"] for entry in result["plan"]] == ["noop", "add", "remove"]
+    assert [
+        "gh",
+        "repo",
+        "edit",
+        "nnennandukwe/policyNIM",
+        "--add-topic",
+        "mcp",
+    ] in calls
+    assert [
+        "gh",
+        "repo",
+        "edit",
+        "nnennandukwe/policyNIM",
+        "--remove-topic",
+        "old-topic",
+    ] in calls
+
+
+def test_apply_and_live_modes_are_mutually_exclusive() -> None:
+    """Prevent an inspect-only command from being combined with mutation mode."""
+    module = _load_script_module()
+
+    with pytest.raises(module.TopicSyncError, match="--apply and --live"):
+        module.sync_topics(
+            desired=["mcp"],
+            apply=True,
+            live=True,
+            repo=None,
+            runner=lambda command: subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"repositoryTopics": []}',
+                stderr="",
+            ),
+        )
+
+
+def test_apply_mode_reports_missing_gh_without_traceback() -> None:
+    """A maintainer without gh installed should get recovery guidance."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.TopicSyncError) as exc_info:
+        module.sync_topics(
+            desired=["mcp"],
+            apply=True,
+            repo=None,
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+
+
+def test_live_mode_reports_missing_gh_without_apply_only_guidance() -> None:
+    """Inspect-only live mode should not tell maintainers gh is only required for --apply."""
+    module = _load_script_module()
+
+    def missing_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    with pytest.raises(module.TopicSyncError) as exc_info:
+        module.sync_topics(
+            desired=["mcp"],
+            apply=False,
+            live=True,
+            repo="nnennandukwe/policyNIM",
+            runner=missing_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "GitHub CLI" in message
+    assert "gh auth status" in message
+    assert "--live" in message
+    assert "required for --apply" not in message

--- a/tests/test_launch_evidence.py
+++ b/tests/test_launch_evidence.py
@@ -1,0 +1,3339 @@
+"""External launch evidence collector contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from types import ModuleType
+from urllib.request import Request
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "collect_launch_evidence.py"
+HOSTED_CODEX_SETUP_COMMAND = (
+    "codex mcp add policynim --url https://policynim.dev/mcp --bearer-token-env-var POLICYNIM_TOKEN"
+)
+HOSTED_CLAUDE_SETUP_COMMAND = (
+    "claude mcp add --transport http policynim https://policynim.dev/mcp "
+    '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+)
+LOCAL_CODEX_SETUP_COMMAND = (
+    "codex mcp add policynim --env NVIDIA_API_KEY=$NVIDIA_API_KEY "
+    "-- policynim mcp --transport stdio"
+)
+LOCAL_CLAUDE_SETUP_COMMAND = (
+    "claude mcp add-json policynim "
+    '\'{"type":"stdio","command":"policynim","args":["mcp","--transport","stdio"],'
+    '"env":{"NVIDIA_API_KEY":"${NVIDIA_API_KEY}"}}\''
+)
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("collect_launch_evidence", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_label_file(repo_root: Path) -> None:
+    labels_file = repo_root / ".github" / "labels.yml"
+    labels_file.parent.mkdir(parents=True)
+    labels_file.write_text(
+        "\n".join(
+            [
+                "- name: type/bug",
+                '  color: "d73a4a"',
+                "  description: Reproducible bug.",
+                "",
+                "- name: surface/mcp-stdio",
+                '  color: "5319e7"',
+                "  description: Local stdio MCP.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    topics_file = repo_root / ".github" / "topics.yml"
+    topics_file.write_text("- mcp\n- verification\n", encoding="utf-8")
+
+
+def _valid_agent_workflows() -> list[dict[str, str]]:
+    return [
+        {
+            "title": "Preflight before implementation",
+            "tool": "policy_preflight",
+            "prompt": (
+                "Before editing, call policy_preflight for: Implement a refresh-token "
+                "cleanup background job. Use the cited constraints in your implementation "
+                "plan. If the result is insufficient_context, stop and call policy_search "
+                "with a narrower query before changing files."
+            ),
+        },
+        {
+            "title": "Retrieve policy evidence while debugging",
+            "tool": "policy_search",
+            "prompt": (
+                "Use policy_search for: release installer checksum verification. "
+                "Summarize the relevant cited policy lines before proposing a fix."
+            ),
+        },
+        {
+            "title": "Verify MCP tool availability",
+            "tool": "list_tools",
+            "prompt": (
+                "List the PolicyNIM MCP tools and confirm policy_preflight and "
+                "policy_search are available before starting implementation."
+            ),
+        },
+    ]
+
+
+def _valid_hosted_client_commands() -> list[str]:
+    return [
+        (
+            "codex mcp add policynim --url https://example.invalid/mcp "
+            "--bearer-token-env-var POLICYNIM_TOKEN"
+        )
+    ]
+
+
+def _valid_support_bundle_hosted_client_commands() -> list[str]:
+    return [
+        *_valid_hosted_client_commands(),
+        (
+            "claude mcp add --transport http policynim https://example.invalid/mcp "
+            '--header "Authorization: Bearer $POLICYNIM_TOKEN"'
+        ),
+    ]
+
+
+def _valid_unix_installer_stdout() -> str:
+    return (
+        "Installed PolicyNIM 0.1.0.\n"
+        "Run `policynim quickstart` to choose a first-run path.\n"
+        "Hosted MCP does not require `policynim init` or `policynim ingest`.\n"
+        "For local CLI or local MCP, run `policynim init` then `policynim ingest`.\n"
+        "Run `policynim doctor` to inspect first-run setup.\n"
+        "Run `policynim support-bundle` before opening an issue.\n"
+    )
+
+
+def _valid_quickstart_output(*, target: str) -> str:
+    payload: dict[str, object] = {
+        "target": target,
+        "requires_local_setup": target != "hosted-mcp",
+        "calls_external_services": False,
+        "commands": [],
+        "agent_workflows": _valid_agent_workflows(),
+        "next_steps": [],
+    }
+    if target == "hosted-mcp":
+        payload["hosted_url"] = "https://example.invalid/mcp"
+        payload["beta_portal_url"] = "https://example.invalid/beta"
+        payload["steps"] = [
+            (
+                "Open https://example.invalid/mcp in a browser; it routes to "
+                "https://example.invalid/beta for token creation."
+            )
+        ]
+        payload["client_commands"] = _valid_hosted_client_commands()
+    if target == "local-mcp":
+        payload["local_launch_mode"] = "installed-cli"
+    return json.dumps(payload)
+
+
+def _valid_support_bundle_output() -> str:
+    return json.dumps(
+        {
+            "schema_version": "1",
+            "first_run": {
+                "runtime_mode": "standalone",
+                "default_target": "hosted-mcp",
+                "targets": {
+                    "hosted_mcp": {
+                        "target": "hosted-mcp",
+                        "requires_local_setup": False,
+                        "calls_external_services": False,
+                        "quickstart_command": (
+                            "policynim quickstart --target hosted-mcp --format json"
+                        ),
+                        "hosted_url": "https://example.invalid/mcp",
+                        "beta_portal_url": "https://example.invalid/beta",
+                        "steps": [
+                            (
+                                "Open https://example.invalid/mcp in a browser; "
+                                "it routes to https://example.invalid/beta for token creation."
+                            )
+                        ],
+                        "client_commands": _valid_support_bundle_hosted_client_commands(),
+                        "agent_workflows": _valid_agent_workflows(),
+                    },
+                    "local_cli": {
+                        "target": "local-cli",
+                        "requires_local_setup": True,
+                        "calls_external_services": False,
+                        "quickstart_command": (
+                            "policynim quickstart --target local-cli --format json"
+                        ),
+                        "agent_workflows": _valid_agent_workflows(),
+                    },
+                    "local_mcp": {
+                        "target": "local-mcp",
+                        "requires_local_setup": True,
+                        "calls_external_services": False,
+                        "local_launch_mode": "installed-cli",
+                        "quickstart_command": (
+                            "policynim quickstart --target local-mcp --client codex --format json"
+                        ),
+                        "agent_workflows": _valid_agent_workflows(),
+                    },
+                },
+            },
+        }
+    )
+
+
+def _release_payload(*, asset_names: Sequence[str]) -> str:
+    return json.dumps(
+        {
+            "tagName": "v0.1.0",
+            "url": "https://github.com/example/policyNIM/releases/tag/v0.1.0",
+            "targetCommitish": "abc123",
+            "publishedAt": "2026-05-30T20:13:33Z",
+            "isDraft": False,
+            "isPrerelease": False,
+            "assets": [
+                {"name": name, "size": 1234, "digest": "sha256:abc"} for name in asset_names
+            ],
+        }
+    )
+
+
+class _FakeUrlResponse:
+    def __init__(self, *, status: int, payload: dict[str, object]) -> None:
+        self.status = status
+        self._payload = payload
+
+    def __enter__(self) -> _FakeUrlResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode()
+
+
+def _release_payload_asset_names(module: ModuleType, release_tag: str) -> list[str]:
+    return [
+        asset
+        for asset in module.expected_release_assets(release_tag)
+        if asset not in {"RELEASE_MANIFEST.json", "SHA256SUMS"}
+    ]
+
+
+def test_expected_release_assets_include_four_standalone_platforms() -> None:
+    """Keep launch evidence aligned with the public standalone asset contract."""
+    module = _load_script_module()
+
+    assert module.expected_release_assets("v0.1.0") == [
+        "RELEASE_MANIFEST.json",
+        "SHA256SUMS",
+        "install.ps1",
+        "install.sh",
+        "policynim-0.1.0-py3-none-any.whl",
+        "policynim-0.1.0.tar.gz",
+        "policynim-v0.1.0-darwin-amd64.tar.gz",
+        "policynim-v0.1.0-darwin-arm64.tar.gz",
+        "policynim-v0.1.0-linux-amd64.tar.gz",
+        "policynim-v0.1.0-windows-amd64.zip",
+    ]
+
+
+def _write_release_metadata_download(
+    module: ModuleType,
+    command: list[str],
+    *,
+    checksum_override: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str] | None:
+    if command[:3] != ["gh", "release", "download"]:
+        return None
+    patterns = [
+        command[index + 1] for index, part in enumerate(command[:-1]) if part == "--pattern"
+    ]
+    if {"RELEASE_MANIFEST.json", "SHA256SUMS"} - set(patterns):
+        return None
+
+    release_tag = command[3]
+    download_dir = Path(command[command.index("--dir") + 1])
+    download_dir.mkdir(parents=True, exist_ok=True)
+    asset_names = _release_payload_asset_names(module, release_tag)
+    checksums = {asset_name: f"{index + 1:064x}" for index, asset_name in enumerate(asset_names)}
+    if checksum_override:
+        checksums.update(checksum_override)
+    manifest = {
+        "schema_version": "1",
+        "release_tag": release_tag,
+        "source_sha": "abc123",
+        "assets": [
+            {
+                "name": asset_name,
+                "size_bytes": 1234,
+                "sha256": checksums[asset_name],
+            }
+            for asset_name in asset_names
+        ],
+    }
+    (download_dir / "RELEASE_MANIFEST.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    (download_dir / "SHA256SUMS").write_text(
+        "".join(f"{checksums[asset_name]}  {asset_name}\n" for asset_name in asset_names),
+        encoding="utf-8",
+    )
+    return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+
+def _successful_runner(
+    module: ModuleType,
+    command: list[str],
+) -> subprocess.CompletedProcess[str]:
+    metadata_download = _write_release_metadata_download(module, command)
+    if metadata_download is not None:
+        return metadata_download
+    if command[:3] == ["gh", "release", "view"]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=_release_payload(asset_names=module.expected_release_assets("v0.1.0")),
+            stderr="",
+        )
+    if command[:3] == ["gh", "label", "list"]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                [
+                    {"name": "type/bug", "color": "d73a4a", "description": "Reproducible bug."},
+                    {
+                        "name": "surface/mcp-stdio",
+                        "color": "5319e7",
+                        "description": "Local stdio MCP.",
+                    },
+                ]
+            ),
+            stderr="",
+        )
+    if command[:3] == ["gh", "repo", "view"]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "nameWithOwner": "example/policyNIM",
+                    "repositoryTopics": [{"name": "mcp"}, {"name": "verification"}],
+                }
+            ),
+            stderr="",
+        )
+    raise AssertionError(command)
+
+
+def _hosted_smoke_run_payload(
+    *,
+    conclusion: str = "success",
+    head_sha: str = "abc123",
+    workflow_name: str = "Hosted Beta Smoke",
+) -> str:
+    return json.dumps(
+        {
+            "conclusion": conclusion,
+            "event": "workflow_dispatch",
+            "headSha": head_sha,
+            "jobs": [
+                {
+                    "conclusion": conclusion,
+                    "name": "hosted-smoke",
+                    "status": "completed",
+                }
+            ],
+            "name": "Hosted Beta Smoke",
+            "status": "completed",
+            "url": "https://github.com/example/policyNIM/actions/runs/123456789",
+            "workflowName": workflow_name,
+        }
+    )
+
+
+def _hosted_smoke_junit_xml(*, test_names: Sequence[str]) -> str:
+    testcases = "\n".join(
+        f'  <testcase classname="tests.test_hosted_mcp_live" name="{name}" />'
+        for name in test_names
+    )
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuite name="pytest" tests="{len(test_names)}" failures="0" errors="0">\n'
+        f"{testcases}\n"
+        "</testsuite>\n"
+    )
+
+
+def _pypi_publish_run_payload(
+    *,
+    conclusion: str = "success",
+    head_sha: str = "abc123",
+    job_name: str = "publish-pypi",
+    workflow_name: str = "Release",
+) -> str:
+    return json.dumps(
+        {
+            "conclusion": conclusion,
+            "event": "workflow_dispatch",
+            "headSha": head_sha,
+            "jobs": [
+                {
+                    "conclusion": conclusion,
+                    "name": job_name,
+                    "status": "completed",
+                }
+            ],
+            "name": "Release",
+            "status": "completed",
+            "url": "https://github.com/example/policyNIM/actions/runs/987654321",
+            "workflowName": workflow_name,
+        }
+    )
+
+
+def _pypi_payload_with_files(*filenames: str) -> dict[str, object]:
+    return {
+        "info": {"version": "0.1.0", "project_url": "https://pypi.org/project/policynim/"},
+        "releases": {
+            "0.1.0": [{"filename": filename} for filename in filenames],
+        },
+    }
+
+
+def _successful_pypi_install_runner(
+    module: ModuleType,
+    command: list[str],
+    *,
+    hosted_quickstart_output: str | None = None,
+    support_bundle_output: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if len(command) >= 3 and command[1:3] == ["-m", "venv"]:
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    if len(command) >= 5 and command[1:4] == ["-m", "pip", "install"]:
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    if command[-1:] == ["--help"]:
+        return subprocess.CompletedProcess(command, 0, stdout="PolicyNIM\n", stderr="")
+    if "quickstart" in command and command[-2:] == ["--format", "json"]:
+        target = "hosted-mcp"
+        if "local-cli" in command:
+            target = "local-cli"
+        elif "local-mcp" in command:
+            target = "local-mcp"
+        output = (
+            hosted_quickstart_output
+            if target == "hosted-mcp" and hosted_quickstart_output is not None
+            else _valid_quickstart_output(target=target)
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+    if command[-3:] == ["doctor", "--format", "json"]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='{"status":"needs_configuration","checks":[]}\n',
+            stderr="",
+        )
+    if "support-bundle" in command:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=support_bundle_output or _valid_support_bundle_output(),
+            stderr="",
+        )
+    if "mcp-config" in command:
+        client = "claude-code" if "claude-code" in command else "codex"
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "schema_version": "1",
+                    "client": client,
+                    "target": "local-stdio",
+                    "server_name": "policynim",
+                    "local_launch_mode": "installed-cli",
+                }
+            ),
+            stderr="",
+        )
+    return _successful_runner(module, command)
+
+
+def test_collect_launch_evidence_populates_only_verifiable_records(tmp_path: Path) -> None:
+    """Collect machine-verifiable external evidence without claiming manual proofs."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    required_assets = module.expected_release_assets("v0.1.0")
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        metadata_download = _write_release_metadata_download(module, command)
+        if metadata_download is not None:
+            return metadata_download
+        if command[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(
+                command, 0, stdout=_release_payload(asset_names=required_assets), stderr=""
+            )
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {"name": "type/bug", "color": "d73a4a", "description": "Reproducible bug."},
+                        {
+                            "name": "surface/mcp-stdio",
+                            "color": "5319e7",
+                            "description": "Local stdio MCP.",
+                        },
+                    ]
+                ),
+                stderr="",
+            )
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "example/policyNIM",
+                        "repositoryTopics": [{"name": "mcp"}, {"name": "verification"}],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload={
+            "info": {"version": "0.1.0", "project_url": "https://pypi.org/project/policynim/"},
+            "releases": {
+                "0.1.0": [
+                    {"filename": "policynim-0.1.0-py3-none-any.whl"},
+                    {"filename": "policynim-0.1.0.tar.gz"},
+                ],
+            },
+        },
+    )
+
+    evidence = payload["evidence"]
+    assert evidence["github_release_artifacts"]["summary"].startswith(
+        "GitHub release v0.1.0 contains"
+    )
+    assert "manifest and SHA256SUMS" in evidence["github_release_artifacts"]["summary"]
+    assert (
+        evidence["github_release_artifacts"]["reference"]
+        == "https://github.com/example/policyNIM/releases/tag/v0.1.0"
+    )
+    assert evidence["github_labels_applied"]["summary"] == "GitHub labels match .github/labels.yml."
+    assert (
+        evidence["github_topics_applied"]["summary"]
+        == "GitHub repository topics match .github/topics.yml."
+    )
+    assert evidence["pypi_project"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+    assert evidence["github_artifact_attestations"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+    assert payload["probes"]["github_artifact_attestations"]["status"] == "manual_required"
+    assert payload["probes"]["pypi_install_smoke"]["status"] == "manual_required"
+    assert payload["probes"]["pypi_project"]["status"] == "manual_required"
+    assert "Trusted publishing" in payload["probes"]["pypi_project"]["next_step"]
+    assert ["gh", "release", "view", "v0.1.0", "--json", module.GITHUB_RELEASE_FIELDS] in calls
+    assert ["gh", "repo", "view", "--json", "repositoryTopics,nameWithOwner"] in calls
+
+
+def test_collect_launch_evidence_refuses_release_when_manifest_checksums_drift(
+    tmp_path: Path,
+) -> None:
+    """Do not claim GitHub release evidence when manifest and SHA256SUMS disagree."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    required_assets = module.expected_release_assets("v0.1.0")
+    mismatched_asset = "policynim-v0.1.0-linux-amd64.tar.gz"
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        metadata_download = _write_release_metadata_download(
+            module,
+            command,
+            checksum_override={mismatched_asset: "f" * 64},
+        )
+        if metadata_download is not None:
+            download_dir = Path(command[command.index("--dir") + 1])
+            checksums_path = download_dir / "SHA256SUMS"
+            checksums_path.write_text(
+                checksums_path.read_text(encoding="utf-8").replace(
+                    f"{'f' * 64}  {mismatched_asset}",
+                    f"{'e' * 64}  {mismatched_asset}",
+                ),
+                encoding="utf-8",
+            )
+            return metadata_download
+        if command[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_release_payload(asset_names=required_assets),
+                stderr="",
+            )
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout="[]", stderr="")
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "example/policyNIM",
+                        "repositoryTopics": [{"name": "mcp"}, {"name": "verification"}],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+    )
+
+    assert payload["evidence"]["github_release_artifacts"]["summary"] == ""
+    assert payload["probes"]["github_release_artifacts"]["status"] == ("release_metadata_invalid")
+    assert mismatched_asset in payload["probes"]["github_release_artifacts"]["detail"]
+
+
+def test_collect_launch_evidence_marks_release_view_failure_as_release_specific(
+    tmp_path: Path,
+) -> None:
+    """Fail closed with a release-specific status when the tag cannot be inspected."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout="",
+                stderr="release not found",
+            )
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout="[]", stderr="")
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "example/policyNIM",
+                        "repositoryTopics": [{"name": "mcp"}, {"name": "verification"}],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.1",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-31T13:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+    )
+
+    probe = payload["probes"]["github_release_artifacts"]
+    assert probe["status"] == "release_view_failed"
+    assert "release not found" in probe["detail"]
+    assert payload["evidence"]["github_release_artifacts"]["summary"] == ""
+
+
+def test_collect_launch_evidence_prefills_release_attestation_when_asset_verifies(
+    tmp_path: Path,
+) -> None:
+    """Download one release asset and turn successful gh attestation verify into evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    asset_name = "policynim-v0.1.0-linux-amd64.tar.gz"
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "release", "download"]:
+            metadata_download = _write_release_metadata_download(module, command)
+            if metadata_download is not None:
+                return metadata_download
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / asset_name).write_text("release asset", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:3] == ["gh", "attestation", "verify"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "verificationResult": {
+                                "statement": {
+                                    "subject": [
+                                        {
+                                            "name": asset_name,
+                                            "digest": {"sha256": ("0" * 64)},
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        release_attestation_asset_name=asset_name,
+    )
+
+    assert [
+        "gh",
+        "release",
+        "download",
+        "v0.1.0",
+        "--pattern",
+        asset_name,
+        "--dir",
+        payload["probes"]["github_artifact_attestations"]["download_dir"],
+        "--repo",
+        "example/policyNIM",
+    ] in calls
+    assert any(command[:3] == ["gh", "attestation", "verify"] for command in calls)
+    assert payload["probes"]["github_artifact_attestations"]["status"] == "passed"
+    assert payload["probes"]["github_artifact_attestations"]["subject_count"] == 1
+    assert payload["probes"]["github_artifact_attestations"]["subject_names"] == [asset_name]
+    assert payload["evidence"]["github_artifact_attestations"] == {
+        "summary": (
+            "GitHub artifact attestation verifies for "
+            "policynim-v0.1.0-linux-amd64.tar.gz from release v0.1.0 with "
+            "1 attested subject."
+        ),
+        "reference": (
+            "https://github.com/example/policyNIM/releases/tag/v0.1.0"
+            "#policynim-v0.1.0-linux-amd64.tar.gz"
+        ),
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+
+
+def test_collect_launch_evidence_refuses_failed_release_attestation(
+    tmp_path: Path,
+) -> None:
+    """Do not claim artifact provenance when gh attestation verify fails."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    asset_name = "policynim-v0.1.0-linux-amd64.tar.gz"
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "release", "download"]:
+            metadata_download = _write_release_metadata_download(module, command)
+            if metadata_download is not None:
+                return metadata_download
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / asset_name).write_text("release asset", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:3] == ["gh", "attestation", "verify"]:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout="",
+                stderr="no attestation found",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        release_attestation_asset_name=asset_name,
+    )
+
+    assert payload["evidence"]["github_artifact_attestations"]["summary"] == ""
+    assert payload["probes"]["github_artifact_attestations"]["status"] == ("verification_failed")
+    assert "no attestation found" in payload["probes"]["github_artifact_attestations"]["detail"]
+
+
+def test_collect_launch_evidence_refuses_empty_attestation_subjects(
+    tmp_path: Path,
+) -> None:
+    """Do not claim release provenance when gh returns no verified subjects."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    asset_name = "policynim-v0.1.0-linux-amd64.tar.gz"
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "release", "download"]:
+            metadata_download = _write_release_metadata_download(module, command)
+            if metadata_download is not None:
+                return metadata_download
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / asset_name).write_text("release asset", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:3] == ["gh", "attestation", "verify"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps([{"verificationResult": {"statement": {"subject": []}}}]),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        release_attestation_asset_name=asset_name,
+    )
+
+    assert payload["evidence"]["github_artifact_attestations"]["summary"] == ""
+    assert payload["probes"]["github_artifact_attestations"]["status"] == (
+        "attestation_missing_subjects"
+    )
+    assert "subject" in payload["probes"]["github_artifact_attestations"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_attestation_for_different_asset(
+    tmp_path: Path,
+) -> None:
+    """Do not claim provenance when verified subjects omit the selected release asset."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    asset_name = "policynim-v0.1.0-linux-amd64.tar.gz"
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "release", "download"]:
+            metadata_download = _write_release_metadata_download(module, command)
+            if metadata_download is not None:
+                return metadata_download
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / asset_name).write_text("release asset", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:3] == ["gh", "attestation", "verify"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "verificationResult": {
+                                "statement": {
+                                    "subject": [
+                                        {
+                                            "name": "policynim-v0.1.0-darwin-arm64.tar.gz",
+                                            "digest": {"sha256": "0" * 64},
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        release_attestation_asset_name=asset_name,
+    )
+
+    assert payload["evidence"]["github_artifact_attestations"]["summary"] == ""
+    assert payload["probes"]["github_artifact_attestations"]["status"] == (
+        "attestation_subject_mismatch"
+    )
+    assert payload["probes"]["github_artifact_attestations"]["subject_names"] == [
+        "policynim-v0.1.0-darwin-arm64.tar.gz"
+    ]
+    assert asset_name in payload["probes"]["github_artifact_attestations"]["next_step"]
+
+
+def test_collect_launch_evidence_prefills_pypi_from_successful_publish_run(
+    tmp_path: Path,
+) -> None:
+    """Combine public PyPI JSON and a successful trusted-publish run into evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_pypi_publish_run_payload(),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_publish_run_url="https://github.com/example/policyNIM/actions/runs/987654321",
+    )
+
+    assert [
+        "gh",
+        "run",
+        "view",
+        "987654321",
+        "--json",
+        module.GITHUB_RUN_FIELDS,
+    ] in calls
+    assert payload["probes"]["pypi_project"]["status"] == "passed"
+    assert payload["probes"]["pypi_project"]["file_count"] == 2
+    assert payload["probes"]["pypi_project"]["filenames"] == [
+        "policynim-0.1.0-py3-none-any.whl",
+        "policynim-0.1.0.tar.gz",
+    ]
+    assert payload["evidence"]["pypi_project"] == {
+        "summary": (
+            "PyPI project policynim version 0.1.0 exposes 2 release files and "
+            "Release run 987654321 completed publish-pypi successfully with "
+            "trusted publishing for release commit abc123."
+        ),
+        "reference": "https://github.com/example/policyNIM/actions/runs/987654321",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+
+
+def test_collect_launch_evidence_prefills_pypi_install_smoke_from_clean_install(
+    tmp_path: Path,
+) -> None:
+    """Prove the public PyPI package installs and first-run commands start."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return _successful_pypi_install_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["probes"]["pypi_install_smoke"]["status"] == "passed"
+    assert payload["probes"]["pypi_install_smoke"]["commands"] == [
+        "python -m venv",
+        "python -m pip install --upgrade pip",
+        "python -m pip install policynim==0.1.0",
+        "policynim --help",
+        "policynim init --help",
+        "policynim ingest --help",
+        "policynim preflight --help",
+        "policynim quickstart --format json",
+        "policynim quickstart --target local-cli --format json",
+        "policynim quickstart --target local-mcp --format json",
+        "policynim doctor --format json",
+        "policynim support-bundle",
+        "policynim mcp-config --client codex --target local-stdio --format json",
+        "policynim mcp-config --client claude-code --target local-stdio --format json",
+    ]
+    assert payload["evidence"]["pypi_install_smoke"] == {
+        "summary": (
+            "Clean PyPI install smoke passed for policynim==0.1.0 with --help, "
+            "primary command help, semantic first-run JSON, support-bundle hosted "
+            "client_commands for Codex and Claude Code, doctor JSON, and local MCP config JSON."
+        ),
+        "reference": "https://pypi.org/project/policynim/0.1.0/",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+    assert any(command[-1:] == ["policynim==0.1.0"] for command in calls)
+
+
+def test_collect_launch_evidence_prefills_github_release_install_smoke(
+    tmp_path: Path,
+) -> None:
+    """Prove the published GitHub installer reaches the first-run CLI contract."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["curl", "-fsSL", "-o"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:2] == ["sh", "-c"] and "install.sh" in command[2]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_valid_unix_installer_stdout(),
+                stderr="",
+            )
+        return _successful_pypi_install_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        github_install_smoke=True,
+    )
+
+    assert payload["probes"]["github_release_install_smoke"]["status"] == "passed"
+    assert payload["probes"]["github_release_install_smoke"]["commands"] == [
+        "download install.sh",
+        "install.sh",
+        "policynim --help",
+        "policynim init --help",
+        "policynim ingest --help",
+        "policynim preflight --help",
+        "policynim quickstart --format json",
+        "policynim quickstart --target local-cli --format json",
+        "policynim quickstart --target local-mcp --format json",
+        "policynim doctor --format json",
+        "policynim support-bundle",
+        "policynim mcp-config --client codex --target local-stdio --format json",
+        "policynim mcp-config --client claude-code --target local-stdio --format json",
+    ]
+    assert payload["evidence"]["github_release_install_smoke"] == {
+        "summary": (
+            "Clean GitHub release installer smoke passed for v0.1.0 with "
+            "install.sh guidance, --help, primary command help, semantic "
+            "first-run JSON, support-bundle hosted client_commands for Codex and "
+            "Claude Code, doctor JSON, and local MCP config JSON."
+        ),
+        "reference": "https://github.com/nnennandukwe/policyNIM/releases/tag/v0.1.0",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+    assert any(
+        command[:3] == ["curl", "-fsSL", "-o"]
+        and command[-1]
+        == "https://github.com/nnennandukwe/policyNIM/releases/download/v0.1.0/install.sh"
+        for command in calls
+    )
+
+
+def test_collect_launch_evidence_refuses_github_install_smoke_without_setup_guidance(
+    tmp_path: Path,
+) -> None:
+    """Do not claim GitHub installer proof when post-install guidance is stale."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["curl", "-fsSL", "-o"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:2] == ["sh", "-c"] and "install.sh" in command[2]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    "Installed PolicyNIM 0.1.0.\n"
+                    "Run `policynim init` to configure your local NVIDIA API key.\n"
+                ),
+                stderr="",
+            )
+        return _successful_pypi_install_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        github_install_smoke=True,
+    )
+
+    assert payload["evidence"]["github_release_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["github_release_install_smoke"]
+    assert probe["status"] == "invalid_installer_guidance"
+    assert probe["command"] == "install.sh"
+    assert "Hosted MCP does not require `policynim init` or `policynim ingest`" in (probe["detail"])
+    assert "For local CLI or local MCP" in probe["detail"]
+
+
+def test_collect_launch_evidence_refuses_github_release_install_smoke_command_failure(
+    tmp_path: Path,
+) -> None:
+    """Do not claim GitHub installer proof when the installed CLI lacks quickstart."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["curl", "-fsSL", "-o"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:2] == ["sh", "-c"] and "install.sh" in command[2]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_valid_unix_installer_stdout(),
+                stderr="",
+            )
+        if command[-3:] == ["quickstart", "--format", "json"]:
+            return subprocess.CompletedProcess(
+                command,
+                2,
+                stdout="",
+                stderr="No such command 'quickstart'.",
+            )
+        return _successful_pypi_install_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        github_install_smoke=True,
+    )
+
+    assert payload["evidence"]["github_release_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["github_release_install_smoke"]
+    assert probe["status"] == "missing_first_run_command"
+    assert probe["command"] == "policynim quickstart --format json"
+    assert "No such command 'quickstart'." in probe["detail"]
+    assert "Publish a new GitHub release built from the current CLI" in probe["next_step"]
+
+
+def test_collect_launch_evidence_refuses_pypi_smoke_without_hosted_client_commands(
+    tmp_path: Path,
+) -> None:
+    """Do not claim public install proof when hosted quickstart lacks MCP setup."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    hosted_quickstart = json.dumps(
+        {
+            "target": "hosted-mcp",
+            "requires_local_setup": False,
+            "calls_external_services": False,
+            "commands": [],
+            "agent_workflows": _valid_agent_workflows(),
+        }
+    )
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _successful_pypi_install_runner(
+            module,
+            command,
+            hosted_quickstart_output=hosted_quickstart,
+        )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["pypi_install_smoke"]
+    assert probe["status"] == "invalid_first_run_contract"
+    assert probe["command"] == "policynim quickstart --format json"
+    assert "client_commands must be a non-empty string list" in probe["detail"]
+    assert (
+        "Publish a new PyPI release built from the current first-run contract"
+        in (probe["next_step"])
+    )
+
+
+def test_collect_launch_evidence_refuses_pypi_smoke_without_mcp_token_flow(
+    tmp_path: Path,
+) -> None:
+    """Do not claim public install proof when quickstart hides token creation."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    hosted_quickstart = json.dumps(
+        {
+            "target": "hosted-mcp",
+            "requires_local_setup": False,
+            "calls_external_services": False,
+            "commands": [],
+            "client_commands": _valid_hosted_client_commands(),
+            "agent_workflows": _valid_agent_workflows(),
+        }
+    )
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _successful_pypi_install_runner(
+            module,
+            command,
+            hosted_quickstart_output=hosted_quickstart,
+        )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["pypi_install_smoke"]
+    assert probe["status"] == "invalid_first_run_contract"
+    assert probe["command"] == "policynim quickstart --format json"
+    assert "hosted quickstart hosted_url must be an https /mcp URL" in probe["detail"]
+    assert "hosted quickstart steps must explain the browser token flow" in (probe["detail"])
+
+
+def test_collect_launch_evidence_refuses_pypi_smoke_without_support_client_commands(
+    tmp_path: Path,
+) -> None:
+    """Do not claim public install proof when support-bundle omits hosted setup."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    support_bundle = json.loads(_valid_support_bundle_output())
+    del support_bundle["first_run"]["targets"]["hosted_mcp"]["client_commands"]
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _successful_pypi_install_runner(
+            module,
+            command,
+            support_bundle_output=json.dumps(support_bundle),
+        )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["pypi_install_smoke"]
+    assert probe["status"] == "invalid_first_run_contract"
+    assert probe["command"] == "policynim support-bundle"
+    assert "first_run.targets.hosted_mcp.client_commands" in probe["detail"]
+
+
+def test_collect_launch_evidence_refuses_pypi_smoke_without_support_claude_command(
+    tmp_path: Path,
+) -> None:
+    """Do not claim install proof when support diagnostics omit a hosted MCP client."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    support_bundle = json.loads(_valid_support_bundle_output())
+    support_bundle["first_run"]["targets"]["hosted_mcp"]["client_commands"] = (
+        _valid_hosted_client_commands()
+    )
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _successful_pypi_install_runner(
+            module,
+            command,
+            support_bundle_output=json.dumps(support_bundle),
+        )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["pypi_install_smoke"]
+    assert probe["status"] == "invalid_first_run_contract"
+    assert probe["command"] == "policynim support-bundle"
+    assert (
+        "first_run.targets.hosted_mcp.client_commands must include a Claude Code MCP add command"
+        in probe["detail"]
+    )
+
+
+def test_collect_launch_evidence_refuses_pypi_smoke_without_support_token_flow(
+    tmp_path: Path,
+) -> None:
+    """Do not claim public install proof when support-bundle hides token setup."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    support_bundle = json.loads(_valid_support_bundle_output())
+    hosted_mcp = support_bundle["first_run"]["targets"]["hosted_mcp"]
+    del hosted_mcp["hosted_url"]
+    del hosted_mcp["steps"]
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _successful_pypi_install_runner(
+            module,
+            command,
+            support_bundle_output=json.dumps(support_bundle),
+        )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    probe = payload["probes"]["pypi_install_smoke"]
+    assert probe["status"] == "invalid_first_run_contract"
+    assert probe["command"] == "policynim support-bundle"
+    assert "first_run.targets.hosted_mcp hosted_url must be an https /mcp URL" in (probe["detail"])
+    assert (
+        "first_run.targets.hosted_mcp steps must explain the browser token flow"
+        in (probe["detail"])
+    )
+
+
+def test_collect_launch_evidence_refuses_pypi_install_smoke_command_failure(
+    tmp_path: Path,
+) -> None:
+    """Do not claim public install proof when first-run smoke commands fail."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[-3:] == ["quickstart", "--format", "json"]:
+            return subprocess.CompletedProcess(
+                command,
+                2,
+                stdout="",
+                stderr="No such command 'quickstart'.",
+            )
+        if len(command) >= 3 and command[1:3] == ["-m", "venv"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if len(command) >= 5 and command[1:4] == ["-m", "pip", "install"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[-1:] == ["--help"]:
+            return subprocess.CompletedProcess(command, 0, stdout="PolicyNIM\n", stderr="")
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_install_smoke=True,
+    )
+
+    assert payload["evidence"]["pypi_install_smoke"]["summary"] == ""
+    assert payload["probes"]["pypi_install_smoke"]["status"] == "missing_first_run_command"
+    assert payload["probes"]["pypi_install_smoke"]["command"] == (
+        "policynim quickstart --format json"
+    )
+    assert "No such command 'quickstart'." in payload["probes"]["pypi_install_smoke"]["detail"]
+    assert (
+        "Publish a new PyPI release built from the current CLI"
+        in (payload["probes"]["pypi_install_smoke"]["next_step"])
+    )
+
+
+def test_collect_launch_evidence_refuses_pypi_run_from_different_release_sha(
+    tmp_path: Path,
+) -> None:
+    """Do not accept trusted-publishing evidence from an unrelated release run."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_pypi_publish_run_payload(head_sha="different-sha"),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_publish_run_url="https://github.com/example/policyNIM/actions/runs/987654321",
+    )
+
+    assert payload["evidence"]["pypi_project"]["summary"] == ""
+    assert payload["probes"]["pypi_project"]["status"] == "release_sha_mismatch"
+    assert payload["probes"]["pypi_project"]["expected_head_sha"] == "abc123"
+    assert payload["probes"]["pypi_project"]["actual_head_sha"] == "different-sha"
+    assert "same commit" in payload["probes"]["pypi_project"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_pypi_without_release_files(
+    tmp_path: Path,
+) -> None:
+    """Do not claim install-channel evidence until PyPI lists the wheel and sdist."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_pypi_publish_run_payload(),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files("policynim-0.1.0-py3-none-any.whl"),
+        pypi_publish_run_url="https://github.com/example/policyNIM/actions/runs/987654321",
+    )
+
+    assert [
+        "gh",
+        "run",
+        "view",
+        "987654321",
+        "--json",
+        module.GITHUB_RUN_FIELDS,
+    ] not in calls
+    assert payload["evidence"]["pypi_project"]["summary"] == ""
+    assert payload["probes"]["pypi_project"]["status"] == "missing_distribution_files"
+    assert payload["probes"]["pypi_project"]["missing_files"] == ["policynim-0.1.0.tar.gz"]
+    assert "wheel and sdist" in payload["probes"]["pypi_project"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_pypi_run_without_publish_job(
+    tmp_path: Path,
+) -> None:
+    """Do not claim PyPI trusted-publishing evidence from a run without publish-pypi."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_pypi_publish_run_payload(job_name="verify"),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_publish_run_url="https://github.com/example/policyNIM/actions/runs/987654321",
+    )
+
+    assert payload["evidence"]["pypi_project"]["summary"] == ""
+    assert payload["probes"]["pypi_project"]["status"] == "job_not_successful"
+    assert payload["probes"]["pypi_project"]["available_jobs"] == [
+        {"conclusion": "success", "name": "verify", "status": "completed"}
+    ]
+    assert "publish-pypi" in payload["probes"]["pypi_project"]["next_step"]
+
+
+def test_collect_launch_evidence_reports_skipped_pypi_publish_job(
+    tmp_path: Path,
+) -> None:
+    """Surface skipped trusted-publishing jobs without accepting PyPI evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "conclusion": "success",
+                        "event": "workflow_dispatch",
+                        "headSha": "abc123",
+                        "jobs": [
+                            {
+                                "conclusion": "skipped",
+                                "name": "publish-pypi",
+                                "status": "completed",
+                            }
+                        ],
+                        "name": "Release",
+                        "status": "completed",
+                        "url": "https://github.com/example/policyNIM/actions/runs/987654321",
+                        "workflowName": "Release",
+                    }
+                ),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=_pypi_payload_with_files(
+            "policynim-0.1.0-py3-none-any.whl",
+            "policynim-0.1.0.tar.gz",
+        ),
+        pypi_publish_run_url="https://github.com/example/policyNIM/actions/runs/987654321",
+    )
+
+    probe = payload["probes"]["pypi_project"]
+    assert payload["evidence"]["pypi_project"]["summary"] == ""
+    assert probe["status"] == "job_not_successful"
+    assert probe["job_name"] == "publish-pypi"
+    assert probe["job_status"] == "completed"
+    assert probe["job_conclusion"] == "skipped"
+
+
+def test_launch_evidence_text_output_includes_pypi_job_details(
+    tmp_path: Path,
+) -> None:
+    """Keep human-readable launch evidence output actionable for skipped jobs."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    payload = {
+        "release_tag": "v0.1.0",
+        "probes": {
+            "pypi_project": {
+                "status": "job_not_successful",
+                "next_step": "Use a Release workflow run where the publish-pypi job passed.",
+                "job_name": "publish-pypi",
+                "job_status": "completed",
+                "job_conclusion": "skipped",
+            }
+        },
+    }
+
+    output = module._render_text(payload)
+
+    assert "- pypi_project: job_not_successful" in output
+    assert "  job: publish-pypi completed/skipped" in output
+
+
+def test_launch_evidence_text_output_includes_probe_failure_detail(
+    tmp_path: Path,
+) -> None:
+    """Expose actionable probe failure details in human-readable output."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    payload = {
+        "release_tag": "v0.1.0",
+        "probes": {
+            "github_artifact_attestations": {
+                "status": "verification_failed",
+                "detail": "Error: HTTP 404: Not Found",
+                "next_step": "Publish release attestations from the Release workflow.",
+            }
+        },
+    }
+
+    output = module._render_text(payload)
+
+    assert "- github_artifact_attestations: verification_failed" in output
+    assert "  detail: Error: HTTP 404: Not Found" in output
+    assert "  next: Publish release attestations from the Release workflow." in output
+
+
+def test_collect_launch_evidence_prefills_hosted_domain_when_url_is_ready(
+    tmp_path: Path,
+) -> None:
+    """Turn an opt-in hosted URL probe into reviewable launch evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def fake_urlopen(request: Request | str, *, timeout: float) -> _FakeUrlResponse:
+        assert timeout == 15
+        url = request.full_url if isinstance(request, Request) else request
+        headers = dict(request.header_items()) if isinstance(request, Request) else {}
+        calls.append((url, headers))
+        if url == "https://policy.example/healthz":
+            return _FakeUrlResponse(
+                status=200,
+                payload={
+                    "ready": True,
+                    "status": "ok",
+                    "row_count": 42,
+                    "mcp_url": "https://policy.example/mcp",
+                },
+            )
+        if url == "https://policy.example/mcp":
+            assert headers["Authorization"] == "Bearer invalid-token"
+            assert headers["Accept"] == "text/event-stream"
+            return _FakeUrlResponse(status=401, payload={"error": "Unauthorized."})
+        raise AssertionError(url)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        hosted_mcp_url="https://policy.example/mcp",
+        urlopen=fake_urlopen,
+    )
+
+    assert payload["probes"]["hosted_mcp_domain"]["status"] == "passed"
+    assert payload["evidence"]["hosted_mcp_domain"] == {
+        "summary": (
+            "Hosted MCP domain https://policy.example reports ready /healthz "
+            "with row_count 42 and rejects invalid bearer tokens on /mcp."
+        ),
+        "reference": "https://policy.example/healthz",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+    assert calls == [
+        ("https://policy.example/healthz", {}),
+        (
+            "https://policy.example/mcp",
+            {"Accept": "text/event-stream", "Authorization": "Bearer invalid-token"},
+        ),
+    ]
+
+
+def test_collect_launch_evidence_refuses_hosted_domain_without_bearer_gate(
+    tmp_path: Path,
+) -> None:
+    """Do not claim hosted MCP evidence when invalid bearer tokens are accepted."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_urlopen(request: Request | str, *, timeout: float) -> _FakeUrlResponse:
+        url = request.full_url if isinstance(request, Request) else request
+        if url == "https://policy.example/healthz":
+            return _FakeUrlResponse(
+                status=200,
+                payload={
+                    "ready": True,
+                    "status": "ok",
+                    "row_count": 42,
+                    "mcp_url": "https://policy.example/mcp",
+                },
+            )
+        if url == "https://policy.example/mcp":
+            return _FakeUrlResponse(status=200, payload={"accepted": True})
+        raise AssertionError(url)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        hosted_mcp_url="https://policy.example/mcp",
+        urlopen=fake_urlopen,
+    )
+
+    assert payload["evidence"]["hosted_mcp_domain"]["summary"] == ""
+    assert payload["probes"]["hosted_mcp_domain"]["status"] == "mcp_auth_not_enforced"
+    assert "401" in payload["probes"]["hosted_mcp_domain"]["next_step"]
+
+
+def test_collect_launch_evidence_prefills_hosted_smoke_from_successful_run(
+    tmp_path: Path,
+) -> None:
+    """Turn a supplied Hosted Beta Smoke run URL into launch evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_hosted_smoke_run_payload(),
+                stderr="",
+            )
+        if command[:3] == ["gh", "run", "download"]:
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / "policynim-hosted-smoke-junit.xml").write_text(
+                _hosted_smoke_junit_xml(test_names=module.expected_hosted_smoke_tests()),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        hosted_smoke_run_url="https://github.com/example/policyNIM/actions/runs/123456789",
+    )
+
+    assert [
+        "gh",
+        "run",
+        "view",
+        "123456789",
+        "--json",
+        module.GITHUB_RUN_FIELDS,
+    ] in calls
+    assert [
+        "gh",
+        "run",
+        "download",
+        "123456789",
+        "--name",
+        "hosted-smoke-evidence",
+        "--dir",
+        "<dynamic-dir>",
+    ][:-1] in [call[:-1] for call in calls]
+    assert payload["probes"]["hosted_beta_live_smoke"]["status"] == "passed"
+    assert payload["probes"]["hosted_beta_live_smoke"]["artifact"] == "hosted-smoke-evidence"
+    assert payload["probes"]["hosted_beta_live_smoke"]["junit_file"] == (
+        "policynim-hosted-smoke-junit.xml"
+    )
+    assert payload["evidence"]["hosted_beta_live_smoke"] == {
+        "summary": (
+            "Hosted Beta Smoke run 123456789 completed successfully with "
+            "hosted-smoke-evidence/policynim-hosted-smoke-junit.xml covering "
+            "5 live MCP checks from release commit abc123."
+        ),
+        "reference": "https://github.com/example/policyNIM/actions/runs/123456789",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+
+
+def test_collect_launch_evidence_refuses_hosted_smoke_run_from_different_release_sha(
+    tmp_path: Path,
+) -> None:
+    """Do not claim hosted smoke proof from a stale or unrelated workflow run."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_hosted_smoke_run_payload(head_sha="different-sha"),
+                stderr="",
+            )
+        if command[:3] == ["gh", "run", "download"]:
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / "policynim-hosted-smoke-junit.xml").write_text(
+                _hosted_smoke_junit_xml(test_names=module.expected_hosted_smoke_tests()),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        hosted_smoke_run_url="https://github.com/example/policyNIM/actions/runs/123456789",
+    )
+
+    assert payload["evidence"]["hosted_beta_live_smoke"]["summary"] == ""
+    assert payload["probes"]["hosted_beta_live_smoke"]["status"] == "release_sha_mismatch"
+    assert payload["probes"]["hosted_beta_live_smoke"]["expected_head_sha"] == "abc123"
+    assert payload["probes"]["hosted_beta_live_smoke"]["actual_head_sha"] == "different-sha"
+    assert "same commit" in payload["probes"]["hosted_beta_live_smoke"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_failed_hosted_smoke_run(tmp_path: Path) -> None:
+    """Do not turn a failed Hosted Beta Smoke run URL into launch evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_hosted_smoke_run_payload(conclusion="failure"),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        hosted_smoke_run_url="https://github.com/example/policyNIM/actions/runs/123456789",
+    )
+
+    assert payload["evidence"]["hosted_beta_live_smoke"]["summary"] == ""
+    assert payload["probes"]["hosted_beta_live_smoke"]["status"] == "run_not_successful"
+    assert "success" in payload["probes"]["hosted_beta_live_smoke"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_hosted_smoke_run_without_expected_junit(
+    tmp_path: Path,
+) -> None:
+    """Do not fill hosted smoke evidence when the retained artifact is incomplete."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    missing_test = "test_hosted_policy_preflight_live"
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "run", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=_hosted_smoke_run_payload(),
+                stderr="",
+            )
+        if command[:3] == ["gh", "run", "download"]:
+            download_dir = Path(command[command.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            retained_tests = [
+                name for name in module.expected_hosted_smoke_tests() if name != missing_test
+            ]
+            (download_dir / "policynim-hosted-smoke-junit.xml").write_text(
+                _hosted_smoke_junit_xml(test_names=retained_tests),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+        hosted_smoke_run_url="https://github.com/example/policyNIM/actions/runs/123456789",
+    )
+
+    assert payload["evidence"]["hosted_beta_live_smoke"]["summary"] == ""
+    assert payload["probes"]["hosted_beta_live_smoke"]["status"] == "junit_missing_tests"
+    assert payload["probes"]["hosted_beta_live_smoke"]["missing_tests"] == [missing_test]
+
+
+def test_collect_launch_evidence_prefills_real_client_session_from_reviewed_file(
+    tmp_path: Path,
+) -> None:
+    """Turn a reviewed Codex or Claude MCP session record into launch evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    session_file = tmp_path / "codex-mcp-session.json"
+    session_file.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "setup_command": HOSTED_CODEX_SETUP_COMMAND,
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "launch-notes/codex-mcp-session.md",
+                "secrets_included": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=session_file,
+    )
+
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "passed"
+    assert payload["evidence"]["real_mcp_client_session"] == {
+        "summary": (
+            "Codex loaded the policynim MCP server over hosted-http using a "
+            "reviewed setup command, listed "
+            "policy_preflight and policy_search, and called policy_preflight."
+        ),
+        "reference": "launch-notes/codex-mcp-session.md",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T21:00:00Z",
+    }
+
+
+def test_collect_launch_evidence_refuses_client_session_with_secrets(
+    tmp_path: Path,
+) -> None:
+    """Do not accept client-session evidence that says secrets were included."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    session_file = tmp_path / "codex-mcp-session.json"
+    session_file.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "setup_command": HOSTED_CODEX_SETUP_COMMAND,
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "launch-notes/codex-mcp-session.md",
+                "secrets_included": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=session_file,
+    )
+
+    assert payload["evidence"]["real_mcp_client_session"]["summary"] == ""
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "secrets_included"
+    assert "redacted" in payload["probes"]["real_mcp_client_session"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_client_session_placeholder_reference(
+    tmp_path: Path,
+) -> None:
+    """Do not accept template-like client-session references as launch proof."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    session_file = tmp_path / "codex-mcp-session.json"
+    session_file.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "setup_command": HOSTED_CODEX_SETUP_COMMAND,
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "https://github.com/example/policyNIM/issues/123",
+                "secrets_included": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=session_file,
+    )
+
+    assert payload["evidence"]["real_mcp_client_session"]["summary"] == ""
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "placeholder_reference"
+    assert (
+        "real, sanitized reference" in (payload["probes"]["real_mcp_client_session"]["next_step"])
+    )
+
+
+def test_collect_launch_evidence_refuses_checked_in_client_session_example(
+    tmp_path: Path,
+) -> None:
+    """Do not turn the checked-in client-session example into real launch proof."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    example_file = Path("docs/mcp-client-evidence.example.json")
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=example_file,
+    )
+
+    assert payload["evidence"]["real_mcp_client_session"]["summary"] == ""
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "missing_reference"
+    assert (
+        "non-empty sanitized reference"
+        in (payload["probes"]["real_mcp_client_session"]["next_step"])
+    )
+
+
+def test_collect_launch_evidence_missing_client_session_guides_setup_proof(
+    tmp_path: Path,
+) -> None:
+    """Keep missing real-client proof guidance aligned with required setup evidence."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+    )
+
+    next_step = payload["probes"]["real_mcp_client_session"]["next_step"]
+
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "manual_required"
+    assert "transcript or screenshot" in next_step
+    assert "secret-safe setup command" in next_step
+    assert "policy_preflight" in next_step
+
+
+def test_collect_launch_evidence_refuses_client_session_without_setup_command(
+    tmp_path: Path,
+) -> None:
+    """Do not accept client-session proof that omits how the MCP server was added."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    session_file = tmp_path / "codex-mcp-session.json"
+    session_file.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "launch-notes/codex-mcp-session.md",
+                "secrets_included": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=session_file,
+    )
+
+    assert payload["evidence"]["real_mcp_client_session"]["summary"] == ""
+    assert payload["probes"]["real_mcp_client_session"]["status"] == "missing_setup_command"
+    assert "setup command" in payload["probes"]["real_mcp_client_session"]["next_step"]
+
+
+def test_collect_launch_evidence_refuses_client_session_with_placeholder_setup_command(
+    tmp_path: Path,
+) -> None:
+    """Do not accept client proof whose setup command still contains placeholders."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    session_file = tmp_path / "codex-mcp-session.json"
+    session_file.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "setup_command": (
+                    "codex mcp add policynim --url https://<railway-domain>/mcp "
+                    "--bearer-token-env-var POLICYNIM_TOKEN"
+                ),
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "launch-notes/codex-mcp-session.md",
+                "secrets_included": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=lambda command: _successful_runner(module, command),
+        pypi_payload=None,
+        mcp_client_evidence_file=session_file,
+    )
+
+    assert payload["evidence"]["real_mcp_client_session"]["summary"] == ""
+    assert payload["probes"]["real_mcp_client_session"]["status"] == ("placeholder_setup_command")
+    assert "real setup command" in (payload["probes"]["real_mcp_client_session"]["next_step"])
+
+
+def test_validate_mcp_client_evidence_payload_checks_setup_command_shape() -> None:
+    """Require the setup command to match the reviewed client and transport."""
+    module = _load_script_module()
+
+    for client, transport, setup_command in (
+        ("codex", "hosted-http", HOSTED_CODEX_SETUP_COMMAND),
+        ("claude-code", "hosted-http", HOSTED_CLAUDE_SETUP_COMMAND),
+        ("codex", "local-stdio", LOCAL_CODEX_SETUP_COMMAND),
+        ("claude-code", "local-stdio", LOCAL_CLAUDE_SETUP_COMMAND),
+    ):
+        assert (
+            module._validate_mcp_client_evidence_payload(
+                {
+                    "client": client,
+                    "transport": transport,
+                    "server_name": "policynim",
+                    "setup_command": setup_command,
+                    "tools": ["policy_preflight", "policy_search"],
+                    "called_tool": "policy_preflight",
+                    "reference": "launch-notes/mcp-session.md",
+                    "secrets_included": False,
+                }
+            )
+            is None
+        )
+
+    wrong_setup = {
+        "client": "codex",
+        "transport": "hosted-http",
+        "server_name": "policynim",
+        "setup_command": "claude mcp add --transport http policynim https://policynim.dev/mcp",
+        "tools": ["policy_preflight", "policy_search"],
+        "called_tool": "policy_preflight",
+        "reference": "launch-notes/mcp-session.md",
+        "secrets_included": False,
+    }
+    error = module._validate_mcp_client_evidence_payload(wrong_setup)
+
+    assert error is not None
+    assert error["status"] == "setup_command_mismatch"
+
+
+def test_mcp_client_evidence_template_matches_checked_in_example() -> None:
+    """Keep generated client-session templates aligned with the safe checked-in example."""
+    module = _load_script_module()
+    checked_in = json.loads(
+        (REPO_ROOT / "docs" / "mcp-client-evidence.example.json").read_text(encoding="utf-8")
+    )
+
+    assert checked_in == module.mcp_client_evidence_template(
+        client="codex",
+        transport="hosted-http",
+    )
+    assert checked_in["reference"] == ""
+    assert checked_in["setup_command"] == ""
+
+
+def test_write_mcp_client_evidence_template_creates_safe_placeholder(
+    tmp_path: Path,
+) -> None:
+    """Let maintainers generate a safe real-client evidence record to fill later."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "claude-mcp-session.json"
+
+    result = module.write_mcp_client_evidence_template(
+        target,
+        client="claude-code",
+        transport="local-stdio",
+        force=False,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert payload == {
+        "client": "claude-code",
+        "transport": "local-stdio",
+        "server_name": "policynim",
+        "setup_command": "",
+        "tools": ["policy_preflight", "policy_search"],
+        "called_tool": "policy_preflight",
+        "reference": "",
+        "secrets_included": False,
+    }
+
+
+def test_write_mcp_client_evidence_template_refuses_overwrite_without_force(
+    tmp_path: Path,
+) -> None:
+    """Protect reviewed client-session evidence from template rewrites."""
+    module = _load_script_module()
+    target = tmp_path / "codex-mcp-session.json"
+    target.write_text("existing evidence", encoding="utf-8")
+
+    result = module.write_mcp_client_evidence_template(
+        target,
+        client="codex",
+        transport="hosted-http",
+        force=False,
+    )
+
+    assert result == 1
+    assert target.read_text(encoding="utf-8") == "existing evidence"
+
+
+def test_write_mcp_client_evidence_record_creates_valid_reviewed_record(
+    tmp_path: Path,
+) -> None:
+    """Let maintainers turn a reviewed session reference into collector-ready JSON."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "codex-mcp-session.json"
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="hosted-http",
+        setup_command=HOSTED_CODEX_SETUP_COMMAND,
+        reference="launch-notes/codex-mcp-session.md",
+        force=False,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert payload == {
+        "client": "codex",
+        "transport": "hosted-http",
+        "server_name": "policynim",
+        "setup_command": HOSTED_CODEX_SETUP_COMMAND,
+        "tools": ["policy_preflight", "policy_search"],
+        "called_tool": "policy_preflight",
+        "reference": "launch-notes/codex-mcp-session.md",
+        "secrets_included": False,
+    }
+    assert module._validate_mcp_client_evidence_payload(payload) is None
+
+
+def test_write_mcp_client_evidence_record_derives_hosted_setup_command(
+    tmp_path: Path,
+) -> None:
+    """Let maintainers generate hosted client evidence from the verified /mcp URL."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "codex-mcp-session.json"
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="hosted-http",
+        setup_command="",
+        hosted_mcp_url="https://policynim.dev/mcp",
+        reference="launch-notes/codex-mcp-session.md",
+        force=False,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert payload["setup_command"] == HOSTED_CODEX_SETUP_COMMAND
+    assert module._validate_mcp_client_evidence_payload(payload) is None
+
+
+def test_write_mcp_client_evidence_record_rejects_hosted_url_for_local_stdio(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Avoid creating local stdio evidence from a hosted-only setup shortcut."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "codex-mcp-session.json"
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="local-stdio",
+        setup_command="",
+        hosted_mcp_url="https://policynim.dev/mcp",
+        reference="launch-notes/codex-mcp-session.md",
+        force=False,
+    )
+
+    assert result == 1
+    assert not target.exists()
+    assert "--mcp-client-hosted-url is only valid with hosted-http" in capsys.readouterr().err
+
+
+def test_write_mcp_client_evidence_record_replaces_blank_template_without_force(
+    tmp_path: Path,
+) -> None:
+    """Let maintainers fill the generated blank template without unsafe overwrite flags."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "codex-mcp-session.json"
+    module.write_mcp_client_evidence_template(
+        target,
+        client="codex",
+        transport="hosted-http",
+        force=False,
+    )
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="hosted-http",
+        setup_command=HOSTED_CODEX_SETUP_COMMAND,
+        hosted_mcp_url="",
+        reference="launch-notes/codex-mcp-session.md",
+        force=False,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert payload["reference"] == "launch-notes/codex-mcp-session.md"
+
+
+def test_write_mcp_client_evidence_record_refuses_nonblank_overwrite_without_force(
+    tmp_path: Path,
+) -> None:
+    """Protect reviewed client-session records from accidental rewrites."""
+    module = _load_script_module()
+    target = tmp_path / "launch-notes" / "codex-mcp-session.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "client": "codex",
+                "transport": "hosted-http",
+                "server_name": "policynim",
+                "setup_command": HOSTED_CODEX_SETUP_COMMAND,
+                "tools": ["policy_preflight", "policy_search"],
+                "called_tool": "policy_preflight",
+                "reference": "launch-notes/old-session.md",
+                "secrets_included": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="hosted-http",
+        setup_command=HOSTED_CODEX_SETUP_COMMAND,
+        reference="launch-notes/new-session.md",
+        force=False,
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 1
+    assert payload["reference"] == "launch-notes/old-session.md"
+
+
+def test_write_mcp_client_evidence_record_refuses_placeholder_reference(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Avoid generating client evidence records that strict launch checks reject."""
+    module = _load_script_module()
+    target = tmp_path / "codex-mcp-session.json"
+
+    result = module.write_mcp_client_evidence_record(
+        target,
+        client="codex",
+        transport="hosted-http",
+        setup_command=HOSTED_CODEX_SETUP_COMMAND,
+        reference="https://github.com/example/policyNIM/issues/123",
+        force=False,
+    )
+
+    assert result == 1
+    assert not target.exists()
+    assert "real, sanitized reference" in capsys.readouterr().err
+
+
+def test_main_writes_mcp_client_template_before_collecting(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Avoid live probes when the user only wants a client evidence template."""
+    module = _load_script_module()
+    target = tmp_path / "codex-mcp-session.json"
+
+    def fail_collect(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("collect_launch_evidence should not run")
+
+    monkeypatch.setattr(module, "collect_launch_evidence", fail_collect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-mcp-client-evidence-template",
+            str(target),
+            "--mcp-client-template-client",
+            "codex",
+            "--mcp-client-template-transport",
+            "hosted-http",
+        ],
+    )
+
+    result = module.main()
+
+    assert result == 0
+    assert "Wrote MCP client evidence template" in capsys.readouterr().out
+    assert json.loads(target.read_text(encoding="utf-8"))["reference"] == ""
+
+
+def test_main_help_documents_client_setup_command_contract(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Keep CLI help clear enough for maintainers collecting client-session proof."""
+    module = _load_script_module()
+    monkeypatch.setattr(sys, "argv", ["collect_launch_evidence.py", "--help"])
+
+    try:
+        module.main()
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    output = capsys.readouterr().out
+    normalized_output = " ".join(output.split())
+
+    assert "--mcp-client-setup-command" in output
+    assert "--mcp-client-hosted-url" in output
+    assert "blank setup_command and reference fields" in output
+    assert "supplying --mcp-client-reference plus either --mcp-client-setup-command" in (
+        normalized_output
+    )
+
+
+def test_main_writes_mcp_client_record_before_collecting(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Avoid live probes when the user only wants a completed client evidence record."""
+    module = _load_script_module()
+    target = tmp_path / "codex-mcp-session.json"
+
+    def fail_collect(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("collect_launch_evidence should not run")
+
+    monkeypatch.setattr(module, "collect_launch_evidence", fail_collect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-mcp-client-evidence-record",
+            str(target),
+            "--mcp-client-template-client",
+            "codex",
+            "--mcp-client-template-transport",
+            "hosted-http",
+            "--mcp-client-setup-command",
+            HOSTED_CODEX_SETUP_COMMAND,
+            "--mcp-client-reference",
+            "launch-notes/codex-mcp-session.md",
+        ],
+    )
+
+    result = module.main()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert "Wrote MCP client evidence record" in capsys.readouterr().out
+    assert payload["setup_command"] == HOSTED_CODEX_SETUP_COMMAND
+    assert payload["reference"] == "launch-notes/codex-mcp-session.md"
+
+
+def test_main_writes_mcp_client_record_from_hosted_url_before_collecting(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Avoid hand-written setup commands when the hosted /mcp URL is known."""
+    module = _load_script_module()
+    target = tmp_path / "codex-mcp-session.json"
+
+    def fail_collect(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("collect_launch_evidence should not run")
+
+    monkeypatch.setattr(module, "collect_launch_evidence", fail_collect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-mcp-client-evidence-record",
+            str(target),
+            "--mcp-client-template-client",
+            "codex",
+            "--mcp-client-template-transport",
+            "hosted-http",
+            "--mcp-client-hosted-url",
+            "https://policynim.dev/mcp",
+            "--mcp-client-reference",
+            "launch-notes/codex-mcp-session.md",
+        ],
+    )
+
+    result = module.main()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert "Wrote MCP client evidence record" in capsys.readouterr().out
+    assert payload["setup_command"] == HOSTED_CODEX_SETUP_COMMAND
+
+
+def test_collect_launch_evidence_reports_incomplete_release_assets(tmp_path: Path) -> None:
+    """Avoid turning a live release into evidence when required assets are missing."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+    assets_without_manifest = [
+        asset
+        for asset in module.expected_release_assets("v0.1.0")
+        if asset != "RELEASE_MANIFEST.json"
+    ]
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(
+                command, 0, stdout=_release_payload(asset_names=assets_without_manifest), stderr=""
+            )
+        if command[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout="[]", stderr="")
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "example/policyNIM",
+                        "repositoryTopics": [{"name": "mcp"}, {"name": "verification"}],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+    )
+
+    assert payload["evidence"]["github_release_artifacts"]["summary"] == ""
+    assert payload["probes"]["github_release_artifacts"]["status"] == "missing_assets"
+    assert payload["probes"]["github_release_artifacts"]["missing_assets"] == [
+        "RELEASE_MANIFEST.json"
+    ]
+    assert payload["probes"]["github_labels_applied"]["status"] == "label_drift"
+    label_next_step = payload["probes"]["github_labels_applied"]["next_step"]
+    assert "gh auth status" in label_next_step
+    assert "sync_github_labels.py --live --format json" in label_next_step
+    assert "sync_github_labels.py --apply --format json" in label_next_step
+
+
+def test_collect_launch_evidence_reports_topic_drift(tmp_path: Path) -> None:
+    """Do not claim repository discoverability evidence when live topics drift."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "nameWithOwner": "example/policyNIM",
+                        "repositoryTopics": [{"name": "mcp"}],
+                    }
+                ),
+                stderr="",
+            )
+        return _successful_runner(module, command)
+
+    payload = module.collect_launch_evidence(
+        repo_root=tmp_path,
+        release_tag="v0.1.0",
+        verified_by="maintainer@example.com",
+        verified_at="2026-05-30T21:00:00Z",
+        runner=fake_runner,
+        pypi_payload=None,
+    )
+
+    assert payload["evidence"]["github_topics_applied"]["summary"] == ""
+    assert payload["probes"]["github_topics_applied"]["status"] == "topic_drift"
+    assert payload["probes"]["github_topics_applied"]["missing_or_changed"] == ["verification"]
+    topic_next_step = payload["probes"]["github_topics_applied"]["next_step"]
+    assert "gh auth status" in topic_next_step
+    assert "sync_github_topics.py --live --format json" in topic_next_step
+    assert "sync_github_topics.py --apply --format json" in topic_next_step
+
+
+def test_write_collected_evidence_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    """Protect hand-reviewed launch evidence from accidental rewrites."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    target.write_text("existing", encoding="utf-8")
+
+    result = module.write_evidence_file(
+        target,
+        evidence=module.blank_external_evidence(),
+        force=False,
+    )
+
+    assert result == 1
+    assert target.read_text(encoding="utf-8") == "existing"
+
+
+def test_main_refuses_existing_evidence_target_before_collecting(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Avoid slow live probes when an output file would be rejected."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    target.write_text("existing", encoding="utf-8")
+
+    def fail_collect(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("collect_launch_evidence should not run")
+
+    monkeypatch.setattr(module, "collect_launch_evidence", fail_collect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-external-evidence-file",
+            str(target),
+        ],
+    )
+
+    result = module.main()
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "already exists" in captured.err
+    assert "--merge-existing" in captured.err
+    assert target.read_text(encoding="utf-8") == "existing"
+
+
+def test_main_json_output_stays_machine_readable_when_writing_evidence(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Expose probe failures to automation even when the collector writes a file."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "github_artifact_attestations": {
+                "status": "verification_failed",
+                "next_step": "Publish release attestations.",
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-external-evidence-file",
+            str(target),
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert result == 0
+    assert captured.err == ""
+    assert output["probes"]["github_artifact_attestations"]["status"] == "verification_failed"
+    assert output["external_evidence_file"] == {
+        "path": str(target),
+        "mode": "written",
+    }
+    assert json.loads(target.read_text(encoding="utf-8")) == payload["evidence"]
+
+
+def test_main_merge_clears_existing_record_when_current_probe_drifts(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Keep the CLI merge path from preserving stale GitHub metadata proof."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing["github_labels_applied"] = {
+        "summary": "GitHub labels match .github/labels.yml.",
+        "reference": "gh label list --json name,color,description --limit 1000",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "github_labels_applied": {
+                "status": "label_drift",
+                "missing_or_changed": ["type/launch"],
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--write-external-evidence-file",
+            str(target),
+            "--merge-existing",
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    output = json.loads(capsys.readouterr().out)
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert output["external_evidence_file"]["mode"] == "merged"
+    assert written["github_labels_applied"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+
+
+def test_main_can_fail_when_requested_probe_does_not_pass(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Let release automation fail when an explicitly requested proof is missing."""
+    module = _load_script_module()
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "github_artifact_attestations": {
+                "status": "verification_failed",
+                "detail": "Error: HTTP 404: Not Found",
+                "next_step": "Publish release attestations.",
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--release-attestation-asset-name",
+            "policynim-0.1.0-py3-none-any.whl",
+            "--require-requested-probes",
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    output = json.loads(capsys.readouterr().out)
+
+    assert result == 1
+    assert output["requested_probe_failures"] == [
+        {
+            "name": "github_artifact_attestations",
+            "status": "verification_failed",
+            "next_step": "Publish release attestations.",
+        }
+    ]
+
+
+def test_main_can_fail_when_requested_pypi_install_smoke_does_not_pass(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Treat requested public install smoke as an enforceable release proof."""
+    module = _load_script_module()
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "pypi_install_smoke": {
+                "status": "command_failed",
+                "next_step": "Rerun the public PyPI install smoke.",
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--pypi-install-smoke",
+            "--require-requested-probes",
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    output = json.loads(capsys.readouterr().out)
+
+    assert result == 1
+    assert output["requested_probe_failures"] == [
+        {
+            "name": "pypi_install_smoke",
+            "status": "command_failed",
+            "next_step": "Rerun the public PyPI install smoke.",
+        }
+    ]
+
+
+def test_main_can_fail_when_requested_github_install_smoke_does_not_pass(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Treat requested GitHub installer smoke as an enforceable release proof."""
+    module = _load_script_module()
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "github_release_install_smoke": {
+                "status": "missing_first_run_command",
+                "next_step": "Publish a new GitHub release.",
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--github-install-smoke",
+            "--require-requested-probes",
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    output = json.loads(capsys.readouterr().out)
+
+    assert result == 1
+    assert output["requested_probe_failures"] == [
+        {
+            "name": "github_release_install_smoke",
+            "status": "missing_first_run_command",
+            "next_step": "Publish a new GitHub release.",
+        }
+    ]
+
+
+def test_main_strict_requested_probe_mode_ignores_unrequested_failures(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Keep partial launch evidence collection compatible by defaulting to requested probes."""
+    module = _load_script_module()
+    payload = {
+        "schema_version": "1",
+        "generated_at": "2026-05-31T12:00:00Z",
+        "release_tag": "v0.1.0",
+        "evidence": module.blank_external_evidence(),
+        "probes": {
+            "github_artifact_attestations": {
+                "status": "manual_required",
+                "next_step": "Pass an asset name.",
+            }
+        },
+    }
+
+    monkeypatch.setattr(module, "_fetch_pypi_payload", lambda: None)
+    monkeypatch.setattr(module, "collect_launch_evidence", lambda **kwargs: payload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_launch_evidence.py",
+            "--require-requested-probes",
+            "--format",
+            "json",
+        ],
+    )
+
+    result = module.main()
+    output = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert "requested_probe_failures" not in output
+
+
+def test_launch_evidence_text_output_includes_requested_probe_failures(
+    tmp_path: Path,
+) -> None:
+    """Make strict collector failures readable without parsing JSON."""
+    module = _load_script_module()
+    _write_label_file(tmp_path)
+
+    payload = {
+        "release_tag": "v0.1.0",
+        "probes": {
+            "github_artifact_attestations": {
+                "status": "verification_failed",
+                "next_step": "Publish release attestations.",
+            }
+        },
+        "requested_probe_failures": [
+            {
+                "name": "github_artifact_attestations",
+                "status": "verification_failed",
+                "next_step": "Publish release attestations.",
+            }
+        ],
+    }
+
+    output = module._render_text(payload)
+
+    assert "Requested probe failures:" in output
+    assert "- github_artifact_attestations: verification_failed" in output
+    assert "  next: Publish release attestations." in output
+
+
+def test_write_collected_evidence_merge_preserves_unverified_existing_records(
+    tmp_path: Path,
+) -> None:
+    """Allow incremental evidence collection without clobbering reviewed records."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing["real_mcp_client_session"] = {
+        "summary": "Codex connected to the hosted MCP and called policy_preflight.",
+        "reference": "launch-notes/codex-mcp-session.json",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    collected = module.blank_external_evidence()
+    collected["github_release_artifacts"] = {
+        "summary": "GitHub release v0.1.0 contains every required artifact.",
+        "reference": "https://github.com/example/policyNIM/releases/tag/v0.1.0",
+        "verified_by": "release-bot",
+        "verified_at": "2026-05-30T23:00:00Z",
+    }
+
+    result = module.write_evidence_file(
+        target,
+        evidence=collected,
+        force=False,
+        merge_existing=True,
+    )
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert written["real_mcp_client_session"] == existing["real_mcp_client_session"]
+    assert written["github_release_artifacts"] == collected["github_release_artifacts"]
+
+
+def test_write_collected_evidence_merge_clears_existing_record_on_current_drift(
+    tmp_path: Path,
+) -> None:
+    """Do not preserve old external proof when the current live probe found drift."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing["github_labels_applied"] = {
+        "summary": "GitHub labels match .github/labels.yml.",
+        "reference": "gh label list --json name,color,description --limit 1000",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    existing["real_mcp_client_session"] = {
+        "summary": "Codex connected to the hosted MCP and called policy_preflight.",
+        "reference": "launch-notes/codex-mcp-session.json",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+
+    result = module.write_evidence_file(
+        target,
+        evidence=module.blank_external_evidence(),
+        force=False,
+        merge_existing=True,
+        probes={
+            "github_labels_applied": {
+                "status": "label_drift",
+                "missing_or_changed": ["type/launch"],
+            }
+        },
+    )
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert written["github_labels_applied"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+    assert written["real_mcp_client_session"] == existing["real_mcp_client_session"]
+
+
+def test_write_collected_evidence_merge_clears_existing_pypi_smoke_on_current_failure(
+    tmp_path: Path,
+) -> None:
+    """Do not preserve old PyPI install proof when the current public smoke fails."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing["pypi_install_smoke"] = {
+        "summary": "Clean PyPI install smoke passed for policynim==0.1.0.",
+        "reference": "https://pypi.org/project/policynim/0.1.0/",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+
+    result = module.write_evidence_file(
+        target,
+        evidence=module.blank_external_evidence(),
+        force=False,
+        merge_existing=True,
+        probes={
+            "pypi_install_smoke": {
+                "status": "missing_first_run_command",
+                "command": "policynim quickstart --format json",
+            }
+        },
+    )
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert written["pypi_install_smoke"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+
+
+def test_write_collected_evidence_merge_clears_existing_github_smoke_on_current_failure(
+    tmp_path: Path,
+) -> None:
+    """Do not preserve old GitHub installer proof when the current smoke fails."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing["github_release_install_smoke"] = {
+        "summary": "Clean GitHub release installer smoke passed for v0.1.0.",
+        "reference": "https://github.com/nnennandukwe/policyNIM/releases/tag/v0.1.0",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+
+    result = module.write_evidence_file(
+        target,
+        evidence=module.blank_external_evidence(),
+        force=False,
+        merge_existing=True,
+        probes={
+            "github_release_install_smoke": {
+                "status": "missing_first_run_command",
+                "command": "policynim quickstart --format json",
+            }
+        },
+    )
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert written["github_release_install_smoke"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+
+
+def test_write_collected_evidence_merge_clears_existing_release_artifacts_on_current_failure(
+    tmp_path: Path,
+) -> None:
+    """Do not preserve old release asset proof when the current release probe fails."""
+    module = _load_script_module()
+    invalidating_statuses = (
+        "draft_release",
+        "missing_assets",
+        "missing_release_reference",
+        "metadata_download_failed",
+        "release_view_failed",
+        "release_view_invalid_json",
+        "release_metadata_missing",
+        "release_metadata_invalid",
+    )
+
+    for status in invalidating_statuses:
+        target = tmp_path / f"{status}.json"
+        existing = module.blank_external_evidence()
+        existing["github_release_artifacts"] = {
+            "summary": (
+                "GitHub release v0.1.0 contains required assets: "
+                "policynim-v0.1.0-linux-amd64.tar.gz."
+            ),
+            "reference": "https://github.com/nnennandukwe/policyNIM/releases/tag/v0.1.0",
+            "verified_by": "maintainer@example.com",
+            "verified_at": "2026-05-30T22:00:00Z",
+        }
+        existing["real_mcp_client_session"] = {
+            "summary": "Codex connected to hosted MCP and called policy_preflight.",
+            "reference": "launch-notes/codex-mcp-session.json",
+            "verified_by": "maintainer@example.com",
+            "verified_at": "2026-05-30T22:00:00Z",
+        }
+        target.write_text(json.dumps(existing), encoding="utf-8")
+
+        result = module.write_evidence_file(
+            target,
+            evidence=module.blank_external_evidence(),
+            force=False,
+            merge_existing=True,
+            probes={
+                "github_release_artifacts": {
+                    "status": status,
+                    "next_step": "Fix the GitHub release asset set.",
+                }
+            },
+        )
+        written = json.loads(target.read_text(encoding="utf-8"))
+
+        assert result == 0
+        assert written["github_release_artifacts"] == {
+            "summary": "",
+            "reference": "",
+            "verified_by": "",
+            "verified_at": "",
+        }
+        assert written["real_mcp_client_session"] == existing["real_mcp_client_session"]
+
+
+def test_write_collected_evidence_merge_upgrades_legacy_missing_checks(
+    tmp_path: Path,
+) -> None:
+    """Allow incremental collection to add newly introduced blank evidence keys."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    existing = module.blank_external_evidence()
+    existing.pop("github_topics_applied")
+    existing["github_labels_applied"] = {
+        "summary": "GitHub labels match .github/labels.yml.",
+        "reference": "gh label list --json name,color,description --limit 1000",
+        "verified_by": "maintainer@example.com",
+        "verified_at": "2026-05-30T22:00:00Z",
+    }
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    collected = module.blank_external_evidence()
+
+    result = module.write_evidence_file(
+        target,
+        evidence=collected,
+        force=False,
+        merge_existing=True,
+    )
+    written = json.loads(target.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert set(written) == set(module.blank_external_evidence())
+    assert written["github_labels_applied"] == existing["github_labels_applied"]
+    assert written["github_topics_applied"] == {
+        "summary": "",
+        "reference": "",
+        "verified_by": "",
+        "verified_at": "",
+    }
+
+
+def test_write_collected_evidence_merge_refuses_malformed_existing_file(
+    tmp_path: Path,
+) -> None:
+    """Fail closed when an incremental evidence merge cannot parse existing proof."""
+    module = _load_script_module()
+    target = tmp_path / "launch-evidence.json"
+    target.write_text("{not-json", encoding="utf-8")
+
+    result = module.write_evidence_file(
+        target,
+        evidence=module.blank_external_evidence(),
+        force=False,
+        merge_existing=True,
+    )
+
+    assert result == 1
+    assert target.read_text(encoding="utf-8") == "{not-json"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -922,6 +922,42 @@ def test_streamable_http_app_rejects_missing_bearer_token(monkeypatch) -> None:
     assert response.json() == {"error": "Unauthorized."}
 
 
+def test_streamable_http_app_redirects_browser_mcp_visits_to_beta_portal(monkeypatch) -> None:
+    """Route humans who paste the hosted MCP URL toward token creation."""
+    _stub_streamable_http_server(monkeypatch)
+
+    app = mcp_module._build_streamable_http_app(_self_serve_hosted_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        response = client.get(
+            "/mcp",
+            headers={"accept": "text/html"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://beta.example.com/beta"
+
+
+def test_streamable_http_app_keeps_bad_bearer_header_json_for_browser_accept(
+    monkeypatch,
+) -> None:
+    """Do not hide broken MCP client auth behind the human onboarding redirect."""
+    _stub_streamable_http_server(monkeypatch)
+
+    app = mcp_module._build_streamable_http_app(_self_serve_hosted_settings())
+
+    with TestClient(app, base_url="https://testserver") as client:
+        response = client.get(
+            "/mcp",
+            headers={"accept": "text/html", "authorization": "Token wrong"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"error": "Unauthorized."}
+
+
 def test_streamable_http_app_logs_auth_rejection(monkeypatch) -> None:
     events: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Stack position

3 of 4. Base: `codex/maintainer-metadata-taxonomy`. Previous PR: #59.

## Summary

- Add a public launch evidence collector with mergeable evidence output.
- Add evidence templates for release, hosted MCP, GitHub/PyPI, label/topic application, and real MCP client sessions.
- Add a public launch evidence issue form and ignore generated local evidence artifacts.

## Validation

- `uv run pytest -q tests/test_launch_evidence.py` -> 70 passed
- Top of stack: `uv lock --check`, `uv run ruff check .`, `uv run pyright`, `uv run pytest -q -m "not live and not docker_live"` -> 776 passed, 10 deselected
- Top of stack: `uv run python scripts/release_check.py --format json` -> `decision: ship`
