### PR TITLE
[codex] Apply weekly code audit cleanups

### DIFF
--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -33,8 +33,6 @@ class ConfigDiscovery:
 
     env_files: tuple[Path, ...]
     active_config_file: Path | None
-    user_config_file: Path
-    has_discovered_config: bool
 
 
 def standalone_paths() -> StandalonePaths:
@@ -103,8 +101,6 @@ def discover_config_files(
     return ConfigDiscovery(
         env_files=tuple(env_files),
         active_config_file=active_config_file,
-        user_config_file=standalone.config_file,
-        has_discovered_config=active_config_file is not None,
     )
 
 

--- a/src/policynim/errors.py
+++ b/src/policynim/errors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 
 class PolicyNIMError(Exception):
     """Base error for PolicyNIM."""
@@ -41,3 +43,21 @@ class RuntimeCitationLinkError(PolicyNIMError):
 
 class RuntimeEvidencePersistenceError(PolicyNIMError):
     """Raised when runtime execution evidence cannot be persisted durably."""
+
+
+def format_validation_error(label: str, exc: ValidationError) -> str:
+    """Render a stable public message from a Pydantic validation error."""
+    error = exc.errors()[0]
+    location = ".".join(str(part) for part in error["loc"]) or "request"
+    return f"{label} is invalid at {location}: {error['msg']}."
+
+
+def failure_class_from_error(exc: BaseException) -> str | None:
+    """Return the first non-empty failure_class found in an exception chain."""
+    current: BaseException | None = exc
+    while current is not None:
+        failure_class = getattr(current, "failure_class", None)
+        if isinstance(failure_class, str) and failure_class:
+            return failure_class
+        current = current.__cause__ or current.__context__
+    return None

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -25,8 +25,14 @@ from pydantic import TypeAdapter, ValidationError
 
 import policynim.config_discovery as config_discovery
 from policynim.agent_workflows import agent_workflows
-from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
+from policynim.errors import (
+    ConfigurationError,
+    MissingIndexError,
+    PolicyNIMError,
+    format_validation_error,
+)
 from policynim.interfaces.mcp import run_server
+from policynim.lifecycle import close_owned_resource
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services import (
     create_beta_auth_service,
@@ -1189,10 +1195,7 @@ def _write_cli_artifact_text(output: str, content: str) -> Path:
     return target
 
 
-def _format_validation_error(label: str, exc: ValidationError) -> str:
-    error = exc.errors()[0]
-    location = ".".join(str(part) for part in error["loc"]) or "request"
-    return f"{label} is invalid at {location}: {error['msg']}."
+_format_validation_error = format_validation_error
 
 
 def _read_json_input(input_value: str) -> object:
@@ -3064,10 +3067,7 @@ def _is_standalone_local_runtime() -> bool:
     )
 
 
-def _close_service(service: object | None) -> None:
-    close = getattr(service, "close", None)
-    if callable(close):
-        close()
+_close_service = close_owned_resource
 
 
 if __name__ == "__main__":

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -30,7 +30,10 @@ from policynim.errors import (
     InvalidPolicyDocumentError,
     PolicyNIMError,
     ProviderError,
+    failure_class_from_error,
+    format_validation_error,
 )
+from policynim.lifecycle import close_owned_resource
 from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
     BetaAuthService,
@@ -123,18 +126,6 @@ def _validate_top_k(top_k: int) -> None:
         raise ValueError(f"top_k must be between {MIN_TOP_K} and {MAX_TOP_K}.")
 
 
-def _format_validation_error(label: str, exc: ValidationError) -> str:
-    error = exc.errors()[0]
-    location = ".".join(str(part) for part in error["loc"]) or "request"
-    return f"{label} is invalid at {location}: {error['msg']}."
-
-
-def _close_service(service: object | None) -> None:
-    close = getattr(service, "close", None)
-    if callable(close):
-        close()
-
-
 def _configure_hosted_logger() -> None:
     """Emit hosted MCP telemetry as one JSON object per line."""
     logger = logging.getLogger(_HOSTED_LOGGER_NAME)
@@ -172,16 +163,6 @@ def _emit_hosted_event(
 
 def _elapsed_ms(start_time: float) -> float:
     return round((time.perf_counter() - start_time) * 1000, 2)
-
-
-def _failure_class_from_error(exc: BaseException) -> str | None:
-    current: BaseException | None = exc
-    while current is not None:
-        failure_class = getattr(current, "failure_class", None)
-        if isinstance(failure_class, str) and failure_class:
-            return failure_class
-        current = current.__cause__ or current.__context__
-    return None
 
 
 def _request_id_from_context(ctx: Context) -> str | None:
@@ -227,9 +208,9 @@ def _run_policy_preflight(
         result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
         return result.model_dump(mode="json")
     except ValidationError as exc:
-        raise ValueError(_format_validation_error("Preflight request", exc)) from exc
+        raise ValueError(format_validation_error("Preflight request", exc)) from exc
     finally:
-        _close_service(service)
+        close_owned_resource(service)
 
 
 def policy_preflight(
@@ -253,7 +234,7 @@ def _run_policy_search(
         result = service.search(SearchRequest(query=query, domain=domain, top_k=resolved_top_k))
         return result.model_dump(mode="json")
     finally:
-        _close_service(service)
+        close_owned_resource(service)
 
 
 def policy_search(
@@ -282,7 +263,7 @@ def _run_logged_tool(
             auth_result=auth_result,
             tool_name=tool_name,
             latency_ms=_elapsed_ms(start_time),
-            upstream_failure_class=_failure_class_from_error(exc),
+            upstream_failure_class=failure_class_from_error(exc),
             request_id=request_id,
         )
         raise

--- a/src/policynim/lifecycle.py
+++ b/src/policynim/lifecycle.py
@@ -1,0 +1,10 @@
+"""Shared helpers for closing optionally owned resources."""
+
+from __future__ import annotations
+
+
+def close_owned_resource(resource: object | None) -> None:
+    """Close an optional resource when it exposes a callable close hook."""
+    close = getattr(resource, "close", None)
+    if callable(close):
+        close()

--- a/src/policynim/providers/nvidia_guardrails.py
+++ b/src/policynim/providers/nvidia_guardrails.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from policynim.contracts import Generator
 from policynim.errors import ConfigurationError, ProviderError
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.providers.nvidia import NVIDIAGenerator
 from policynim.settings import Settings
 from policynim.types import (
@@ -372,12 +373,6 @@ def _ordered_unique(values: Sequence[str]) -> list[str]:
         seen.add(value)
         ordered.append(value)
     return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = ["NeMoGuardrailsPreflightGenerator"]

--- a/src/policynim/services/compiler.py
+++ b/src/policynim/services/compiler.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, PolicyCompiler, Reranker
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.services.router import PolicyRouterService, create_policy_router_service
 from policynim.settings import Settings, get_settings
 from policynim.types import (
@@ -250,12 +251,6 @@ def _ordered_unique(values: Sequence[str]) -> list[str]:
         seen.add(value)
         ordered.append(value)
     return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import PolicyConformanceEvaluator
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.types import (
     CompiledPolicyConstraint,
     EvalBackend,
@@ -310,12 +311,6 @@ def _average(values: Sequence[float]) -> float:
     if not values:
         return 0.0
     return sum(values) / len(values)
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -17,8 +17,11 @@ from tempfile import TemporaryDirectory
 from types import TracebackType
 from typing import Any, cast
 
+import httpx
+
 from policynim.contracts import Generator, IndexStore, Reranker
 from policynim.errors import PolicyNIMError
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.runtime_paths import resolve_eval_suite_path, resolve_runtime_path
 from policynim.services.compiler import PolicyCompilerService
 from policynim.services.conformance import PolicyConformanceService
@@ -1045,7 +1048,9 @@ def _publish_eval_result_to_phoenix(result: EvalRunResult, *, endpoint: str) -> 
 def _ensure_phoenix_project(client: Any, project_name: str) -> None:
     try:
         client.projects.get(project_name=project_name)
-    except Exception:
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 404:
+            raise
         client.projects.create(name=project_name)
 
 
@@ -1351,12 +1356,6 @@ def _create_live_regeneration_service(
         _close_component(generator)
         _close_component(compiler_service)
         raise
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 class _PassThroughReranker(Reranker):

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -11,6 +11,7 @@ from typing import Protocol
 
 from policynim.contracts import Embedder
 from policynim.ingest import chunk_policy_documents, load_policy_documents
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.runtime_paths import resolve_corpus_root, resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
@@ -205,10 +206,3 @@ def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> No
 def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
     """Best-effort cleanup for staged artifact files after a failed ingest."""
     staged_path.unlink(missing_ok=True)
-
-
-def _close_component(component: object | None) -> None:
-    """Close an optional owned component when it exposes a close hook."""
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Any
 
 from policynim.contracts import Embedder, Generator, IndexStore, PolicyCompiler, Reranker
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
 from policynim.services.router import PolicyRouterService
 from policynim.settings import Settings, get_settings
@@ -390,12 +391,6 @@ def _trace_step(
         summary=summary.strip() or kind,
         citation_ids=_ordered_unique(list(citation_ids)),
     )
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/regeneration.py
+++ b/src/policynim/services/regeneration.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Protocol
 
 from policynim.contracts import Generator
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.services.compiler import create_policy_compiler_service
 from policynim.services.conformance import PolicyConformanceService
 from policynim.services.evidence_trace import (
@@ -638,12 +639,6 @@ def _ordered_unique(values: Sequence[str]) -> list[str]:
         seen.add(value)
         ordered.append(value)
     return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/router.py
+++ b/src/policynim/services/router.py
@@ -9,6 +9,7 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
 from policynim.types import (
@@ -347,12 +348,6 @@ def _empty_route_result(request: RouteRequest, profile: TaskProfile) -> RouteRes
         ),
         retained_context=[],
     )
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = ["PolicyRouterService", "create_policy_router_service", "profile_task"]

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -20,7 +20,8 @@ from policynim.contracts import (
     RuntimeDecisionServiceProtocol,
     RuntimeEvidenceStoreProtocol,
 )
-from policynim.errors import RuntimeEvidencePersistenceError
+from policynim.errors import RuntimeEvidencePersistenceError, failure_class_from_error
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services.runtime_decision import create_runtime_decision_service
 from policynim.settings import Settings, get_settings
@@ -555,21 +556,8 @@ def _residual_uncertainty_for_decision(decision_result: RuntimeDecisionResult) -
     return None
 
 
-def _failure_class_from_error(exc: BaseException) -> str | None:
-    current: BaseException | None = exc
-    while current is not None:
-        failure_class = getattr(current, "failure_class", None)
-        if isinstance(failure_class, str) and failure_class:
-            return failure_class
-        current = current.__cause__ or current.__context__
-    return None
+_failure_class_from_error = failure_class_from_error
 
 
 def _elapsed_ms(start_time: float) -> float:
     return round((time.perf_counter() - start_time) * 1000, 2)
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -6,6 +6,7 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
+from policynim.lifecycle import close_owned_resource as _close_component
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
 from policynim.types import SearchRequest, SearchResult
@@ -98,9 +99,3 @@ def _create_default_search_components(settings: Settings) -> tuple[Embedder, Rer
 def _ensure_index_ready(index_store: IndexStore) -> None:
     if not index_store.exists() or index_store.count() == 0:
         raise MissingIndexError("Run `policynim ingest` before searching the policy corpus.")
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/tests/test_eval_service.py
+++ b/tests/test_eval_service.py
@@ -7,10 +7,11 @@ import sys
 import types
 from pathlib import Path
 
+import httpx
 import pytest
 
 from policynim.errors import PolicyNIMError
-from policynim.services.eval import EvalService
+from policynim.services.eval import EvalService, _ensure_phoenix_project
 from policynim.settings import Settings
 from policynim.types import (
     CompiledPolicyPacket,
@@ -452,7 +453,9 @@ def test_eval_service_publish_to_ui_logs_deterministic_spans_and_annotations(
 
     class MockPhoenixProjects:
         def get(self, *, project_name: str) -> None:
-            raise RuntimeError(f"missing project {project_name}")
+            request = httpx.Request("GET", f"http://127.0.0.1:8123/v1/projects/{project_name}")
+            response = httpx.Response(status_code=404, request=request)
+            raise httpx.HTTPStatusError("missing project", request=request, response=response)
 
         def create(self, *, name: str) -> dict[str, str]:
             return {"name": name}
@@ -513,3 +516,25 @@ def test_eval_service_publish_to_ui_surfaces_phoenix_endpoint_and_log_path(
         service.publish_to_ui(result, port=8124)
 
     assert "phoenix.log" in str(exc_info.value)
+
+
+def test_ensure_phoenix_project_reraises_non_404_errors() -> None:
+    class MockProjects:
+        def __init__(self) -> None:
+            self.create_called = False
+
+        def get(self, *, project_name: str) -> None:
+            request = httpx.Request("GET", f"http://127.0.0.1:8123/v1/projects/{project_name}")
+            response = httpx.Response(status_code=500, request=request)
+            raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+        def create(self, *, name: str) -> dict[str, str]:
+            self.create_called = True
+            return {"name": name}
+
+    client = types.SimpleNamespace(projects=MockProjects())
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _ensure_phoenix_project(client, "PolicyNIM Eval")
+
+    assert client.projects.create_called is False


### PR DESCRIPTION
## Summary
- centralize shared lifecycle and validation/failure-class helpers used by CLI, MCP, services, and providers
- remove unused `ConfigDiscovery` fields that were dead internal state
- narrow Phoenix project bootstrap handling so only a real 404 triggers project creation, with regression coverage

## Why
The weekly audit surfaced three concrete issues worth fixing in one pass:

1. identical cleanup and error-formatting helpers were copied across multiple modules, which made ownership and failure handling harder to keep consistent
2. `ConfigDiscovery` carried unused redundant fields, adding internal state that no caller consumed
3. the eval Phoenix publish path treated any project lookup failure as "project missing", which could mask server or transport failures and send debugging in the wrong direction

## Impact
This keeps the repo behavior the same for the validated paths while reducing duplicated internal contracts and making Phoenix publish failures more accurate.

## Validation
- `uv run --group test --group dev ruff check .`
- `uv run --group test --group dev pyright`
- `uv run --group test pytest -q`
