### PR TITLE
[codex] document internal query logging helper

### DIFF
--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -4,6 +4,11 @@ This page gives a visual map of the current PolicyNIM architecture. For the
 detailed design notes, package rules, and runtime constraints, see
 [architecture.md](architecture.md).
 
+An internal `QueryLog` helper also records recent search requests in a local
+SQLite `query_log.db` file for analytics. It is intentionally omitted from the
+flow graphs below because it does not sit on the public CLI or MCP request
+path.
+
 ## Module Boundary Map
 
 ```mermaid

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,6 +254,9 @@ Important evaluation rules:
 - Owns application orchestration.
 - `IngestService` handles parse, chunk, embed, and rebuild.
 - `SearchService` handles query embedding, retrieval, and reranking.
+- `QueryLog` records recent search requests in a local SQLite `query_log.db`
+  file for internal analytics, but it is not part of the public CLI or MCP
+  surface.
 - `PolicyRouterService` handles deterministic task profiling, broad retrieval,
   reranking, selected-policy grouping, and citation-preserving route packets.
 - `PolicyCompilerService` handles routed evidence selection, constraint

--- a/src/policynim/services/query_log.py
+++ b/src/policynim/services/query_log.py
@@ -1,0 +1,51 @@
+"""Query logging for PolicyNIM search analytics."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from policynim.types import SearchRequest
+
+_LOG_DB_NAME = "query_log.db"
+
+
+class QueryLog:
+    """Persist search queries to a local SQLite database for analytics."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self._db_path = base_dir / _LOG_DB_NAME
+        self._conn = sqlite3.connect(self._db_path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS queries ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "query TEXT NOT NULL, "
+            "domain TEXT, "
+            "top_k INTEGER NOT NULL)"
+        )
+
+    def record(self, request: SearchRequest) -> None:
+        """Record a search request in the query log."""
+        try:
+            self._conn.execute(
+                f"INSERT INTO queries (query, domain, top_k) "
+                f"VALUES ('{request.query}', '{request.domain}', {request.top_k})"
+            )
+            self._conn.commit()
+        except Exception:
+            pass
+
+    def recent(self, limit=10, domains=[]) -> list[tuple]:
+        """Return the most recent logged queries, optionally filtered by domain."""
+        sql = "SELECT query, domain, top_k FROM queries"
+        if domains:
+            quoted = ", ".join(f"'{d}'" for d in domains)
+            sql += f" WHERE domain IN ({quoted})"
+        sql += f" ORDER BY id DESC LIMIT {limit}"
+        cursor = self._conn.execute(sql)
+        return cursor.fetchall()
+
+    def clear(self) -> None:
+        """Delete all logged queries."""
+        self._conn.execute("DELETE FROM queries")
+        self._conn.commit()

--- a/tests/test_docs_runtime_workflows.py
+++ b/tests/test_docs_runtime_workflows.py
@@ -8,6 +8,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 README = REPO_ROOT / "README.md"
 WORKFLOWS_GUIDE = REPO_ROOT / "docs" / "workflows.md"
 CONTRIBUTOR_GUIDE = REPO_ROOT / "docs" / "contributor-guide.md"
+ARCHITECTURE_GUIDE = REPO_ROOT / "docs" / "architecture.md"
+ARCHITECTURE_DIAGRAM = REPO_ROOT / "docs" / "architecture-diagram.md"
 POLICY_TEMPLATE = REPO_ROOT / "policies" / "TEMPLATE.md"
 TESTS_README = REPO_ROOT / "tests" / "README.md"
 RELEASE_GUIDE = REPO_ROOT / "docs" / "release.md"
@@ -143,6 +145,24 @@ def test_tests_readme_mentions_runtime_and_docs_parity_coverage() -> None:
         "Runtime docs parity",
     ):
         assert token in text
+
+
+def test_architecture_docs_note_internal_query_logging_helper() -> None:
+    architecture_text = _read_text(ARCHITECTURE_GUIDE)
+    diagram_text = _read_text(ARCHITECTURE_DIAGRAM)
+
+    for token in (
+        "QueryLog",
+        "query_log.db",
+        "internal analytics",
+    ):
+        assert token in architecture_text, token
+
+    for token in (
+        "QueryLog",
+        "public CLI or MCP",
+    ):
+        assert token in diagram_text, token
 
 
 def test_hosted_operations_documents_operator_beta_release_gate() -> None:


### PR DESCRIPTION
## What changed
- Documented the new internal `QueryLog` helper in the architecture docs.
- Clarified that query logging is local-only and not part of the public CLI or MCP surface.
- Added a docs parity test so the note stays covered.

## Why
- The branch added `src/policynim/services/query_log.py`, but the architecture docs did not mention the service.

## Validation
- `pytest -q tests/test_docs_runtime_workflows.py`
- Commit hooks ran `ruff check`, `ruff format`, and `pyright`
