### PR TITLE
chore: apply weekly code audit cleanup

### DIFF
--- a/src/policynim/config_discovery.py
+++ b/src/policynim/config_discovery.py
@@ -230,7 +230,7 @@ def find_source_checkout_root(*, cwd: Path | None = None) -> Path | None:
             if resolved in seen:
                 continue
             seen.add(resolved)
-            if _looks_like_source_checkout(resolved):
+            if looks_like_source_checkout(resolved):
                 return resolved
 
     return None
@@ -305,5 +305,6 @@ def _quote_env_value(value: str) -> str:
     return f"'{escaped}'"
 
 
-def _looks_like_source_checkout(path: Path) -> bool:
+def looks_like_source_checkout(path: Path) -> bool:
+    """Return whether a path has the expected PolicyNIM checkout shape."""
     return (path / "pyproject.toml").is_file() and (path / "src" / "policynim").is_dir()

--- a/src/policynim/errors.py
+++ b/src/policynim/errors.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from time import perf_counter
+
+from pydantic import ValidationError
+
 
 class PolicyNIMError(Exception):
     """Base error for PolicyNIM."""
@@ -41,3 +45,31 @@ class RuntimeCitationLinkError(PolicyNIMError):
 
 class RuntimeEvidencePersistenceError(PolicyNIMError):
     """Raised when runtime execution evidence cannot be persisted durably."""
+
+
+def format_validation_error(
+    label: str,
+    exc: ValidationError,
+    *,
+    location_fallback: str = "request",
+) -> str:
+    """Render the first Pydantic validation error in the CLI/MCP house style."""
+    error = exc.errors()[0]
+    location = ".".join(str(part) for part in error["loc"]) or location_fallback
+    return f"{label} is invalid at {location}: {error['msg']}."
+
+
+def find_failure_class(exc: BaseException) -> str | None:
+    """Walk chained exceptions until a populated failure class is found."""
+    current: BaseException | None = exc
+    while current is not None:
+        failure_class = getattr(current, "failure_class", None)
+        if isinstance(failure_class, str) and failure_class:
+            return failure_class
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def elapsed_ms(start_time: float) -> float:
+    """Return elapsed milliseconds rounded for structured output."""
+    return round((perf_counter() - start_time) * 1000, 2)

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -25,7 +25,12 @@ from pydantic import TypeAdapter, ValidationError
 
 import policynim.config_discovery as config_discovery
 from policynim.agent_workflows import agent_workflows
