### PR TITLE
[codex] Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/hosted-smoke.yml
+++ b/.github/workflows/hosted-smoke.yml
@@ -14,13 +14,13 @@ jobs:
       POLICYNIM_BETA_MCP_TOKEN: ${{ secrets.POLICYNIM_BETA_MCP_TOKEN }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -56,7 +56,7 @@ jobs:
         run: uv build --out-dir dist
 
       - name: Upload Python distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: python-dist
           path: dist/*
@@ -67,13 +67,13 @@ jobs:
     needs: verify
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: python-dist
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -105,13 +105,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -186,7 +186,7 @@ jobs:
           Compress-Archive -Path "dist/policynim/*" -DestinationPath "artifacts/$AssetName" -Force
 
       - name: Upload standalone bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: standalone-${{ matrix.platform }}
           path: artifacts/*
@@ -202,10 +202,10 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: release-downloads
 
@@ -280,7 +280,7 @@ jobs:
       contents: read
     steps:
       - name: Download Python distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: python-dist
           path: dist

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -9,11 +9,52 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 HOSTED_SMOKE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hosted-smoke.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+WORKFLOW_FILES = (CI_WORKFLOW, HOSTED_SMOKE_WORKFLOW, RELEASE_WORKFLOW)
+USES_LINE = re.compile(
+    r"uses: (?P<action>[^@\s]+)@(?P<ref>[0-9a-f]{40}|v[0-9][^\s#]*)"
+    r"(?:\s+#\s*(?P<version>v[0-9][^\s#]*))?"
+)
+NODE24_ACTION_MAJOR_COMMENTS = {
+    "actions/checkout": {"v5", "v6", "v7"},
+    "actions/setup-python": {"v6"},
+    "actions/upload-artifact": {"v6", "v7"},
+    "actions/download-artifact": {"v7", "v8"},
+    "astral-sh/setup-uv": {"v8"},
+}
 
 
 def _read_text(path: Path) -> str:
     """Read a workflow file as UTF-8 text."""
     return path.read_text(encoding="utf-8")
+
+
+def _workflow_uses(path: Path) -> list[tuple[str, str, str | None]]:
+    """Return action, ref, and version comment from workflow uses lines."""
+    return [
+        (
+            match.group("action"),
+            match.group("ref"),
+            match.group("version"),
+        )
+        for match in USES_LINE.finditer(_read_text(path))
+    ]
+
+
+def test_workflows_pin_node24_compatible_actions() -> None:
+    """Keep JavaScript actions on Node 24-capable pinned generations."""
+    for path in WORKFLOW_FILES:
+        for action, ref, version in _workflow_uses(path):
+            if action == "pypa/gh-action-pypi-publish":
+                continue
+
+            assert re.fullmatch(r"[0-9a-f]{40}", ref), (path, action, ref)
+            assert version is not None, (path, action)
+            assert version.split(".")[0] in NODE24_ACTION_MAJOR_COMMENTS[action], (
+                path,
+                action,
+                version,
+            )
+        assert "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" not in _read_text(path)
 
 
 def test_ci_pytest_gate_excludes_all_live_markers() -> None:


### PR DESCRIPTION
## Summary
- Update CI, hosted smoke, and release workflow action pins to Node 24-capable action generations while keeping SHA-pinned refs.
- Move release artifact upload/download actions to Node 24-compatible majors without changing offline verification, artifact ordering, or PyPI trusted publishing gates.
- Extend workflow contract tests to reject the Node 20 opt-out env var and require approved Node 24-compatible action generation comments.

## Verification
Reverified on 2026-07-21 against PR head `7df00675352e792344280689b98436d70760e4c1`:
- `uv sync --group test --group dev` -> success
- `uv run --group test --group dev pytest -q tests/test_ci_workflows.py` -> 10 passed
- `uv lock --check` -> success
- `uv run --group test --group dev ruff check .` -> all checks passed
- `uv run --group test --group dev pyright` -> 0 errors, 0 warnings, 0 informations
- `uv run --group test --group dev pytest -q -m "not live and not docker_live"` -> 582 passed, 10 deselected
- `gh pr checks 83` -> lint, test, GitGuardian, and Railway status all passing

Also rechecked upstream action metadata: the pinned checkout, setup-uv, setup-python, upload-artifact, and download-artifact refs report `runs.using: node24`; the PyPI publisher tag reports `composite` and remains covered as a repo-approved action.

## Remaining Risk
- Local checks validate workflow contracts but do not execute GitHub-hosted release artifact jobs; final upload/download behavior still needs the normal tag or manual release workflow path.
- Pyright emitted only a version availability notice (`v1.1.409 -> v1.1.411`); the repo remains on its locked toolchain for deterministic validation.