### PR TITLE
[DX-1] Redact public health readiness failure details

### DIFF
--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 from policynim.contracts import IndexStore
@@ -13,6 +14,11 @@ from policynim.storage import create_index_store
 from policynim.types import HealthCheckResult
 
 LOGGER = logging.getLogger(__name__)
+_LOCAL_PATH_PATTERN = re.compile(r"(?<![\w.:])/(?:[^\s,;:'\")]+/?)+")
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"\b(api[_-]?key|token|bearer|secret|password|key)\s*[:=]\s*[^\s,;]+",
+    re.IGNORECASE,
+)
 
 
 class RuntimeHealthService:
@@ -199,10 +205,17 @@ def _single_line_message(message: str | None) -> str | None:
     """Return a compact sanitized exception message, if one is available."""
     if message is None:
         return None
-    message = " ".join(message.split()).strip().rstrip(".")
+    message = " ".join(message.split()).strip()
+    message = _redact_public_exception_message(message).rstrip(".")
     if message:
         return message
     return None
+
+
+def _redact_public_exception_message(message: str) -> str:
+    """Remove path and secret details before exposing exception text publicly."""
+    message = _LOCAL_PATH_PATTERN.sub("<local-path>", message)
+    return _SECRET_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", message)
 
 
 def _format_hosted_runtime_error(*, index_path: Path | str, table_name: str, reason: str) -> str:

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -128,6 +128,26 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
     assert "/tmp/key" not in result.reason
 
 
+def test_format_health_failure_reason_redacts_sensitive_message_parts() -> None:
+    reason = health_module.format_health_failure_reason(
+        PermissionError(
+            13,
+            "permission denied for /Users/operator/policynim/index.sqlite "
+            "with token=pnm_super_secret and api_key=nvapi-secret-value",
+            "/Users/operator/policynim/index.sqlite",
+        )
+    )
+
+    assert reason == (
+        "Local index readiness could not be inspected: PermissionError: "
+        "permission denied for <local-path> with token=[redacted] and api_key=[redacted]."
+    )
+    assert "permission denied" in reason
+    assert "/Users/operator" not in reason
+    assert "pnm_super_secret" not in reason
+    assert "nvapi-secret-value" not in reason
+
+
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         health_module,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -810,6 +810,36 @@ def test_healthz_returns_fallback_payload_when_service_construction_fails(monkey
     assert "index_uri" not in payload
 
 
+def test_healthz_redacts_sensitive_fallback_reason_parts(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp_module,
+        "create_runtime_health_service",
+        lambda settings: (_ for _ in ()).throw(
+            PermissionError(
+                13,
+                "permission denied for /tmp/policynim/index.sqlite with bearer=secret-token-value",
+                "/tmp/policynim/index.sqlite",
+            )
+        ),
+    )
+
+    app = mcp_module._build_streamable_http_app(
+        Settings.model_validate({"mcp_public_base_url": "https://beta.example.com"})
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["reason"] == (
+        "Local index readiness could not be inspected: PermissionError: "
+        "permission denied for <local-path> with bearer=[redacted]."
+    )
+    assert "/tmp/policynim" not in payload["reason"]
+    assert "secret-token-value" not in payload["reason"]
+
+
 def test_healthz_returns_fallback_payload_when_probe_fails(monkeypatch) -> None:
     """Return a sanitized public fallback reason when health checks raise later."""
 


### PR DESCRIPTION
## Summary

Demo PR for the Qodo AI code review best-practices flow. It shows how rich task intent from Jira and Confluence can be carried into a GitHub PR so review can evaluate requirement fit, repo standards, docs context, tests, and CI evidence.

This change keeps `/healthz` public and preserves the existing readiness payload shape, while sanitizing the operator-facing exception text before it can appear in a public readiness failure reason.

## Requirement Context

- Jira story: https://qodo-ai.atlassian.net/browse/DX-1
- Confluence PRD: https://qodo-ai.atlassian.net/wiki/spaces/SD/pages/65372162/PRD+Public+health+readiness+redaction+for+PolicyNIM+code+review+demo

## Acceptance Criteria Mirror

- `/healthz` remains public.
- The JSON response shape remains `status`, `ready`, `table_name`, `row_count`, `mcp_url`, and `reason`.
- Public failure reasons keep the exception class and an operator-safe summary.
- Public failure reasons do not expose raw local paths such as `/tmp/...` or `/Users/...`.
- Public failure reasons do not expose token, key, secret, password, bearer, or API-key assignment values.
- Existing simple phrases such as `permission denied` remain readable after sanitization.
- Regression tests cover the health service and MCP route behavior.

## Review Context

Please review against:

- `policies/security/secrets-redaction-and-handling.md`
- `policies/backend/config-validation-and-fail-closed.md`
- `policies/backend/backend-logging-standard.md`
- `docs/hosted-beta-operations.md`
- `tests/test_mcp.py`
- `tests/test_health_service.py`

## What Changed

- Added regression tests for public readiness redaction in the health service and hosted MCP route.
- Centralized exception-message sanitization in `src/policynim/services/health.py`.
- Redacts absolute local paths and secret-like assignment values from public readiness failure reasons.

## Validation

- `uv run ruff check`
- `uv run pyright`
- `uv run pytest -q tests/test_mcp.py tests/test_health_service.py`
- `uv run pytest -q -m "not live and not docker_live"`

## Demo Scope

This PR intentionally skips pre-PR review. The demo focus is Jira/Confluence task intent, GitHub PR context, Qodo review, CI checks, and human triage.
