### PR TITLE
Add public readiness endpoint safety standard

### DIFF
--- a/docs/public-source-grounding.md
+++ b/docs/public-source-grounding.md
@@ -89,6 +89,18 @@ how the repo uses that source material.
   - The repo policy combines public guidance on secret storage, redaction, and
     safe diagnostics into one practical handling standard for application teams.
 
+### `SEC-PUBLIC-ENDPOINT-002`
+
+- Path: `policies/security/public-endpoint-safety.md`
+- Public grounding:
+  - OWASP Error Handling Cheat Sheet
+  - OWASP Logging Cheat Sheet
+  - The Twelve-Factor App config guidance
+- Provenance note:
+  - The repo policy adapts public error-handling, logging, and configuration
+    guidance into review expectations for public readiness endpoints and
+    operator-safe diagnostics.
+
 ### `SEC-SESSION-001`
 
 - Path: `policies/security/session-lifetime-and-token-boundaries.md`

--- a/policies/security/public-endpoint-safety.md
+++ b/policies/security/public-endpoint-safety.md
@@ -1,0 +1,60 @@
+---
+policy_id: SEC-PUBLIC-ENDPOINT-002
+title: Public Endpoint Safety
+doc_type: security-standard
+domain: security
+tags:
+  - public-endpoints
+  - readiness
+  - redaction
+  - logging
+  - configuration
+grounded_in:
+  - https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html
+  - https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+  - https://12factor.net/config
+---
+
+# Public Endpoint Safety
+
+## Intent
+
+Public operational endpoints should give operators enough signal to understand
+service readiness without exposing internals that help an attacker or leak
+environment-specific secrets.
+
+## Required Rules
+
+- Public readiness endpoints may expose stable status fields, but they must not
+  return raw exception text, traceback content, local filesystem paths, database
+  paths, bearer tokens, API keys, session secrets, passwords, or private config
+  values.
+- Failure messages returned from public endpoints must be allowlisted or
+  sanitized before leaving the service boundary.
+- Runtime setup failures, missing indexes, malformed configuration, and weak
+  policy grounding must fail closed with an operator-safe reason.
+- Application settings must be read through the central settings surface. Public
+  route handlers and service helpers must not introduce scattered environment
+  lookups.
+- Logs emitted from public endpoint failure paths must use safe, structured
+  context. Do not log raw request bodies, raw authorization headers, or raw
+  exception strings that can include secret-like values.
+
+## Review Expectations
+
+- Verify public response schemas stay stable unless the change explicitly
+  coordinates a schema migration.
+- Verify failure tests include local path, token-like, and secret-like examples
+  when endpoint output or logging changes.
+- Verify safe messages still preserve enough detail for an operator to identify
+  the failure class and next diagnostic step.
+- Verify public endpoint changes keep CLI and MCP behavior aligned when both
+  surfaces expose the same readiness or runtime state.
+
+## Public Grounding
+
+- OWASP error-handling guidance informed the rule against exposing raw exception
+  details through public responses.
+- OWASP logging guidance informed the safe diagnostic logging requirements.
+- The Twelve-Factor App config guidance informed the central configuration
+  boundary and fail-closed setup expectations.


### PR DESCRIPTION
## Summary

Adds a security policy for public readiness and operational endpoints. The policy defines expectations for safe public response fields, sanitized failure messages, centralized configuration access, and operator-safe logging.

## Why

Hosted readiness endpoints need enough detail for operators to understand failure classes without exposing local paths, secret-like values, raw exception text, or configuration internals.

## Validation

- `uv run ruff check`
- `uv run --group test --group dev python -m pytest -q tests/test_ingest.py tests/test_docs_runtime_workflows.py`
- `git diff --check`
