### PR TITLE
[codex] Harden index readiness and CLI recovery

### DIFF
--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -78,10 +78,9 @@ def discover_config_files(
     env_files: list[Path] = []
     active_config_file: Path | None = None
 
-    if source_root is None and not is_hosted_process:
-        if standalone.config_file.is_file():
-            env_files.append(standalone.config_file)
-            active_config_file = standalone.config_file
+    if source_root is None and not is_hosted_process and standalone.config_file.is_file():
+        env_files.append(standalone.config_file)
+        active_config_file = standalone.config_file
 
     if source_root is not None and not is_hosted_process:
         checkout_env_file = source_root / ".env"

--- a/src/policynim/ingest/parser.py
+++ b/src/policynim/ingest/parser.py
@@ -728,11 +728,9 @@ def _looks_like_non_string_yaml_scalar(value: str) -> bool:
         return True
     if _NUMERIC_YAML_SCALAR_RE.match(value):
         return True
-    if (value.startswith("{") and value.endswith("}")) or (
+    return (value.startswith("{") and value.endswith("}")) or (
         value.startswith("[") and value.endswith("]")
-    ):
-        return True
-    return False
+    )
 
 
 def _frontmatter_line_number(index: int) -> int:

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -45,6 +45,10 @@ from policynim.services import (
 )
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
+from policynim.storage.index_readiness import (
+    format_index_readiness_detail,
+    inspect_index_readiness,
+)
 from policynim.types import (
     MAX_TOP_K,
     CompileRequest,
@@ -1178,13 +1182,14 @@ def _write_cli_artifact_text(output: str, content: str) -> Path:
             temp_file.write("\n")
         os.replace(temp_path, target)
     except OSError as exc:
+        cleanup_note = ""
         if temp_path is not None:
             try:
                 Path(temp_path).unlink(missing_ok=True)
-            except OSError:
-                pass
+            except OSError as cleanup_exc:
+                cleanup_note = f" Cleanup of staged file {temp_path} also failed: {cleanup_exc}."
         raise PolicyNIMError(
-            f"Could not write runtime evidence report to {target}: {exc}."
+            f"Could not write runtime evidence report to {target}: {exc}.{cleanup_note}"
         ) from exc
     return target
 
@@ -2773,7 +2778,8 @@ def _build_doctor_report() -> dict[str, object]:
 
     legacy_lancedb_alias_configured = _doctor_legacy_lancedb_alias_configured(discovery)
     index_recovery_step_added = False
-    if index_path.is_dir():
+    index_readiness = inspect_index_readiness(create_index_store(settings))
+    if index_readiness.state == "directory":
         checks.append(
             {
                 "name": "local_index_path",
@@ -2791,29 +2797,26 @@ def _build_doctor_report() -> dict[str, object]:
             )
         )
         index_recovery_step_added = True
-    elif index_path.exists():
-        if _doctor_local_index_ready(settings):
-            checks.append(
-                {
-                    "name": "local_index_path",
-                    "status": "ok",
-                    "message": "A populated local SQLite index exists.",
-                }
-            )
-        else:
-            checks.append(
-                {
-                    "name": "local_index_path",
-                    "status": "action_required",
-                    "message": (
-                        "Configured local SQLite index file is not a populated "
-                        "PolicyNIM sqlite-vec index."
-                    ),
-                }
-            )
-            next_steps.append(_doctor_ingest_next_step())
-            index_recovery_step_added = True
-    else:
+    elif index_readiness.state == "ready":
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "ok",
+                "message": "A populated local SQLite index exists.",
+            }
+        )
+    elif index_readiness.state == "unreadable":
+        detail = format_index_readiness_detail(index_readiness.error) or "PermissionError"
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": f"Configured local SQLite index file could not be read ({detail}).",
+            }
+        )
+        next_steps.append(_doctor_index_unreadable_next_step())
+        index_recovery_step_added = True
+    elif index_readiness.state == "missing":
         checks.append(
             {
                 "name": "local_index_path",
@@ -2822,6 +2825,19 @@ def _build_doctor_report() -> dict[str, object]:
             }
         )
         next_steps.append(_doctor_ingest_next_step())
