### PR TITLE
[codex] Migrate GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,21 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -37,13 +40,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/hosted-smoke.yml
+++ b/.github/workflows/hosted-smoke.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   hosted-smoke:
     runs-on: ubuntu-24.04
@@ -14,13 +17,13 @@ jobs:
       POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,20 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.11"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   verify:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -56,7 +57,7 @@ jobs:
         run: uv build --out-dir dist
 
       - name: Upload Python distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: python-dist
           path: dist/*
@@ -67,13 +68,13 @@ jobs:
     needs: verify
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: python-dist
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -105,13 +106,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -186,7 +187,7 @@ jobs:
           Compress-Archive -Path "dist/policynim/*" -DestinationPath "artifacts/$AssetName" -Force
 
       - name: Upload standalone bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: standalone-${{ matrix.platform }}
           path: artifacts/*
@@ -202,10 +203,10 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: release-downloads
 
@@ -280,7 +281,7 @@ jobs:
       contents: read
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: python-dist
           path: dist

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+WORKFLOWS = (CI_WORKFLOW, HOSTED_SMOKE_WORKFLOW, RELEASE_WORKFLOW)
 
 
 def _read_text(path: Path) -> str:
@@ -22,6 +23,38 @@ def test_ci_pytest_gate_excludes_all_live_markers() -> None:
 
     assert 'uv run pytest -q -m "not live and not docker_live"' in text
     assert 'uv run pytest -q -m "not live"\n' not in text
+
+
+def test_workflows_opt_into_node24_javascript_actions() -> None:
+    """Exercise the Node 24 runner default without allowing the Node 20 fallback."""
+    for workflow in WORKFLOWS:
+        text = _read_text(workflow)
+
+        assert 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"' in text
+        assert "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" not in text
+
+
+def test_workflows_use_approved_node24_migration_action_pins() -> None:
+    """Keep migrated GitHub action lines on approved major versions and SHA pins."""
+    text = "\n".join(_read_text(workflow) for workflow in WORKFLOWS)
+
+    expected_refs = (
+        r"actions/checkout@[0-9a-f]{40} # v5",
+        r"actions/setup-python@[0-9a-f]{40} # v6",
+        r"astral-sh/setup-uv@[0-9a-f]{40} # v6\.8\.0",
+        r"actions/upload-artifact@[0-9a-f]{40} # v5",
+        r"actions/download-artifact@[0-9a-f]{40} # v5",
+    )
+    for ref_pattern in expected_refs:
+        assert re.search(ref_pattern, text), ref_pattern
+
+    for legacy_ref in (
+        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+        "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+        "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    ):
+        assert legacy_ref not in text
 
 
 def test_hosted_smoke_workflow_is_manual_and_secret_gated() -> None:


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Migrate GitHub Actions workflows to Node 24 runtime (opt-in + pins + tests)
<code>⚙️ Configuration changes</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- Opt CI, hosted smoke, and release workflows into the GitHub Actions Node 24 JavaScript runtime ahead of the June 16, 2026 default migration.
- Update approved action pins across workflows: `actions/checkout` v5, `actions/setup-python` v6, `astral-sh/setup-uv` v6.8.0, and release artifact actions v5, while keeping SHA pins for deterministic supply-chain behavior.
- Extend workflow contract tests to enforce the Node 24 opt-in, reject the insecure Node 20 fallback, preserve pinned action references, and keep live checks opt-in.

## Verification

- `uv run pytest -q tests/test_ci_workflows.py` -> 11 passed
- `uv lock --check` -> resolved 263 packages
- `uv run ruff check .` -> all checks passed
- `uv run --group test --group dev pyright` -> 0 errors, 0 warnings, 0 informations
- `uv run pytest -q -m "not live and not docker_live"` -> 583 passed, 10 deselected
- Commit hook reran Ruff, Ruff format, and Pyright successfully

## Remaining risk

- As of this migration, `actions/upload-artifact@v5`, `actions/download-artifact@v5`, and `astral-sh/setup-uv@v6.8.0` still declare `node20` in their action metadata. The workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` setting exercises GitHub's Node 24 runner behavior now and avoids relying on the temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` fallback while those action maintainers finish metadata updates.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Opt workflows into GitHub Actions Node 24 JavaScript runtime via environment override.
• Refresh pinned action SHAs to approved major versions (checkout v5, setup-python v6, artifacts
  v5).
• Extend workflow contract tests to enforce Node 24 opt-in and reject Node 20 fallback.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  T["Workflow contract tests"] --> CI[".github/workflows/ci.yml"] --> ENV["Node24 opt-in env"] --> R(["GitHub Actions runner"])
  T --> SM[".github/workflows/hosted-smoke.yml"] --> ENV
  T --> RL[".github/workflows/release.yml"] --> ENV
  CI --> A(["Pinned JS actions"])
  SM --> A
  RL --> A
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Wait for GitHub&#x27;s default Node 24 migration date</b></summary>

- ➕ Avoids adding temporary workflow-level override knobs
- ➕ Lets upstream action maintainers update metadata first
- ➖ Defers discovering runtime breaks until the platform flips
- ➖ Creates a narrower window to react before releases/CI are impacted

</details>

<details>
<summary><b>2. Use ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION fallback (Node 20)</b></summary>

- ➕ Maximizes compatibility with JS actions still declaring node20
- ➕ Reduces risk of unexpected Node 24 runtime regressions
- ➖ Explicitly opts into a less secure runtime path
- ➖ Encourages lingering on a deprecated/unsupported configuration

</details>

<details>
<summary><b>3. Centralize workflow invariants via a reusable workflow</b></summary>

- ➕ Single place to manage env and approved action pins
- ➕ Less duplication across CI/smoke/release workflows
- ➖ More refactor than needed for a time-boxed runtime migration
- ➖ Adds indirection that can complicate troubleshooting

</details>

**Recommendation:** Proceed with the current approach: explicitly forcing Node 24 at the workflow level and locking action SHAs provides early validation ahead of the platform change, while the expanded contract tests prevent accidental reintroduction of the Node 20 fallback and unapproved pins. Reusable workflows are a reasonable follow-up, but not necessary to safely land this migration.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_ci_workflows.py</strong> <code>Add contract tests for Node 24 opt-in and approved action pins</code> <code>+33/-0</code></summary>

<br/>

>Add contract tests for Node 24 opt-in and approved action pins
>
><pre>
>• Introduces tests that require the Node 24 opt-in env var across key workflows and forbid the Node 20 insecure fallback. Adds regex checks ensuring approved major versions and SHA-pinned action references while rejecting legacy pinned SHAs.
></pre>
>
><a href='https://github.com/nnennandukwe/policyNIM/pull/62/files#diff-7f1df0ceac61ea5868c25b3bc8c1db58a5437864956adad66eef9f6fac319651'>tests/test_ci_workflows.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>ci.yml</strong> <code>Force Node 24 JS runtime and refresh CI action pins</code> <code>+9/-6</code></summary>

<br/>

>Force Node 24 JS runtime and refresh CI action pins
>
><pre>
>• Adds a workflow-level Node 24 opt-in environment setting. Updates pinned SHAs/major versions for checkout (v5), setup-python (v6), and setup-uv (v6.8.0) across CI jobs.
></pre>
>
><a href='https://github.com/nnennandukwe/policyNIM/pull/62/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f'>.github/workflows/ci.yml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>hosted-smoke.yml</strong> <code>Force Node 24 JS runtime and refresh hosted-smoke action pins</code> <code>+6/-3</code></summary>

<br/>

>Force Node 24 JS runtime and refresh hosted-smoke action pins
>
><pre>
>• Adds the Node 24 opt-in environment setting for the hosted smoke workflow. Updates pinned SHAs/major versions for checkout (v5), setup-python (v6), and setup-uv (v6.8.0).
></pre>
>
><a href='https://github.com/nnennandukwe/policyNIM/pull/62/files#diff-9f6e30987bbce6671010029860473e4a3f4e86ccd72281f3542052f98a6d78dc'>.github/workflows/hosted-smoke.yml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>release.yml</strong> <code>Force Node 24 JS runtime and refresh release artifact/action pins</code> <code>+14/-13</code></summary>

<br/>

>Force Node 24 JS runtime and refresh release artifact/action pins
>
><pre>
>• Adds workflow-level Node 24 opt-in env configuration. Updates pinned action SHAs/majors for checkout (v5), setup-python (v6), setup-uv (v6.8.0), and artifact upload/download actions (v5).
></pre>
>
><a href='https://github.com/nnennandukwe/policyNIM/pull/62/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34'>.github/workflows/release.yml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>