-from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
+from policynim.errors import (
+    ConfigurationError,
+    MissingIndexError,
+    PolicyNIMError,
+    format_validation_error,
+)
 from policynim.interfaces.mcp import run_server
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services import (
@@ -392,7 +397,7 @@ def preflight(
             else:
                 result = preflight_service.preflight(request)
     except ValidationError as exc:
-        _exit_with_error(_format_validation_error("Preflight request", exc))
+        _exit_with_error(format_validation_error("Preflight request", exc))
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
@@ -484,7 +489,7 @@ def route(
         service = create_policy_router_service(settings)
         result = service.route(request)
     except ValidationError as exc:
-        _exit_with_error(_format_validation_error("Route request", exc))
+        _exit_with_error(format_validation_error("Route request", exc))
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     except ValueError as exc:
@@ -539,7 +544,7 @@ def compile(
         service = create_policy_compiler_service(settings)
         result = service.compile(request)
     except ValidationError as exc:
-        _exit_with_error(_format_validation_error("Compile request", exc))
+        _exit_with_error(format_validation_error("Compile request", exc))
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     except ValueError as exc:
@@ -1189,12 +1194,6 @@ def _write_cli_artifact_text(output: str, content: str) -> Path:
     return target
 
 
-def _format_validation_error(label: str, exc: ValidationError) -> str:
-    error = exc.errors()[0]
-    location = ".".join(str(part) for part in error["loc"]) or "request"
-    return f"{label} is invalid at {location}: {error['msg']}."
-
-
 def _read_json_input(input_value: str) -> object:
     source_label = _describe_runtime_input_source(input_value)
     try:
@@ -1229,7 +1228,7 @@ def _load_runtime_request_payload(input_value: str) -> RuntimeActionRequest:
     try:
         return _RUNTIME_REQUEST_ADAPTER.validate_python(payload)
     except ValidationError as exc:
-        raise PolicyNIMError(_format_validation_error("Runtime input", exc)) from exc
+        raise PolicyNIMError(format_validation_error("Runtime input", exc)) from exc
 
 
 def _build_cli_confirmer():
@@ -1294,7 +1293,7 @@ def _build_quickstart_payload(
 ) -> dict[str, object]:
     """Build offline first-run guidance for the requested workflow target."""
     normalized_hosted_url = _normalize_hosted_mcp_url(
-        _normalize_quickstart_value(hosted_url, label="Hosted MCP URL")
+        _normalize_required_cli_value(hosted_url, label="Hosted MCP URL")
     )
     normalized_token_env_var = _normalize_env_var_name(bearer_token_env_var)
 
@@ -1649,7 +1648,7 @@ def _build_mcp_config_payload(
         bearer_token_env_var=bearer_token_env_var,
         uv_command=uv_command,
     )
-    normalized_server_name = _normalize_mcp_config_value(
+    normalized_server_name = _normalize_required_cli_value(
         server_name,
         label="MCP server name",
     )
@@ -1778,7 +1777,7 @@ def _resolve_local_mcp_launch(
             ],
         }
 
-    normalized_uv_command = _normalize_mcp_config_value(uv_command, label="uv command")
+    normalized_uv_command = _normalize_required_cli_value(uv_command, label="uv command")
     return {
         "mode": "source-checkout",
         "command": normalized_uv_command,
@@ -1912,7 +1911,7 @@ def _resolve_mcp_config_repo_root(repo_root: Path | None) -> Path | None:
     else:
         candidate = repo_root
     resolved = candidate.expanduser().resolve(strict=False)
-    if not _looks_like_policynim_checkout(resolved):
+    if not config_discovery.looks_like_source_checkout(resolved):
         raise PolicyNIMError(
             "--repo-root must point to a PolicyNIM source checkout. "
             "Omit --repo-root to launch the installed CLI."
@@ -1920,13 +1919,8 @@ def _resolve_mcp_config_repo_root(repo_root: Path | None) -> Path | None:
     return resolved
 
 
-def _looks_like_policynim_checkout(path: Path) -> bool:
-    """Return whether a path has the expected PolicyNIM checkout shape."""
-    return (path / "pyproject.toml").is_file() and (path / "src" / "policynim").is_dir()
-
-
-def _normalize_mcp_config_value(value: str, *, label: str) -> str:
-    """Trim and validate a required MCP config string value."""
+def _normalize_required_cli_value(value: str, *, label: str) -> str:
+    """Trim and validate a required CLI string value."""
     stripped = value.strip()
     if not stripped:
         raise PolicyNIMError(f"{label} cannot be empty.")
@@ -1961,14 +1955,6 @@ def _normalize_env_var_name(value: str) -> str:
         raise PolicyNIMError(
             "Bearer token env var must contain only letters, numbers, and underscores."
         )
-    return stripped
-
-
-def _normalize_quickstart_value(value: str, *, label: str) -> str:
-    """Trim and validate a required quickstart string value."""
-    stripped = value.strip()
-    if not stripped:
-        raise PolicyNIMError(f"{label} cannot be empty.")
     return stripped
 
 

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -30,6 +30,9 @@ from policynim.errors import (
     InvalidPolicyDocumentError,
     PolicyNIMError,
     ProviderError,
+    elapsed_ms,
+    find_failure_class,
+    format_validation_error,
 )
 from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
@@ -123,12 +126,6 @@ def _validate_top_k(top_k: int) -> None:
         raise ValueError(f"top_k must be between {MIN_TOP_K} and {MAX_TOP_K}.")
 
 
-def _format_validation_error(label: str, exc: ValidationError) -> str:
-    error = exc.errors()[0]
-    location = ".".join(str(part) for part in error["loc"]) or "request"
-    return f"{label} is invalid at {location}: {error['msg']}."
-
-
 def _close_service(service: object | None) -> None:
     close = getattr(service, "close", None)
     if callable(close):
@@ -168,20 +165,6 @@ def _emit_hosted_event(
         "request_id": request_id,
     }
     logging.getLogger(_HOSTED_LOGGER_NAME).info(json.dumps(payload, sort_keys=True))
-
-
-def _elapsed_ms(start_time: float) -> float:
-    return round((time.perf_counter() - start_time) * 1000, 2)
-
-
-def _failure_class_from_error(exc: BaseException) -> str | None:
-    current: BaseException | None = exc
-    while current is not None:
-        failure_class = getattr(current, "failure_class", None)
-        if isinstance(failure_class, str) and failure_class:
-            return failure_class
-        current = current.__cause__ or current.__context__
-    return None
 
 
 def _request_id_from_context(ctx: Context) -> str | None:
@@ -227,7 +210,7 @@ def _run_policy_preflight(
         result = service.preflight(PreflightRequest(task=task, domain=domain, top_k=resolved_top_k))
         return result.model_dump(mode="json")
     except ValidationError as exc:
-        raise ValueError(_format_validation_error("Preflight request", exc)) from exc
+        raise ValueError(format_validation_error("Preflight request", exc)) from exc
     finally:
         _close_service(service)
 
@@ -281,8 +264,8 @@ def _run_logged_tool(
             "mcp.tool",
             auth_result=auth_result,
             tool_name=tool_name,
-            latency_ms=_elapsed_ms(start_time),
-            upstream_failure_class=_failure_class_from_error(exc),
+            latency_ms=elapsed_ms(start_time),
+            upstream_failure_class=find_failure_class(exc),
             request_id=request_id,
         )
         raise
@@ -291,7 +274,7 @@ def _run_logged_tool(
         "mcp.tool",
         auth_result=auth_result,
         tool_name=tool_name,
-        latency_ms=_elapsed_ms(start_time),
+        latency_ms=elapsed_ms(start_time),
         upstream_failure_class=None,
         request_id=request_id,
     )

--- a/src/policynim/iterables.py
+++ b/src/policynim/iterables.py
@@ -1,0 +1,17 @@
+"""Focused iterable helpers shared across PolicyNIM modules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def ordered_unique(values: Iterable[str]) -> list[str]:
+    """Keep first-seen string order while dropping duplicates."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -23,6 +23,7 @@ from pydantic import ValidationError
 
 from policynim.contracts import Embedder, Generator, Reranker
 from policynim.errors import ConfigurationError, ProviderError
+from policynim.iterables import ordered_unique
 from policynim.settings import Settings
 from policynim.types import (
     CompiledPolicyConstraint,
@@ -1082,18 +1083,7 @@ def _allowed_policy_conformance_chunk_ids(
     trace_chunk_ids = [
         citation_id for step in request.trace_steps for citation_id in step.citation_ids
     ]
-    return _ordered_unique([*constraint_chunk_ids, *result_chunk_ids, *trace_chunk_ids])
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
+    return ordered_unique([*constraint_chunk_ids, *result_chunk_ids, *trace_chunk_ids])
 
 
 def _parse_json_object_response(content: str, *, operation: str) -> dict[str, Any]:

--- a/src/policynim/providers/nvidia_guardrails.py
+++ b/src/policynim/providers/nvidia_guardrails.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from policynim.contracts import Generator
 from policynim.errors import ConfigurationError, ProviderError
+from policynim.iterables import ordered_unique
 from policynim.providers.nvidia import NVIDIAGenerator
 from policynim.settings import Settings
 from policynim.types import (
@@ -312,7 +313,7 @@ def _validate_guardrailed_draft(
     if unsupported_citation_ids:
         raise ProviderError(
             "NeMo Guardrails output rails returned unsupported citation ids: "
-            f"{', '.join(_ordered_unique(unsupported_citation_ids))}.",
+            f"{', '.join(ordered_unique(unsupported_citation_ids))}.",
             failure_class="invalid_response",
         )
 
@@ -328,13 +329,13 @@ def _validate_guardrailed_draft(
     if unsupported_trigger_chunk_ids:
         raise ProviderError(
             "Regeneration context referenced chunk ids outside the retained context: "
-            f"{', '.join(_ordered_unique(unsupported_trigger_chunk_ids))}.",
+            f"{', '.join(ordered_unique(unsupported_trigger_chunk_ids))}.",
             failure_class="invalid_response",
         )
 
 
 def _draft_citation_ids(draft: GeneratedPreflightDraft) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [
             *draft.citation_ids,
             *[
@@ -361,17 +362,6 @@ def _rail_result_content(result: Any) -> Any:
     if isinstance(result, Mapping):
         return result.get("content")
     return getattr(result, "content", None)
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/services/compiler.py
+++ b/src/policynim/services/compiler.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, PolicyCompiler, Reranker
+from policynim.iterables import ordered_unique
 from policynim.services.router import PolicyRouterService, create_policy_router_service
 from policynim.settings import Settings, get_settings
 from policynim.types import (
@@ -156,7 +157,7 @@ def _materialize_compiled_packet(
     if not all_constraints:
         return _insufficient_packet_from_selection(selection_packet)
 
-    citation_ids = _ordered_unique(
+    citation_ids = ordered_unique(
         [citation_id for constraint in all_constraints for citation_id in constraint.citation_ids]
     )
     citations = [_citation_from_chunk(context_by_id[citation_id]) for citation_id in citation_ids]
@@ -188,7 +189,7 @@ def _compile_constraint_list(
     compiled_constraints: list[CompiledPolicyConstraint] = []
     for generated_constraint in generated_constraints:
         statement = generated_constraint.statement.strip()
-        citation_ids = _ordered_unique(
+        citation_ids = ordered_unique(
             [citation_id.strip() for citation_id in generated_constraint.citation_ids]
         )
         if not statement or not citation_ids:
@@ -196,7 +197,7 @@ def _compile_constraint_list(
         if any(citation_id not in context_by_id for citation_id in citation_ids):
             return None
 
-        source_policy_ids = _ordered_unique(
+        source_policy_ids = ordered_unique(
             [context_by_id[citation_id].policy.policy_id for citation_id in citation_ids]
         )
         compiled_constraints.append(
@@ -239,17 +240,6 @@ def _citation_from_chunk(chunk: ScoredChunk) -> Citation:
         lines=chunk.lines,
         chunk_id=chunk.chunk_id,
     )
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import PolicyConformanceEvaluator
+from policynim.iterables import ordered_unique
 from policynim.types import (
     CompiledPolicyConstraint,
     EvalBackend,
@@ -201,7 +202,7 @@ def _forbidden_pattern_metric(
 def _citation_support_metric(
     request: PolicyConformanceRequest,
 ) -> PolicyConformanceMetric:
-    expected_chunk_ids = _ordered_unique(
+    expected_chunk_ids = ordered_unique(
         [
             citation_id
             for constraints in (
@@ -215,7 +216,7 @@ def _citation_support_metric(
             for citation_id in constraint.citation_ids
         ]
     )
-    actual_chunk_ids = _ordered_unique([citation.chunk_id for citation in request.result.citations])
+    actual_chunk_ids = ordered_unique([citation.chunk_id for citation in request.result.citations])
     if not expected_chunk_ids:
         return PolicyConformanceMetric(
             name="citation_support",
@@ -293,17 +294,6 @@ def _contains_statement(statement: str, texts: Sequence[str]) -> bool:
 
 def _normalize_for_matching(value: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", value.lower())).strip()
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 def _average(values: Sequence[float]) -> float:

--- a/src/policynim/services/evidence_trace.py
+++ b/src/policynim/services/evidence_trace.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections.abc import Sequence
 
+from policynim.iterables import ordered_unique
 from policynim.types import (
     CompiledPolicyConstraint,
     CompiledPolicyPacket,
@@ -107,7 +108,7 @@ def _trace_policies(compiled_packet: CompiledPolicyPacket) -> list[PolicyEvidenc
             policy_id=policy.policy_id,
             title=policy.title,
             reason=policy.reason,
-            supporting_chunk_ids=_ordered_unique(
+            supporting_chunk_ids=ordered_unique(
                 [evidence.chunk_id for evidence in policy.evidence]
             ),
         )
@@ -188,7 +189,7 @@ def _trace_text_outputs(
                 index=index,
                 text=text,
                 constraint_ids=[constraint.constraint_id for constraint in linked_constraints],
-                chunk_ids=_ordered_unique(
+                chunk_ids=ordered_unique(
                     [
                         chunk_id
                         for constraint in linked_constraints
@@ -209,7 +210,7 @@ def _trace_conformance_checks(
 
     constraints_by_category = _constraints_by_category(constraints)
     all_constraint_ids = [constraint.constraint_id for constraint in constraints]
-    all_chunk_ids = _ordered_unique(
+    all_chunk_ids = ordered_unique(
         [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
     )
     checks: list[PolicyEvidenceTraceConformanceCheck] = []
@@ -330,20 +331,9 @@ def _metric_chunk_ids(
         constraints = constraints_by_category["forbidden_patterns"]
     else:
         constraints = []
-    return _ordered_unique(
+    return ordered_unique(
         [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
     )
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 __all__ = [

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Any
 
 from policynim.contracts import Embedder, Generator, IndexStore, PolicyCompiler, Reranker
+from policynim.iterables import ordered_unique
 from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
 from policynim.services.router import PolicyRouterService
 from policynim.settings import Settings, get_settings
@@ -248,7 +249,7 @@ def _validate_and_materialize_result(
     if not context_by_id:
         return None
 
-    citation_ids = _ordered_unique(
+    citation_ids = ordered_unique(
         draft.citation_ids
         or [
             citation_id
@@ -263,7 +264,7 @@ def _validate_and_materialize_result(
 
     applicable_policies: list[PolicyGuidance] = []
     for policy in draft.applicable_policies:
-        policy_citation_ids = _ordered_unique(policy.citation_ids)
+        policy_citation_ids = ordered_unique(policy.citation_ids)
         if not policy_citation_ids:
             continue
         if any(citation_id not in context_by_id for citation_id in policy_citation_ids):
@@ -323,17 +324,6 @@ def _insufficient_context_result(request: PreflightRequest) -> PreflightResult:
     )
 
 
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
 def _apply_compiled_packet_to_draft(
     draft: GeneratedPreflightDraft,
     compiled_packet: CompiledPolicyPacket,
@@ -360,13 +350,13 @@ def _apply_compiled_packet_to_draft(
 
     return draft.model_copy(
         update={
-            "plan_steps": _ordered_unique([*compiled_plan_steps, *draft.plan_steps]),
-            "implementation_guidance": _ordered_unique(
+            "plan_steps": ordered_unique([*compiled_plan_steps, *draft.plan_steps]),
+            "implementation_guidance": ordered_unique(
                 [*compiled_guidance, *draft.implementation_guidance]
             ),
-            "review_flags": _ordered_unique([*compiled_review_flags, *draft.review_flags]),
-            "tests_required": _ordered_unique([*compiled_tests, *draft.tests_required]),
-            "citation_ids": _ordered_unique([*draft_citation_ids, *compiled_citation_ids]),
+            "review_flags": ordered_unique([*compiled_review_flags, *draft.review_flags]),
+            "tests_required": ordered_unique([*compiled_tests, *draft.tests_required]),
+            "citation_ids": ordered_unique([*draft_citation_ids, *compiled_citation_ids]),
         }
     )
 
@@ -388,7 +378,7 @@ def _trace_step(
         step_id=step_id,
         kind=kind,
         summary=summary.strip() or kind,
-        citation_ids=_ordered_unique(list(citation_ids)),
+        citation_ids=ordered_unique(list(citation_ids)),
     )
 
 

--- a/src/policynim/services/regeneration.py
+++ b/src/policynim/services/regeneration.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import Protocol
 
 from policynim.contracts import Generator
+from policynim.iterables import ordered_unique
 from policynim.services.compiler import create_policy_compiler_service
 from policynim.services.conformance import PolicyConformanceService
 from policynim.services.evidence_trace import (
@@ -580,7 +581,7 @@ def _all_constraint_ids(compiled_packet: CompiledPolicyPacket) -> list[str]:
 
 
 def _all_constraint_chunk_ids(compiled_packet: CompiledPolicyPacket) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [
             citation_id
             for _category_name, constraints in _constraint_categories(compiled_packet)
@@ -605,7 +606,7 @@ def _constraint_categories(
 def _constraint_chunk_ids(
     constraints: Sequence[CompiledPolicyConstraint],
 ) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [citation_id for constraint in constraints for citation_id in constraint.citation_ids]
     )
 
@@ -627,17 +628,6 @@ def _dedupe_triggers(triggers: Sequence[RegenerationTrigger]) -> list[Regenerati
         seen.add(key)
         deduped.append(trigger)
     return deduped
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/services/runtime_decision.py
+++ b/src/policynim/services/runtime_decision.py
@@ -18,7 +18,9 @@ from policynim.errors import (
     RuntimeCitationLinkError,
     RuntimeRulesArtifactInvalidError,
     RuntimeRulesArtifactMissingError,
+    format_validation_error,
 )
+from policynim.iterables import ordered_unique
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
@@ -158,10 +160,13 @@ def _load_runtime_rules_artifact(artifact_path: Path) -> RuntimeRulesArtifact:
     try:
         return RuntimeRulesArtifact.model_validate(payload)
     except ValidationError as exc:
-        error = exc.errors()[0]
-        location = ".".join(str(part) for part in error["loc"]) or "artifact"
         raise RuntimeRulesArtifactInvalidError(
-            f"Runtime rules artifact at {artifact_path} is invalid at {location}: {error['msg']}. "
+            format_validation_error(
+                f"Runtime rules artifact at {artifact_path}",
+                exc,
+                location_fallback="artifact",
+            )
+            + " "
             "Run `policynim ingest` to rebuild the runtime rules artifact."
         ) from exc
 
@@ -253,7 +258,7 @@ def _normalize_file_write_paths(request: FileWriteActionRequest) -> tuple[str, .
 
     candidate_paths.append(lexical_target.as_posix())
     candidate_paths.append(resolved_target.as_posix())
-    return tuple(_ordered_unique(candidate_paths))
+    return tuple(ordered_unique(candidate_paths))
 
 
 def _resolve_from_base(path: Path, *, base: Path) -> Path:
@@ -298,18 +303,6 @@ def _relative_posix_path(path: Path, *, root: Path) -> str | None:
         return path.relative_to(root).as_posix()
     except ValueError:
         return None
-
-
-def _ordered_unique(values: list[str]) -> list[str]:
-    """Keep first-seen string order while dropping duplicates."""
-    ordered: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        if value in seen:
-            continue
-        ordered.append(value)
-        seen.add(value)
-    return ordered
 
 
 def _rule_matches(

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -20,7 +20,7 @@ from policynim.contracts import (
     RuntimeDecisionServiceProtocol,
     RuntimeEvidenceStoreProtocol,
 )
-from policynim.errors import RuntimeEvidencePersistenceError
+from policynim.errors import RuntimeEvidencePersistenceError, elapsed_ms, find_failure_class
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services.runtime_decision import create_runtime_decision_service
 from policynim.settings import Settings, get_settings
@@ -269,7 +269,7 @@ def _run_confirmation(
     try:
         accepted = bool(confirmer(decision_result))
     except Exception as exc:
-        return "unavailable", _failure_class_from_error(exc) or "confirmation_error"
+        return "unavailable", find_failure_class(exc) or "confirmation_error"
     if not accepted:
         return "refused", None
     return "confirmed", None
@@ -309,7 +309,7 @@ def _run_shell_command(
             succeeded=False,
             metadata=ShellCommandExecutionMetadata(
                 exit_code=None,
-                duration_ms=_elapsed_ms(start),
+                duration_ms=elapsed_ms(start),
             ),
             failure_class="timeout",
         )
@@ -321,7 +321,7 @@ def _run_shell_command(
         )
     metadata = ShellCommandExecutionMetadata(
         exit_code=completed.returncode,
-        duration_ms=_elapsed_ms(start),
+        duration_ms=elapsed_ms(start),
     )
     if completed.returncode != 0:
         return _ActionExecutionResult(
@@ -391,7 +391,7 @@ def _run_http_request(
             succeeded=False,
             metadata=HTTPRequestExecutionMetadata(
                 status_code=None,
-                duration_ms=_elapsed_ms(start),
+                duration_ms=elapsed_ms(start),
             ),
             failure_class="timeout",
         )
@@ -400,7 +400,7 @@ def _run_http_request(
             succeeded=False,
             metadata=HTTPRequestExecutionMetadata(
                 status_code=None,
-                duration_ms=_elapsed_ms(start),
+                duration_ms=elapsed_ms(start),
             ),
             failure_class="connection",
         )
@@ -409,14 +409,14 @@ def _run_http_request(
             succeeded=False,
             metadata=HTTPRequestExecutionMetadata(
                 status_code=None,
-                duration_ms=_elapsed_ms(start),
+                duration_ms=elapsed_ms(start),
             ),
             failure_class="unexpected",
         )
 
     metadata = HTTPRequestExecutionMetadata(
         status_code=response.status_code,
-        duration_ms=_elapsed_ms(start),
+        duration_ms=elapsed_ms(start),
     )
     if response.status_code >= 400:
         return _ActionExecutionResult(
@@ -553,20 +553,6 @@ def _residual_uncertainty_for_decision(decision_result: RuntimeDecisionResult) -
     if decision_result.decision == "confirm":
         return "Execution required explicit confirmation before side effects."
     return None
-
-
-def _failure_class_from_error(exc: BaseException) -> str | None:
-    current: BaseException | None = exc
-    while current is not None:
-        failure_class = getattr(current, "failure_class", None)
-        if isinstance(failure_class, str) and failure_class:
-            return failure_class
-        current = current.__cause__ or current.__context__
-    return None
-
-
-def _elapsed_ms(start_time: float) -> float:
-    return round((time.perf_counter() - start_time) * 1000, 2)
 
 
 def _close_component(component: object | None) -> None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from time import perf_counter
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from policynim.errors import PolicyNIMError, elapsed_ms, find_failure_class, format_validation_error
+
+
+class _Payload(BaseModel):
+    task: str
+
+
+def test_format_validation_error_uses_first_location() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        _Payload.model_validate({})
+
+    message = format_validation_error("Preflight request", excinfo.value)
+
+    assert message.startswith("Preflight request is invalid at task:")
+
+
+def test_find_failure_class_walks_exception_causes() -> None:
+    try:
+        raise PolicyNIMError("upstream timeout", failure_class="timeout")
+    except PolicyNIMError as exc:
+        try:
+            raise RuntimeError("wrapper") from exc
+        except RuntimeError as wrapper:
+            assert find_failure_class(wrapper) == "timeout"
+
+
+def test_elapsed_ms_returns_non_negative_float() -> None:
+    value = elapsed_ms(perf_counter())
+
+    assert isinstance(value, float)
+    assert value >= 0.0

--- a/tests/test_iterables.py
+++ b/tests/test_iterables.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from policynim.iterables import ordered_unique
+
+
+def test_ordered_unique_preserves_first_seen_order() -> None:
+    assert ordered_unique(["alpha", "beta", "alpha", "", "beta", "gamma"]) == [
+        "alpha",
+        "beta",
+        "",
+        "gamma",
+    ]


### PR DESCRIPTION
## Summary
- consolidate repeated ordered-dedup helpers into a shared `policynim.iterables.ordered_unique` seam
- centralize validation-error, failure-class, and elapsed-time helpers in `policynim.errors`
- remove duplicate checkout-shape and required CLI value helpers, and add focused tests for the shared helpers

## Audit Findings Addressed
- `audit-abstractions` / `audit-dead-code` / `audit-drift`: the same ordered-unique logic was reimplemented across services and providers
- `audit-errors` / `audit-drift`: validation formatting and chained failure-class lookup had drift-prone duplicate implementations across CLI, MCP, and runtime execution paths
- `audit-boundaries` / `audit-names`: CLI checkout detection and required-value normalization duplicated config and validation logic unnecessarily

## Validation
- `uv run --group test --group dev ruff check .`
- `uv run --group test --group dev pyright`
- `uv run --group test pytest -q`