+    else:
+        checks.append(
+            {
+                "name": "local_index_path",
+                "status": "action_required",
+                "message": (
+                    "Configured local SQLite index file is not a populated "
+                    "PolicyNIM sqlite-vec index."
+                ),
+            }
+        )
+        next_steps.append(_doctor_ingest_next_step())
+        index_recovery_step_added = True
 
     if runtime_rules_path.exists():
         checks.append(
@@ -2888,14 +2904,6 @@ def _doctor_ingest_next_step() -> str:
     )
 
 
-def _doctor_local_index_ready(settings: Settings) -> bool:
-    """Return whether the configured local SQLite index is ready for runtime use."""
-    try:
-        return create_index_store(settings).exists()
-    except Exception:
-        return False
-
-
 def _doctor_index_directory_next_step(*, legacy_lancedb_alias_configured: bool) -> str:
     """Return recovery guidance for SQLite index paths that point at directories."""
     if legacy_lancedb_alias_configured:
@@ -2906,6 +2914,15 @@ def _doctor_index_directory_next_step(*, legacy_lancedb_alias_configured: bool) 
         )
     return (
         "Set `POLICYNIM_INDEX_DB_PATH=data/index.sqlite3`, then run "
+        f"`{_doctor_cli_command('ingest')}`."
+    )
+
+
+def _doctor_index_unreadable_next_step() -> str:
+    """Return recovery guidance for unreadable SQLite index files."""
+    return (
+        "Fix the local SQLite index file permissions or point "
+        "`POLICYNIM_INDEX_DB_PATH` at a readable SQLite file, then run "
         f"`{_doctor_cli_command('ingest')}`."
     )
 

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -10,6 +10,11 @@ from policynim.errors import ConfigurationError
 from policynim.services.ingest import create_ingest_service
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
+from policynim.storage.index_readiness import (
+    IndexReadinessReport,
+    format_index_readiness_detail,
+    inspect_index_readiness,
+)
 from policynim.types import HealthCheckResult
 
 LOGGER = logging.getLogger(__name__)
@@ -32,26 +37,20 @@ class RuntimeHealthService:
     def check(self) -> HealthCheckResult:
         """Return a readiness payload for the hosted HTTP runtime."""
         try:
-            if not self._index_store.exists():
-                return self._not_ready(f"Local index table {self._table_name!r} does not exist.")
-
-            row_count = self._index_store.count()
-            if row_count <= 0:
-                return self._not_ready(
-                    f"Local index table {self._table_name!r} exists but contains no rows."
-                )
-
+            readiness = inspect_index_readiness(self._index_store)
+        except Exception as exc:
+            LOGGER.exception("Runtime health check failed.")
+            return self._not_ready(format_health_failure_reason(exc))
+        if readiness.state == "ready":
             return HealthCheckResult(
                 status="ok",
                 ready=True,
                 table_name=self._table_name,
-                row_count=row_count,
+                row_count=readiness.row_count,
                 mcp_url=self._mcp_url,
                 reason=None,
             )
