### PR TITLE
[demo][issue-64] Add errno detail to health readiness failures

### DIFF
--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -191,6 +191,8 @@ def format_health_failure_reason(exc: Exception) -> str:
     if isinstance(exc, OSError):
         message = _single_line_message(exc.strerror)
         if message:
+            if exc.errno is not None:
+                message = f"{message} (errno {exc.errno})"
             return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
     return f"Local index readiness could not be inspected: {type(exc).__name__}."
 

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -123,7 +123,8 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert result.row_count == 0
     assert result.reason is not None
     assert result.reason == (
-        "Local index readiness could not be inspected: PermissionError: permission denied."
+        "Local index readiness could not be inspected: PermissionError: "
+        "permission denied (errno 13)."
     )
     assert "/tmp/key" not in result.reason
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -810,6 +810,32 @@ def test_healthz_returns_fallback_payload_when_service_construction_fails(monkey
     assert "index_uri" not in payload
 
 
+def test_healthz_includes_errno_for_os_readiness_failures(monkeypatch) -> None:
+    """Keep public readiness failures more actionable for OS-level errors."""
+    monkeypatch.setattr(
+        mcp_module,
+        "create_runtime_health_service",
+        lambda settings: (_ for _ in ()).throw(
+            PermissionError(13, "permission denied", "/tmp/policynim/index.sqlite")
+        ),
+    )
+
+    app = mcp_module._build_streamable_http_app(
+        Settings.model_validate({"mcp_public_base_url": "https://beta.example.com"})
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: PermissionError: "
+        "permission denied (errno 13)."
+    )
+    assert "/tmp/policynim" not in payload["reason"]
+
+
 def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
     """Return a sanitized public fallback reason when health checks raise later."""
 


### PR DESCRIPTION
## Summary

The issue identifies `/healthz`, asks for more actionable readiness failures, and says to preserve the existing response fields. It also leaves open questions about safety and test scope, so this branch makes a bounded improvement without the full Jira/Confluence acceptance criteria from PR #65.

## Requirement Context
- No Jira issue
- No Confluence PRD

## What Changed

- Public readiness failure reasons now include `errno` for OS-level readiness inspection failures.
- The implementation still uses `OSError.strerror`, not raw `str(exc)`, so the existing local-path safety behavior is preserved.
- Added tests for health service and MCP `/healthz` fallback behavior.

## Validation

- `uv run ruff check`
- `uv run pyright`
- `uv run pytest -q tests/test_mcp.py tests/test_health_service.py`
