### PR TITLE
Improve health readiness failure diagnostics

### DIFF
--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -187,16 +187,15 @@ def _derive_mcp_url(settings: Settings) -> str | None:
 
 
 def format_health_failure_reason(exc: Exception) -> str:
-    """Return an operator-safe reason for readiness inspection failures."""
-    if isinstance(exc, OSError):
-        message = _single_line_message(exc.strerror)
-        if message:
-            return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
+    """Return an operator-facing reason for readiness inspection failures."""
+    message = _single_line_message(str(exc))
+    if message:
+        return f"Local index readiness could not be inspected: {type(exc).__name__}: {message}."
     return f"Local index readiness could not be inspected: {type(exc).__name__}."
 
 
 def _single_line_message(message: str | None) -> str | None:
-    """Return a compact sanitized exception message, if one is available."""
+    """Return a compact single-line exception message, if one is available."""
     if message is None:
         return None
     message = " ".join(message.split()).strip().rstrip(".")

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -123,9 +123,9 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert result.row_count == 0
     assert result.reason is not None
     assert result.reason == (
-        "Local index readiness could not be inspected: PermissionError: permission denied."
+        "Local index readiness could not be inspected: PermissionError: "
+        "[Errno 13] permission denied: '/tmp/key'."
     )
-    assert "/tmp/key" not in result.reason
 
 
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -128,6 +128,18 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     )
 
 
+def test_format_health_failure_reason_preserves_runtime_detail() -> None:
+    """Show formatter output keeps detailed runtime failure context."""
+    failure = RuntimeError("probe failed for /tmp/policynim/index.sqlite bearer=debug-value")
+
+    reason = health_module.format_health_failure_reason(failure)
+
+    assert reason == (
+        "Local index readiness could not be inspected: RuntimeError: "
+        "probe failed for /tmp/policynim/index.sqlite bearer=debug-value."
+    )
+
+
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         health_module,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -805,18 +805,22 @@ def test_healthz_returns_fallback_payload_when_service_construction_fails(monkey
     assert response.status_code == 503
     payload = response.json()
     assert payload["ready"] is False
-    assert payload["reason"] == "Local index readiness could not be inspected: OSError."
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: OSError: permission denied."
+    )
     assert payload["mcp_url"] == "https://beta.example.com/mcp"
     assert "index_uri" not in payload
 
 
 def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
-    """Return a sanitized public fallback reason when health checks raise later."""
+    """Return a diagnostic public fallback reason when health checks raise later."""
 
     class FailingHealthService:
         def check(self) -> HealthCheckResult:
             """Raise a representative unexpected health-check failure."""
-            raise RuntimeError("unexpected readiness failure")
+            raise RuntimeError(
+                "unexpected readiness failure for /tmp/policynim/index.sqlite bearer=debug-value"
+            )
 
     monkeypatch.setattr(
         mcp_module,
@@ -834,7 +838,10 @@ def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
     assert response.status_code == 503
     payload = response.json()
     assert payload["ready"] is False
-    assert payload["reason"] == ("Local index readiness could not be inspected: RuntimeError.")
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: RuntimeError: "
+        "unexpected readiness failure for /tmp/policynim/index.sqlite bearer=debug-value."
+    )
     assert payload["mcp_url"] == "https://beta.example.com/mcp"
     assert "index_uri" not in payload
 


### PR DESCRIPTION
## Summary
Improves hosted readiness failure diagnostics by preserving the underlying failure message when formatting the public health reason.

## Why
Operators need enough context to distinguish missing index state, permission failures, and unexpected runtime readiness failures during hosted startup and health probes.

## Validation
- uv run ruff check
- uv run --group test --group dev python -m pytest -q tests/test_health_service.py tests/test_mcp.py
- git diff --check