-        except Exception as exc:
-            LOGGER.exception("Runtime health check failed.")
-            return self._not_ready(format_health_failure_reason(exc))
+        return self._not_ready(_health_not_ready_reason(readiness, table_name=self._table_name))
 
     def _not_ready(self, reason: str) -> HealthCheckResult:
         return HealthCheckResult(
@@ -184,6 +183,23 @@ def _derive_mcp_url(settings: Settings) -> str | None:
     if settings.mcp_public_base_url is None:
         return None
     return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
+
+
+def _health_not_ready_reason(readiness: IndexReadinessReport, *, table_name: str) -> str:
+    """Return a public readiness reason for one non-ready index state."""
+    if readiness.state == "missing":
+        return f"Local index table {table_name!r} does not exist."
+    if readiness.state == "empty":
+        return f"Local index table {table_name!r} exists but contains no rows."
+    if readiness.state == "directory":
+        return "Local index path points to a directory, not a SQLite file."
+    if readiness.state == "invalid":
+        return "Local index file is not a readable PolicyNIM sqlite-vec database."
+
+    detail = format_index_readiness_detail(readiness.error)
+    if detail is None:
+        return "Local index readiness could not be inspected."
+    return f"Local index readiness could not be inspected: {detail}."
 
 
 def format_health_failure_reason(exc: Exception) -> str:

--- a/src/policynim/services/router.py
+++ b/src/policynim/services/router.py
@@ -11,6 +11,11 @@ from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
+from policynim.storage.index_readiness import (
+    IndexReadinessReport,
+    format_index_readiness_detail,
+    inspect_index_readiness,
+)
 from policynim.types import (
     PolicyMetadata,
     PolicySelectionPacket,
@@ -217,8 +222,42 @@ def _create_default_router_components(settings: Settings) -> tuple[Embedder, Rer
 
 
 def _ensure_index_ready(index_store: IndexStore) -> None:
-    if not index_store.exists() or index_store.count() == 0:
-        raise MissingIndexError("Run `policynim ingest` before routing policy selection.")
+    readiness = inspect_index_readiness(index_store)
+    if readiness.state == "ready":
+        return
+    raise MissingIndexError(
+        _index_not_ready_message(
+            readiness,
+            action="routing policy selection",
+        )
+    )
+
+
+def _index_not_ready_message(readiness: IndexReadinessReport, *, action: str) -> str:
+    """Return routing guidance for a non-ready local index."""
+    if readiness.state in {"missing", "empty"}:
+        return f"Run `policynim ingest` before {action}."
+    if readiness.state == "directory":
+        return (
+            "Local SQLite index path points to a directory, not a SQLite file. "
+            "Set `POLICYNIM_INDEX_DB_PATH` to a SQLite file path, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail = format_index_readiness_detail(readiness.error)
+    if readiness.state == "unreadable":
+        detail_suffix = f" ({detail})" if detail is not None else ""
+        return (
+            f"Local SQLite index could not be read{detail_suffix}. "
+            "Fix file permissions or `POLICYNIM_INDEX_DB_PATH`, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail_suffix = f" ({detail})" if detail is not None else ""
+    return (
+        f"Local SQLite index is not a readable PolicyNIM sqlite-vec database{detail_suffix}. "
+        f"Rebuild it with `policynim ingest` before {action}."
+    )
 
 
 def _matching_signals(text: str, patterns: Sequence[_TaskPattern]) -> list[str]:

--- a/src/policynim/services/runtime_decision.py
+++ b/src/policynim/services/runtime_decision.py
@@ -22,6 +22,11 @@ from policynim.errors import (
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
+from policynim.storage.index_readiness import (
+    IndexReadinessReport,
+    format_index_readiness_detail,
+    inspect_index_readiness,
+)
 from policynim.types import (
     Citation,
     CompiledRuntimeRule,
@@ -206,8 +211,42 @@ def _load_indexed_chunk_spans(index_store: IndexStore) -> list[_IndexedChunkSpan
 
 def _ensure_index_ready(index_store: IndexStore) -> None:
     """Require a non-empty local index before runtime decisions can proceed."""
-    if not index_store.exists() or index_store.count() == 0:
-        raise MissingIndexError("Run `policynim ingest` before using runtime decisions.")
+    readiness = inspect_index_readiness(index_store)
+    if readiness.state == "ready":
+        return
+    raise MissingIndexError(
+        _index_not_ready_message(
+            readiness,
+            action="using runtime decisions",
+        )
+    )
+
+
+def _index_not_ready_message(readiness: IndexReadinessReport, *, action: str) -> str:
+    """Return runtime-decision guidance for a non-ready local index."""
+    if readiness.state in {"missing", "empty"}:
+        return f"Run `policynim ingest` before {action}."
+    if readiness.state == "directory":
+        return (
+            "Local SQLite index path points to a directory, not a SQLite file. "
+            "Set `POLICYNIM_INDEX_DB_PATH` to a SQLite file path, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail = format_index_readiness_detail(readiness.error)
+    if readiness.state == "unreadable":
+        detail_suffix = f" ({detail})" if detail is not None else ""
+        return (
+            f"Local SQLite index could not be read{detail_suffix}. "
+            "Fix file permissions or `POLICYNIM_INDEX_DB_PATH`, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail_suffix = f" ({detail})" if detail is not None else ""
+    return (
+        f"Local SQLite index is not a readable PolicyNIM sqlite-vec database{detail_suffix}. "
+        f"Rebuild it with `policynim ingest` before {action}."
+    )
 
 
 def _normalize_runtime_action(request: RuntimeActionRequest) -> _NormalizedRuntimeAction:

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -8,6 +8,11 @@ from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
+from policynim.storage.index_readiness import (
+    IndexReadinessReport,
+    format_index_readiness_detail,
+    inspect_index_readiness,
+)
 from policynim.types import SearchRequest, SearchResult
 
 _DEFAULT_RERANK_CANDIDATE_POOL = 15
@@ -96,8 +101,42 @@ def _create_default_search_components(settings: Settings) -> tuple[Embedder, Rer
 
 
 def _ensure_index_ready(index_store: IndexStore) -> None:
-    if not index_store.exists() or index_store.count() == 0:
-        raise MissingIndexError("Run `policynim ingest` before searching the policy corpus.")
+    readiness = inspect_index_readiness(index_store)
+    if readiness.state == "ready":
+        return
+    raise MissingIndexError(
+        _index_not_ready_message(
+            readiness,
+            action="searching the policy corpus",
+        )
+    )
+
+
+def _index_not_ready_message(readiness: IndexReadinessReport, *, action: str) -> str:
+    """Return retrieval guidance for a non-ready local index."""
+    if readiness.state in {"missing", "empty"}:
+        return f"Run `policynim ingest` before {action}."
+    if readiness.state == "directory":
+        return (
+            "Local SQLite index path points to a directory, not a SQLite file. "
+            "Set `POLICYNIM_INDEX_DB_PATH` to a SQLite file path, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail = format_index_readiness_detail(readiness.error)
+    if readiness.state == "unreadable":
+        detail_suffix = f" ({detail})" if detail is not None else ""
+        return (
+            f"Local SQLite index could not be read{detail_suffix}. "
+            "Fix file permissions or `POLICYNIM_INDEX_DB_PATH`, then run "
+            f"`policynim ingest` before {action}."
+        )
+
+    detail_suffix = f" ({detail})" if detail is not None else ""
+    return (
+        f"Local SQLite index is not a readable PolicyNIM sqlite-vec database{detail_suffix}. "
+        f"Rebuild it with `policynim ingest` before {action}."
+    )
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/storage/index_readiness.py
+++ b/src/policynim/storage/index_readiness.py
@@ -1,0 +1,56 @@
+"""Shared local-index readiness inspection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from policynim.contracts import IndexStore
+
+IndexReadinessState = Literal["ready", "missing", "directory", "empty", "invalid", "unreadable"]
+
+
+@dataclass(frozen=True, slots=True)
+class IndexReadinessReport:
+    """Describe whether a local index can safely serve retrieval operations."""
+
+    state: IndexReadinessState
+    row_count: int = 0
+    error: Exception | None = None
+
+
+def inspect_index_readiness(index_store: IndexStore) -> IndexReadinessReport:
+    """Return the readiness state for one index store."""
+    inspect = getattr(index_store, "inspect_readiness", None)
+    if callable(inspect):
+        report = inspect()
+        if isinstance(report, IndexReadinessReport):
+            return report
+
+    try:
+        if not index_store.exists():
+            return IndexReadinessReport(state="missing")
+        row_count = index_store.count()
+    except OSError as exc:
+        return IndexReadinessReport(state="unreadable", error=exc)
+    except Exception as exc:
+        return IndexReadinessReport(state="invalid", error=exc)
+
+    if row_count <= 0:
+        return IndexReadinessReport(state="empty")
+    return IndexReadinessReport(state="ready", row_count=row_count)
+
+
+def format_index_readiness_detail(error: Exception | None) -> str | None:
+    """Return a compact one-line error detail for operator-facing output."""
+    if error is None:
+        return None
+
+    if isinstance(error, OSError):
+        raw_message = error.strerror or str(error)
+    else:
+        raw_message = str(error)
+    message = " ".join(raw_message.split()).strip().rstrip(".")
+    if message:
+        return f"{type(error).__name__}: {message}"
+    return type(error).__name__

--- a/src/policynim/storage/sqlite_vec.py
+++ b/src/policynim/storage/sqlite_vec.py
@@ -13,6 +13,7 @@ import sqlite_vec
 
 from policynim.contracts import IndexStore
 from policynim.errors import MissingIndexError
+from policynim.storage.index_readiness import IndexReadinessReport
 from policynim.types import EmbeddedChunk, PolicyChunk, PolicyMetadata, ScoredChunk
 
 _SCHEMA_VERSION = "1"
@@ -72,25 +73,14 @@ class SQLiteVecIndexStore(IndexStore):
 
     def exists(self) -> bool:
         """Return whether the local index exists."""
-        if not self._path.exists() or self._path.is_dir():
-            return False
-        try:
-            with closing(_connect(self._path)) as conn:
-                return _has_required_schema(conn) and _count_chunks(conn) > 0
-        except (OSError, sqlite3.DatabaseError):
-            return False
+        return self.inspect_readiness().state == "ready"
 
     def count(self) -> int:
         """Return the number of rows in the local index."""
-        if not self._path.exists() or self._path.is_dir():
+        readiness = self.inspect_readiness()
+        if readiness.state != "ready":
             return 0
-        try:
-            with closing(_connect(self._path)) as conn:
-                if not _has_required_schema(conn):
-                    return 0
-                return _count_chunks(conn)
-        except (OSError, sqlite3.DatabaseError):
-            return 0
+        return readiness.row_count
 
     def list_chunks(self) -> list[PolicyChunk]:
         """Return all indexed chunks without embeddings."""
@@ -177,6 +167,27 @@ class SQLiteVecIndexStore(IndexStore):
     def reset_for_tests(self) -> None:
         """Reset the backing SQLite file and WAL sidecars for deterministic tests."""
         _cleanup_database_files(self._path)
+
+    def inspect_readiness(self) -> IndexReadinessReport:
+        """Describe whether the local SQLite index is ready for retrieval use."""
+        if not self._path.exists():
+            return IndexReadinessReport(state="missing")
+        if self._path.is_dir():
+            return IndexReadinessReport(state="directory")
+
+        try:
+            with closing(_connect(self._path)) as conn:
+                if not _has_required_schema(conn):
+                    return IndexReadinessReport(state="invalid")
+                row_count = _count_chunks(conn)
+        except OSError as exc:
+            return IndexReadinessReport(state="unreadable", error=exc)
+        except sqlite3.DatabaseError as exc:
+            return IndexReadinessReport(state="invalid", error=exc)
+
+        if row_count <= 0:
+            return IndexReadinessReport(state="empty")
+        return IndexReadinessReport(state="ready", row_count=row_count)
 
     def _require_connection(self) -> sqlite3.Connection:
         """Open a validated SQLite connection or fail with missing-index guidance."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from policynim.services.runtime_evidence_report import RuntimeEvidenceReportServ
 from policynim.services.runtime_execution import RuntimeExecutionService
 from policynim.settings import Settings, get_settings
 from policynim.storage import RuntimeEvidenceStore
+from policynim.storage.index_readiness import IndexReadinessReport
 from policynim.types import (
     BetaAccount,
     BetaAuditEvent,
@@ -1718,6 +1719,54 @@ def test_doctor_flags_invalid_sqlite_index_file(
             "and runtime rules artifact."
         )
     ]
+
+
+def test_doctor_surfaces_unreadable_sqlite_index_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Report unreadable SQLite indexes as permission/path issues, not missing data."""
+
+    class UnreadableDoctorIndexStore:
+        """Doctor-only index-store stub with an unreadable readiness state."""
+
+        def inspect_readiness(self) -> IndexReadinessReport:
+            """Return an unreadable readiness report for doctor assertions."""
+            return IndexReadinessReport(
+                state="unreadable",
+                error=PermissionError(13, "permission denied"),
+            )
+
+    checkout_root, _, _ = configure_checkout_cli_environment(monkeypatch, tmp_path)
+    runtime_rules_path = checkout_root / "data" / "runtime" / "runtime_rules.json"
+    runtime_rules_path.parent.mkdir(parents=True)
+    runtime_rules_path.write_text("{}", encoding="utf-8")
+    write_env_file(
+        checkout_root / ".env",
+        NVIDIA_API_KEY="nvapi-test-key",
+        POLICYNIM_INDEX_DB_PATH="data/index.sqlite3",
+        POLICYNIM_RUNTIME_RULES_ARTIFACT_PATH="data/runtime/runtime_rules.json",
+    )
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_index_store",
+        lambda settings: UnreadableDoctorIndexStore(),
+    )
+
+    result = runner.invoke(app, ["doctor", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    local_index_check = next(
+        check for check in payload["checks"] if check["name"] == "local_index_path"
+    )
+    assert local_index_check["status"] == "action_required"
+    assert "could not be read" in local_index_check["message"]
+    assert "PermissionError: permission denied" in local_index_check["message"]
+    assert (
+        "Fix the local SQLite index file permissions or point "
+        "`POLICYNIM_INDEX_DB_PATH` at a readable SQLite file, then run "
+        "`uv run policynim ingest`."
+    ) in payload["next_steps"]
 
 
 def test_doctor_flags_legacy_lancedb_directory_index_path(
@@ -4230,6 +4279,52 @@ def test_evidence_report_command_rejects_empty_output(
 
     assert result.exit_code == 1
     assert "must not be empty" in result.stderr
+
+
+def test_evidence_report_command_surfaces_staged_cleanup_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Include staged-file cleanup failures in the returned CLI error."""
+    service = MockRuntimeEvidenceReportService(_cli_evidence_summary())
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.create_runtime_evidence_report_service",
+        lambda settings: service,
+        raising=False,
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "policynim.interfaces.cli.os.replace",
+        lambda src, dst: (_ for _ in ()).throw(PermissionError("permission denied")),
+    )
+
+    original_unlink = Path.unlink
+
+    def fail_unlink(self: Path, *, missing_ok: bool = False) -> None:
+        """Fail staged-file cleanup to verify the surfaced CLI error text."""
+        del missing_ok
+        if self.suffix == ".tmp":
+            raise OSError("cleanup failed")
+        original_unlink(self, missing_ok=False)
+
+    monkeypatch.setattr("policynim.interfaces.cli.Path.unlink", fail_unlink)
+
+    result = runner.invoke(
+        app,
+        [
+            "evidence",
+            "report",
+            "--session-id",
+            "session-1",
+            "--output",
+            str(Path("reports") / "session-1.json"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Cleanup of staged file" in result.stderr
+    assert "cleanup failed" in result.stderr
+    assert list((tmp_path / "reports").glob("*.tmp"))
 
 
 def test_evidence_report_command_surfaces_missing_session_errors(monkeypatch) -> None:

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -10,6 +10,7 @@ from policynim.errors import ConfigurationError
 from policynim.services import health as health_module
 from policynim.services.health import RuntimeHealthService
 from policynim.settings import Settings
+from policynim.storage.index_readiness import IndexReadinessReport
 from policynim.types import HealthCheckResult
 
 
@@ -23,11 +24,13 @@ class StubIndexStore:
         row_count: int = 1,
         exists_error: Exception | None = None,
         count_error: Exception | None = None,
+        readiness: IndexReadinessReport | None = None,
     ) -> None:
         self._exists = exists
         self._row_count = row_count
         self._exists_error = exists_error
         self._count_error = count_error
+        self._readiness = readiness
 
     def replace(self, chunks) -> None:  # pragma: no cover - protocol filler for tests
         raise NotImplementedError
@@ -47,6 +50,20 @@ class StubIndexStore:
 
     def search(self, query_embedding, *, top_k: int, domain: str | None = None):  # pragma: no cover
         raise NotImplementedError
+
+    def inspect_readiness(self) -> IndexReadinessReport:
+        """Return an optional explicit readiness report for health-service tests."""
+        if self._readiness is not None:
+            return self._readiness
+        if self._exists_error is not None:
+            return IndexReadinessReport(state="unreadable", error=self._exists_error)
+        if self._count_error is not None:
+            return IndexReadinessReport(state="unreadable", error=self._count_error)
+        if not self._exists:
+            return IndexReadinessReport(state="missing")
+        if self._row_count <= 0:
+            return IndexReadinessReport(state="empty")
+        return IndexReadinessReport(state="ready", row_count=self._row_count)
 
 
 class StaticHealthService:
@@ -126,6 +143,27 @@ def test_runtime_health_service_reports_unreadable_index() -> None:
         "Local index readiness could not be inspected: PermissionError: permission denied."
     )
     assert "/tmp/key" not in result.reason
+
+
+def test_runtime_health_service_reports_invalid_database_file() -> None:
+    """Expose invalid SQLite files as invalid databases instead of missing tables."""
+    service = RuntimeHealthService(
+        index_store=StubIndexStore(
+            readiness=IndexReadinessReport(
+                state="invalid",
+                error=RuntimeError("file is not a database"),
+            )
+        ),
+        table_name="policy_chunks",
+        mcp_url=None,
+    )
+
+    result = service.check()
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.row_count == 0
+    assert result.reason == "Local index file is not a readable PolicyNIM sqlite-vec database."
 
 
 def test_ensure_hosted_runtime_ready_accepts_ready_index(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from policynim.errors import MissingIndexError
 from policynim.services.search import SearchService
+from policynim.storage.index_readiness import IndexReadinessReport
 from policynim.types import EmbeddedChunk, PolicyChunk, PolicyMetadata, ScoredChunk, SearchRequest
 
 
@@ -222,6 +223,31 @@ def test_search_service_requires_existing_index() -> None:
 
     with pytest.raises(MissingIndexError):
         service.search(SearchRequest(query="backend logs", top_k=1))
+
+
+def test_search_service_surfaces_unreadable_index_guidance() -> None:
+    """Return actionable recovery text when the local index cannot be read."""
+
+    class UnreadableIndexStore(MockIndexStore):
+        """Search-store stub that reports an unreadable backing SQLite file."""
+
+        def inspect_readiness(self) -> IndexReadinessReport:
+            """Return the unreadable local-index state for the search preflight."""
+            return IndexReadinessReport(
+                state="unreadable",
+                error=PermissionError(13, "permission denied"),
+            )
+
+    service = SearchService(
+        embedder=MockEmbedder(),
+        index_store=UnreadableIndexStore([make_chunk(chunk_id="BACKEND-1", domain="backend")]),
+        reranker=MockReranker(),
+    )
+
+    with pytest.raises(MissingIndexError, match="permission denied") as exc_info:
+        service.search(SearchRequest(query="backend logs", top_k=1))
+
+    assert "Fix file permissions" in str(exc_info.value)
 
 
 def test_search_service_close_closes_embedder_and_reranker() -> None:

--- a/tests/test_sqlite_vec.py
+++ b/tests/test_sqlite_vec.py
@@ -171,6 +171,23 @@ def test_sqlite_vec_store_rejects_directory_path_without_partial_index(tmp_path:
     assert store.exists() is False
 
 
+def test_sqlite_vec_store_inspect_readiness_reports_invalid_database_file(tmp_path: Path) -> None:
+    """Classify placeholder files as invalid SQLite indexes instead of missing ones."""
+    from policynim.storage.sqlite_vec import SQLiteVecIndexStore
+
+    index_path = tmp_path / "index.sqlite3"
+    index_path.write_text("not a sqlite database", encoding="utf-8")
+    store = SQLiteVecIndexStore(path=index_path)
+
+    readiness = store.inspect_readiness()
+
+    assert readiness.state == "invalid"
+    assert readiness.row_count == 0
+    assert readiness.error is not None
+    assert store.exists() is False
+    assert store.count() == 0
+
+
 def test_sqlite_vec_store_supports_injected_ingest_and_search_round_trip(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed
- centralized local SQLite index readiness classification so search, routing, runtime decisions, `doctor`, and hosted health checks distinguish missing, empty, unreadable, directory-backed, and invalid index states consistently
- surfaced staged temp-file cleanup failures in the CLI runtime evidence report write path instead of silently swallowing them
- applied the small control-flow cleanups that survived the repo-wide idiomatic audit

## Why
This weekly audit surfaced one cross-cutting root cause: readiness was inferred through duplicated `exists()/count()` checks that collapsed permission errors and invalid databases into generic missing-index behavior. That made CLI recovery text, hosted readiness output, and service preflight failures less actionable than they should be.

## Impact
- local commands now tell operators when the configured SQLite index is unreadable or invalid, not just "missing"
- `policynim doctor` points users at permission/path recovery when the index file exists but cannot be read
- hosted `/healthz` keeps its public fallback contract while the internal runtime health service now reports invalid index files explicitly
- runtime evidence report failures now include staged-file cleanup failures when a `.tmp` file could not be removed

## Validation
- `uv run --group test --group dev ruff check .`
- `uv run --group test --group dev pyright`
- `uv run --group test pytest -q -m "not live and not docker_live"`
- `uv run --group test pytest -q`
