### PR TITLE
[codex] Pin Node 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/hosted-smoke.yml
+++ b/.github/workflows/hosted-smoke.yml
@@ -14,13 +14,13 @@ jobs:
       POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -56,7 +56,7 @@ jobs:
         run: uv build --out-dir dist
 
       - name: Upload Python distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: python-dist
           path: dist/*
@@ -67,13 +67,13 @@ jobs:
     needs: verify
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: python-dist
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -105,13 +105,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -186,7 +186,7 @@ jobs:
           Compress-Archive -Path "dist/policynim/*" -DestinationPath "artifacts/$AssetName" -Force
 
       - name: Upload standalone bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: standalone-${{ matrix.platform }}
           path: artifacts/*
@@ -202,10 +202,10 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: release-downloads
 
@@ -280,7 +280,7 @@ jobs:
       contents: read
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: python-dist
           path: dist

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -9,11 +9,41 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+NODE24_ACTION_PINS = {
+    "actions/checkout": ("93cb6efe18208431cddfb8368fd83d5badbf9bfd", "v5.0.1"),
+    "actions/setup-python": ("a309ff8b426b58ec0e2a45f0f869d46889d02405", "v6.2.0"),
+    "actions/upload-artifact": ("b7c566a772e6b6bfb58ed0dc250532a479d7789f", "v6.0.0"),
+    "actions/download-artifact": ("37930b1c2abaa49bbe596cd826c3c89aef350131", "v7.0.0"),
+    "astral-sh/setup-uv": ("37802adc94f370d6bfd71619e3f0bf239e1f3b78", "v7.6.0"),
+}
 
 
 def _read_text(path: Path) -> str:
     """Read a workflow file as UTF-8 text."""
     return path.read_text(encoding="utf-8")
+
+
+def _workflow_texts() -> list[str]:
+    """Return all workflow files that participate in the CI/release contract."""
+    return [
+        _read_text(CI_WORKFLOW),
+        _read_text(HOSTED_SMOKE_WORKFLOW),
+        _read_text(RELEASE_WORKFLOW),
+    ]
+
+
+def test_workflows_use_node24_compatible_action_pins() -> None:
+    """Lock GitHub Actions to approved commits whose action metadata runs on Node 24."""
+    combined_text = "\n".join(_workflow_texts())
+
+    assert "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" not in combined_text
+    for action_name, (expected_ref, expected_version) in NODE24_ACTION_PINS.items():
+        pattern = rf"uses: {re.escape(action_name)}@([0-9a-f]{{40}})\s+#\s+([^\n]+)"
+        matches = re.findall(pattern, combined_text)
+        assert matches, action_name
+        for actual_ref, actual_version in matches:
+            assert actual_ref == expected_ref
+            assert actual_version == expected_version
 
 
 def test_ci_pytest_gate_excludes_all_live_markers() -> None:


### PR DESCRIPTION
## Summary
- Update CI, hosted smoke, and release workflow action pins to upstream commits whose action metadata runs on Node 24.
- Keep live hosted smoke manual and secret-gated; offline CI still excludes `live` and `docker_live` markers.
- Add a workflow contract test that locks the approved Node 24-compatible action pins and rejects the insecure Node 20 opt-out env.

## Verification
- `uv run pytest -q tests/test_ci_workflows.py` -> 10 passed
- `uv lock --check` -> passed
- `uv run ruff check .` -> passed
- `uv run --group test --group dev pyright` -> 0 errors, 0 warnings, 0 informations
- `uv sync --group test --group dev` -> passed
- `uv run pytest -q -m "not live and not docker_live"` -> 582 passed, 10 deselected
- Commit hook: `ruff check`, `ruff format`, `pyright` -> passed
- Hosted PR checks: `lint`, `test`, and `GitGuardian Security Checks` passed

## Remaining risk
- The release workflow artifact upload/download path only runs on tag or manual release events, so it still needs the normal release dry run or tag-triggered verification before publishing release assets.
- Railway deploy check was still pending when this PR was opened and is outside the GitHub Actions Node runtime migration path.