### PR TITLE
Weekly audit: consolidate shared helper seams

### DIFF
--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -27,6 +27,7 @@ import policynim.config_discovery as config_discovery
 from policynim.agent_workflows import agent_workflows
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
+from policynim.lifecycle import close_if_supported
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services import (
     create_beta_auth_service,
@@ -266,7 +267,7 @@ def ingest() -> None:
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(f"Indexed {result.chunk_count} chunks from {result.document_count} documents.")
     typer.echo(f"Model: {result.embedding_model}")
@@ -298,7 +299,7 @@ def dump_index(
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(f"Indexed chunks: {len(chunks)}")
     if count_only:
@@ -398,7 +399,7 @@ def preflight(
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.model_dump_json(indent=2))
 
@@ -435,7 +436,7 @@ def search(
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.model_dump_json(indent=2))
 
@@ -490,7 +491,7 @@ def route(
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.packet.model_dump_json(indent=2))
 
@@ -545,7 +546,7 @@ def compile(
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.packet.model_dump_json(indent=2))
 
@@ -569,7 +570,7 @@ def runtime_decide(
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.model_dump_json(indent=2))
 
@@ -596,7 +597,7 @@ def runtime_execute(
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(result.model_dump_json(indent=2))
     exit_code = _exit_code_for_runtime_execution(result.execution_outcome)
@@ -641,7 +642,7 @@ def evidence_report(
     except PolicyNIMError as exc:
         _exit_with_error(_cli_error_message(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     if output is not None and written_path is not None:
         typer.echo(f"Wrote runtime evidence report to {written_path}.")
@@ -714,7 +715,7 @@ def eval(
     except ValueError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     if any(run.metrics.passed_count != run.metrics.case_count for run in result.runs):
         raise typer.Exit(code=1)
@@ -954,7 +955,7 @@ def beta_admin_list_accounts() -> None:
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(
         json.dumps(
@@ -979,7 +980,7 @@ def beta_admin_suspend(
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(account.model_dump_json(indent=2))
 
@@ -999,7 +1000,7 @@ def beta_admin_resume(
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(account.model_dump_json(indent=2))
 
@@ -1019,7 +1020,7 @@ def beta_admin_revoke_key(
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(account.model_dump_json(indent=2))
 
@@ -1051,7 +1052,7 @@ def beta_admin_audit_log(
     except PolicyNIMError as exc:
         _exit_with_error(str(exc))
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
     typer.echo(json.dumps([event.model_dump(mode="json") for event in events], indent=2))
 
@@ -2890,10 +2891,7 @@ def _doctor_ingest_next_step() -> str:
 
 def _doctor_local_index_ready(settings: Settings) -> bool:
     """Return whether the configured local SQLite index is ready for runtime use."""
-    try:
-        return create_index_store(settings).exists()
-    except Exception:
-        return False
+    return create_index_store(settings).exists()
 
 
 def _doctor_index_directory_next_step(*, legacy_lancedb_alias_configured: bool) -> str:
@@ -3062,12 +3060,6 @@ def _is_standalone_local_runtime() -> bool:
         not config_discovery.is_source_checkout()
         and not config_discovery.is_hosted_process_environment()
     )
-
-
-def _close_service(service: object | None) -> None:
-    close = getattr(service, "close", None)
-    if callable(close):
-        close()
 
 
 if __name__ == "__main__":

--- a/src/policynim/interfaces/mcp.py
+++ b/src/policynim/interfaces/mcp.py
@@ -31,6 +31,8 @@ from policynim.errors import (
     PolicyNIMError,
     ProviderError,
 )
+from policynim.lifecycle import close_if_supported
+from policynim.public_urls import public_base_url_uses_https, public_url
 from policynim.runtime_paths import resolve_asset_path, resolve_template_root
 from policynim.services import (
     BetaAuthService,
@@ -129,12 +131,6 @@ def _format_validation_error(label: str, exc: ValidationError) -> str:
     return f"{label} is invalid at {location}: {error['msg']}."
 
 
-def _close_service(service: object | None) -> None:
-    close = getattr(service, "close", None)
-    if callable(close):
-        close()
-
-
 def _configure_hosted_logger() -> None:
     """Emit hosted MCP telemetry as one JSON object per line."""
     logger = logging.getLogger(_HOSTED_LOGGER_NAME)
@@ -229,7 +225,7 @@ def _run_policy_preflight(
     except ValidationError as exc:
         raise ValueError(_format_validation_error("Preflight request", exc)) from exc
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
 
 def policy_preflight(
@@ -253,7 +249,7 @@ def _run_policy_search(
         result = service.search(SearchRequest(query=query, domain=domain, top_k=resolved_top_k))
         return result.model_dump(mode="json")
     finally:
-        _close_service(service)
+        close_if_supported(service)
 
 
 def policy_search(
@@ -363,7 +359,7 @@ def _register_beta_routes(
         max_attempts=settings.beta_auth_rate_limit_max_attempts,
         window_seconds=settings.beta_auth_rate_limit_window_seconds,
     )
-    trust_forwarded_headers = _beta_session_https_only(settings)
+    trust_forwarded_headers = public_base_url_uses_https(settings)
 
     def _rate_limited(request: Request) -> HTMLResponse | None:
         client_ip = _client_address(
@@ -530,7 +526,7 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
             ready=False,
             table_name=table_name,
             row_count=0,
-            mcp_url=_derive_mcp_url(settings),
+            mcp_url=public_url(settings, _STREAMABLE_HTTP_PATH),
             reason=reason,
         )
         return JSONResponse(result.model_dump(mode="json"), status_code=503)
@@ -548,18 +544,6 @@ def _register_health_route(server: FastMCP, settings: Settings) -> None:
 
         status_code = 200 if result.ready else 503
         return JSONResponse(result.model_dump(mode="json"), status_code=status_code)
-
-
-def _derive_mcp_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
-
-
-def _derive_beta_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + _BETA_PATH
 
 
 def _beta_asset_path(filename: str) -> Path:
@@ -654,8 +638,8 @@ def _render_beta_landing(
     message: str | None = None,
     status_code: int = 200,
 ) -> HTMLResponse:
-    portal_url = _derive_beta_url(settings) or _BETA_PATH
-    mcp_url = _derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
+    portal_url = public_url(settings, _BETA_PATH) or _BETA_PATH
+    mcp_url = public_url(settings, _STREAMABLE_HTTP_PATH) or _STREAMABLE_HTTP_PATH
     notices: list[dict[str, str]] = []
     if message:
         notices.append(
@@ -721,8 +705,8 @@ def _render_beta_dashboard(
     message: str | None = None,
     message_tone: str = "warning",
 ) -> HTMLResponse:
-    portal_url = _derive_beta_url(settings) or _BETA_PATH
-    mcp_url = _derive_mcp_url(settings) or _STREAMABLE_HTTP_PATH
+    portal_url = public_url(settings, _BETA_PATH) or _BETA_PATH
+    mcp_url = public_url(settings, _STREAMABLE_HTTP_PATH) or _STREAMABLE_HTTP_PATH
     current_key = account.api_key_prefix or "No active key"
     current_key_created = (
         account.api_key_created_at.isoformat() if account.api_key_created_at is not None else "N/A"
@@ -866,13 +850,6 @@ def _require_beta_session_account_id(request: Request) -> int | None:
         return None
 
 
-def _beta_session_https_only(settings: Settings) -> bool:
-    """Use secure beta session cookies for HTTPS-hosted deployments."""
-    if settings.mcp_public_base_url is None:
-        return False
-    return settings.mcp_public_base_url.scheme == "https"
-
-
 def _build_beta_auth_service(settings: Settings) -> BetaAuthService | None:
     if not settings.beta_signup_enabled and not settings.mcp_require_auth:
         return None
@@ -1003,7 +980,7 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
             app,
             secret_key=session_secret,
             same_site="lax",
-            https_only=_beta_session_https_only(settings),
+            https_only=public_base_url_uses_https(settings),
         )
     if not settings.mcp_require_auth:
         return app
@@ -1012,7 +989,7 @@ def _build_streamable_http_app(settings: Settings) -> ASGIApp:
         protected_path=server.settings.streamable_http_path,
         valid_tokens=settings.mcp_bearer_tokens,
         beta_auth_service=beta_auth_service,
-        beta_portal_url=_derive_beta_url(settings) if settings.beta_signup_enabled else None,
+        beta_portal_url=public_url(settings, _BETA_PATH) if settings.beta_signup_enabled else None,
     )
 
 

--- a/src/policynim/iterables.py
+++ b/src/policynim/iterables.py
@@ -1,0 +1,20 @@
+"""Iterable helpers for deterministic ordering behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable
+from typing import TypeVar
+
+T = TypeVar("T", bound=Hashable)
+
+
+def ordered_unique(values: Iterable[T]) -> list[T]:
+    """Return first-seen hashable values while preserving input order."""
+    seen: set[T] = set()
+    ordered: list[T] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered

--- a/src/policynim/lifecycle.py
+++ b/src/policynim/lifecycle.py
@@ -1,0 +1,10 @@
+"""Lifecycle helpers for optional owned components."""
+
+from __future__ import annotations
+
+
+def close_if_supported(component: object | None) -> None:
+    """Close one optional component when it exposes a callable close hook."""
+    close = getattr(component, "close", None)
+    if callable(close):
+        close()

--- a/src/policynim/providers/nvidia.py
+++ b/src/policynim/providers/nvidia.py
@@ -23,6 +23,8 @@ from pydantic import ValidationError
 
 from policynim.contracts import Embedder, Generator, Reranker
 from policynim.errors import ConfigurationError, ProviderError
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.settings import Settings
 from policynim.types import (
     CompiledPolicyConstraint,
@@ -91,7 +93,7 @@ class NVIDIAEmbedder(Embedder):
     def close(self) -> None:
         """Release the owned OpenAI client when supported by the SDK."""
         if self._owns_client:
-            _close_client(self._client)
+            close_if_supported(self._client)
 
     def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed policy chunk text in batches."""
@@ -401,7 +403,7 @@ class NVIDIAGenerator(Generator):
     def close(self) -> None:
         """Release the owned OpenAI client when supported by the SDK."""
         if self._owns_client:
-            _close_client(self._client)
+            close_if_supported(self._client)
 
 
 class NVIDIAPolicyCompiler:
@@ -466,7 +468,7 @@ class NVIDIAPolicyCompiler:
     def close(self) -> None:
         """Release the owned OpenAI client when supported by the SDK."""
         if self._owns_client:
-            _close_client(self._client)
+            close_if_supported(self._client)
 
 
 class NVIDIAPolicyConformanceEvaluator:
@@ -531,7 +533,7 @@ class NVIDIAPolicyConformanceEvaluator:
     def close(self) -> None:
         """Release the owned OpenAI client when supported by the SDK."""
         if self._owns_client:
-            _close_client(self._client)
+            close_if_supported(self._client)
 
 
 def _request_chat_completion(
@@ -1082,18 +1084,7 @@ def _allowed_policy_conformance_chunk_ids(
     trace_chunk_ids = [
         citation_id for step in request.trace_steps for citation_id in step.citation_ids
     ]
-    return _ordered_unique([*constraint_chunk_ids, *result_chunk_ids, *trace_chunk_ids])
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
+    return ordered_unique([*constraint_chunk_ids, *result_chunk_ids, *trace_chunk_ids])
 
 
 def _parse_json_object_response(content: str, *, operation: str) -> dict[str, Any]:
@@ -1127,9 +1118,3 @@ def _extract_embedded_json_object(content: str) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
-
-
-def _close_client(client: object) -> None:
-    close = getattr(client, "close", None)
-    if callable(close):
-        close()

--- a/src/policynim/providers/nvidia_guardrails.py
+++ b/src/policynim/providers/nvidia_guardrails.py
@@ -14,6 +14,8 @@ from pydantic import ValidationError
 
 from policynim.contracts import Generator
 from policynim.errors import ConfigurationError, ProviderError
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.providers.nvidia import NVIDIAGenerator
 from policynim.settings import Settings
 from policynim.types import (
@@ -63,7 +65,7 @@ class NeMoGuardrailsPreflightGenerator(Generator):
                     model=model or _DEFAULT_GUARDRAILS_MODEL
                 )
             except ConfigurationError:
-                _close_component(base_generator)
+                close_if_supported(base_generator)
                 raise
             owns_rails = True
 
@@ -87,8 +89,8 @@ class NeMoGuardrailsPreflightGenerator(Generator):
                 owns_rails=True,
             )
         except Exception:
-            _close_component(base_generator)
-            _close_component(rails)
+            close_if_supported(base_generator)
+            close_if_supported(rails)
             raise
 
     def generate_preflight(
@@ -118,9 +120,9 @@ class NeMoGuardrailsPreflightGenerator(Generator):
 
     def close(self) -> None:
         """Release owned generator and Guardrails resources."""
-        _close_component(self._base_generator)
+        close_if_supported(self._base_generator)
         if self._owns_rails:
-            _close_component(self._rails)
+            close_if_supported(self._rails)
 
     def _check_output_rails(self, draft: GeneratedPreflightDraft) -> str:
         content = json.dumps(draft.model_dump(mode="json"), sort_keys=True)
@@ -312,7 +314,7 @@ def _validate_guardrailed_draft(
     if unsupported_citation_ids:
         raise ProviderError(
             "NeMo Guardrails output rails returned unsupported citation ids: "
-            f"{', '.join(_ordered_unique(unsupported_citation_ids))}.",
+            f"{', '.join(ordered_unique(unsupported_citation_ids))}.",
             failure_class="invalid_response",
         )
 
@@ -328,13 +330,13 @@ def _validate_guardrailed_draft(
     if unsupported_trigger_chunk_ids:
         raise ProviderError(
             "Regeneration context referenced chunk ids outside the retained context: "
-            f"{', '.join(_ordered_unique(unsupported_trigger_chunk_ids))}.",
+            f"{', '.join(ordered_unique(unsupported_trigger_chunk_ids))}.",
             failure_class="invalid_response",
         )
 
 
 def _draft_citation_ids(draft: GeneratedPreflightDraft) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [
             *draft.citation_ids,
             *[
@@ -361,23 +363,6 @@ def _rail_result_content(result: Any) -> Any:
     if isinstance(result, Mapping):
         return result.get("content")
     return getattr(result, "content", None)
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = ["NeMoGuardrailsPreflightGenerator"]

--- a/src/policynim/public_urls.py
+++ b/src/policynim/public_urls.py
@@ -1,0 +1,38 @@
+"""Hosted public URL helpers."""
+
+from __future__ import annotations
+
+from policynim.errors import ConfigurationError
+from policynim.settings import Settings
+
+_PUBLIC_BASE_URL_SETTING = "POLICYNIM_MCP_PUBLIC_BASE_URL"
+
+
+def public_url(settings: Settings, path: str) -> str | None:
+    """Return the hosted public URL for one route when configured."""
+    if settings.mcp_public_base_url is None:
+        return None
+    return str(settings.mcp_public_base_url).rstrip("/") + _normalize_public_path(path)
+
+
+def require_public_url(settings: Settings, path: str) -> str:
+    """Return the hosted public URL for one route or fail when unset."""
+    url = public_url(settings, path)
+    if url is None:
+        raise ConfigurationError(f"{_PUBLIC_BASE_URL_SETTING} must be configured.")
+    return url
+
+
+def public_base_url_uses_https(settings: Settings) -> bool:
+    """Return whether the hosted public base URL should use secure-only cookies."""
+    if settings.mcp_public_base_url is None:
+        return False
+    return settings.mcp_public_base_url.scheme == "https"
+
+
+def _normalize_public_path(path: str) -> str:
+    """Normalize one public route suffix for URL construction."""
+    normalized = "/" + path.lstrip("/")
+    if normalized == "/":
+        return normalized
+    return normalized.rstrip("/")

--- a/src/policynim/services/beta_auth.py
+++ b/src/policynim/services/beta_auth.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 import httpx
 
 from policynim.errors import ConfigurationError, PolicyNIMError, ProviderError
+from policynim.public_urls import require_public_url
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import AuthStore
@@ -51,23 +52,17 @@ class BetaAuthService:
     @property
     def mcp_url(self) -> str:
         """Return the public hosted MCP URL."""
-        if self._settings.mcp_public_base_url is None:
-            raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/mcp"
+        return require_public_url(self._settings, "/mcp")
 
     @property
     def portal_url(self) -> str:
         """Return the public hosted beta portal URL."""
-        if self._settings.mcp_public_base_url is None:
-            raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/beta"
+        return require_public_url(self._settings, "/beta")
 
     @property
     def github_callback_url(self) -> str:
         """Return the configured GitHub OAuth callback URL."""
-        if self._settings.mcp_public_base_url is None:
-            raise ConfigurationError("POLICYNIM_MCP_PUBLIC_BASE_URL must be configured.")
-        return str(self._settings.mcp_public_base_url).rstrip("/") + "/auth/github/callback"
+        return require_public_url(self._settings, "/auth/github/callback")
 
     def list_accounts(self) -> list[BetaAccount]:
         """Return all hosted beta accounts."""

--- a/src/policynim/services/compiler.py
+++ b/src/policynim/services/compiler.py
@@ -6,6 +6,8 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, PolicyCompiler, Reranker
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.services.router import PolicyRouterService, create_policy_router_service
 from policynim.settings import Settings, get_settings
 from policynim.types import (
@@ -61,8 +63,8 @@ class PolicyCompilerService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._router)
-        _close_component(self._compiler)
+        close_if_supported(self._router)
+        close_if_supported(self._compiler)
 
     def compile(self, request: CompileRequest) -> CompileResult:
         """Compile routed policy evidence into a grounded policy packet."""
@@ -156,7 +158,7 @@ def _materialize_compiled_packet(
     if not all_constraints:
         return _insufficient_packet_from_selection(selection_packet)
 
-    citation_ids = _ordered_unique(
+    citation_ids = ordered_unique(
         [citation_id for constraint in all_constraints for citation_id in constraint.citation_ids]
     )
     citations = [_citation_from_chunk(context_by_id[citation_id]) for citation_id in citation_ids]
@@ -188,7 +190,7 @@ def _compile_constraint_list(
     compiled_constraints: list[CompiledPolicyConstraint] = []
     for generated_constraint in generated_constraints:
         statement = generated_constraint.statement.strip()
-        citation_ids = _ordered_unique(
+        citation_ids = ordered_unique(
             [citation_id.strip() for citation_id in generated_constraint.citation_ids]
         )
         if not statement or not citation_ids:
@@ -196,7 +198,7 @@ def _compile_constraint_list(
         if any(citation_id not in context_by_id for citation_id in citation_ids):
             return None
 
-        source_policy_ids = _ordered_unique(
+        source_policy_ids = ordered_unique(
             [context_by_id[citation_id].policy.policy_id for citation_id in citation_ids]
         )
         compiled_constraints.append(
@@ -239,23 +241,6 @@ def _citation_from_chunk(chunk: ScoredChunk) -> Citation:
         lines=chunk.lines,
         chunk_id=chunk.chunk_id,
     )
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/conformance.py
+++ b/src/policynim/services/conformance.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 from types import TracebackType
 
 from policynim.contracts import PolicyConformanceEvaluator
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.types import (
     CompiledPolicyConstraint,
     EvalBackend,
@@ -39,7 +41,7 @@ class PolicyConformanceService:
 
     def close(self) -> None:
         """Release owned evaluator resources."""
-        _close_component(self._evaluator)
+        close_if_supported(self._evaluator)
 
     def evaluate(
         self,
@@ -201,7 +203,7 @@ def _forbidden_pattern_metric(
 def _citation_support_metric(
     request: PolicyConformanceRequest,
 ) -> PolicyConformanceMetric:
-    expected_chunk_ids = _ordered_unique(
+    expected_chunk_ids = ordered_unique(
         [
             citation_id
             for constraints in (
@@ -215,7 +217,7 @@ def _citation_support_metric(
             for citation_id in constraint.citation_ids
         ]
     )
-    actual_chunk_ids = _ordered_unique([citation.chunk_id for citation in request.result.citations])
+    actual_chunk_ids = ordered_unique([citation.chunk_id for citation in request.result.citations])
     if not expected_chunk_ids:
         return PolicyConformanceMetric(
             name="citation_support",
@@ -295,27 +297,10 @@ def _normalize_for_matching(value: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", value.lower())).strip()
 
 
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
 def _average(values: Sequence[float]) -> float:
     if not values:
         return 0.0
     return sum(values) / len(values)
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/eval.py
+++ b/src/policynim/services/eval.py
@@ -19,6 +19,7 @@ from typing import Any, cast
 
 from policynim.contracts import Generator, IndexStore, Reranker
 from policynim.errors import PolicyNIMError
+from policynim.lifecycle import close_if_supported
 from policynim.runtime_paths import resolve_eval_suite_path, resolve_runtime_path
 from policynim.services.compiler import PolicyCompilerService
 from policynim.services.conformance import PolicyConformanceService
@@ -296,8 +297,8 @@ class EvalService:
         finally:
             search_service.close()
             preflight_service.close()
-            _close_component(regeneration_service)
-            _close_component(conformance_service)
+            close_if_supported(regeneration_service)
+            close_if_supported(conformance_service)
 
     def _run_live_suite(
         self,
@@ -317,7 +318,7 @@ class EvalService:
             try:
                 ingest_service.run()
             finally:
-                _close_component(ingest_service)
+                close_if_supported(ingest_service)
 
             search_service = _create_live_search_service(
                 temp_settings,
@@ -355,8 +356,8 @@ class EvalService:
             finally:
                 search_service.close()
                 preflight_service.close()
-                _close_component(conformance_service)
-                _close_component(regeneration_service)
+                close_if_supported(conformance_service)
+                close_if_supported(regeneration_service)
 
     def _persist_mode_run(
         self,
@@ -1347,16 +1348,10 @@ def _create_live_regeneration_service(
             conformance_service=conformance_service,
         )
     except Exception:
-        _close_component(conformance_service)
-        _close_component(generator)
-        _close_component(compiler_service)
+        close_if_supported(conformance_service)
+        close_if_supported(generator)
+        close_if_supported(compiler_service)
         raise
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 class _PassThroughReranker(Reranker):

--- a/src/policynim/services/evidence_trace.py
+++ b/src/policynim/services/evidence_trace.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections.abc import Sequence
 
+from policynim.iterables import ordered_unique
 from policynim.types import (
     CompiledPolicyConstraint,
     CompiledPolicyPacket,
@@ -107,7 +108,7 @@ def _trace_policies(compiled_packet: CompiledPolicyPacket) -> list[PolicyEvidenc
             policy_id=policy.policy_id,
             title=policy.title,
             reason=policy.reason,
-            supporting_chunk_ids=_ordered_unique(
+            supporting_chunk_ids=ordered_unique(
                 [evidence.chunk_id for evidence in policy.evidence]
             ),
         )
@@ -188,7 +189,7 @@ def _trace_text_outputs(
                 index=index,
                 text=text,
                 constraint_ids=[constraint.constraint_id for constraint in linked_constraints],
-                chunk_ids=_ordered_unique(
+                chunk_ids=ordered_unique(
                     [
                         chunk_id
                         for constraint in linked_constraints
@@ -209,7 +210,7 @@ def _trace_conformance_checks(
 
     constraints_by_category = _constraints_by_category(constraints)
     all_constraint_ids = [constraint.constraint_id for constraint in constraints]
-    all_chunk_ids = _ordered_unique(
+    all_chunk_ids = ordered_unique(
         [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
     )
     checks: list[PolicyEvidenceTraceConformanceCheck] = []
@@ -330,20 +331,9 @@ def _metric_chunk_ids(
         constraints = constraints_by_category["forbidden_patterns"]
     else:
         constraints = []
-    return _ordered_unique(
+    return ordered_unique(
         [chunk_id for constraint in constraints for chunk_id in constraint.citation_ids]
     )
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
 
 
 __all__ = [

--- a/src/policynim/services/health.py
+++ b/src/policynim/services/health.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from policynim.contracts import IndexStore
 from policynim.errors import ConfigurationError
+from policynim.public_urls import public_url
 from policynim.services.ingest import create_ingest_service
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
@@ -71,7 +72,7 @@ def create_runtime_health_service(settings: Settings | None = None) -> RuntimeHe
     return RuntimeHealthService(
         index_store=index_store,
         table_name=index_store.table_name,
-        mcp_url=_derive_mcp_url(active_settings),
+        mcp_url=public_url(active_settings, "/mcp"),
     )
 
 
@@ -178,12 +179,6 @@ def _rebuild_hosted_runtime_index(
         result.chunk_count,
         result.document_count,
     )
-
-
-def _derive_mcp_url(settings: Settings) -> str | None:
-    if settings.mcp_public_base_url is None:
-        return None
-    return str(settings.mcp_public_base_url).rstrip("/") + "/mcp"
 
 
 def format_health_failure_reason(exc: Exception) -> str:

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -11,6 +11,7 @@ from typing import Protocol
 
 from policynim.contracts import Embedder
 from policynim.ingest import chunk_policy_documents, load_policy_documents
+from policynim.lifecycle import close_if_supported
 from policynim.runtime_paths import resolve_corpus_root, resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
@@ -75,7 +76,7 @@ class IngestService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._embedder)
+        close_if_supported(self._embedder)
 
     def run(self) -> IngestResult:
         """Load, chunk, embed, and persist the policy corpus."""
@@ -205,10 +206,3 @@ def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> No
 def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
     """Best-effort cleanup for staged artifact files after a failed ingest."""
     staged_path.unlink(missing_ok=True)
-
-
-def _close_component(component: object | None) -> None:
-    """Close an optional owned component when it exposes a close hook."""
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/src/policynim/services/preflight.py
+++ b/src/policynim/services/preflight.py
@@ -7,6 +7,8 @@ from types import TracebackType
 from typing import Any
 
 from policynim.contracts import Embedder, Generator, IndexStore, PolicyCompiler, Reranker
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.services.compiler import PolicyCompilerService, create_policy_compiler_service
 from policynim.services.router import PolicyRouterService
 from policynim.settings import Settings, get_settings
@@ -85,8 +87,8 @@ class PreflightService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._compiler_service)
-        _close_component(self._generator)
+        close_if_supported(self._compiler_service)
+        close_if_supported(self._generator)
 
     def preflight(self, request: PreflightRequest) -> PreflightResult:
         """Run the grounded preflight pipeline."""
@@ -248,7 +250,7 @@ def _validate_and_materialize_result(
     if not context_by_id:
         return None
 
-    citation_ids = _ordered_unique(
+    citation_ids = ordered_unique(
         draft.citation_ids
         or [
             citation_id
@@ -263,7 +265,7 @@ def _validate_and_materialize_result(
 
     applicable_policies: list[PolicyGuidance] = []
     for policy in draft.applicable_policies:
-        policy_citation_ids = _ordered_unique(policy.citation_ids)
+        policy_citation_ids = ordered_unique(policy.citation_ids)
         if not policy_citation_ids:
             continue
         if any(citation_id not in context_by_id for citation_id in policy_citation_ids):
@@ -323,17 +325,6 @@ def _insufficient_context_result(request: PreflightRequest) -> PreflightResult:
     )
 
 
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
 def _apply_compiled_packet_to_draft(
     draft: GeneratedPreflightDraft,
     compiled_packet: CompiledPolicyPacket,
@@ -360,13 +351,13 @@ def _apply_compiled_packet_to_draft(
 
     return draft.model_copy(
         update={
-            "plan_steps": _ordered_unique([*compiled_plan_steps, *draft.plan_steps]),
-            "implementation_guidance": _ordered_unique(
+            "plan_steps": ordered_unique([*compiled_plan_steps, *draft.plan_steps]),
+            "implementation_guidance": ordered_unique(
                 [*compiled_guidance, *draft.implementation_guidance]
             ),
-            "review_flags": _ordered_unique([*compiled_review_flags, *draft.review_flags]),
-            "tests_required": _ordered_unique([*compiled_tests, *draft.tests_required]),
-            "citation_ids": _ordered_unique([*draft_citation_ids, *compiled_citation_ids]),
+            "review_flags": ordered_unique([*compiled_review_flags, *draft.review_flags]),
+            "tests_required": ordered_unique([*compiled_tests, *draft.tests_required]),
+            "citation_ids": ordered_unique([*draft_citation_ids, *compiled_citation_ids]),
         }
     )
 
@@ -388,14 +379,8 @@ def _trace_step(
         step_id=step_id,
         kind=kind,
         summary=summary.strip() or kind,
-        citation_ids=_ordered_unique(list(citation_ids)),
+        citation_ids=ordered_unique(list(citation_ids)),
     )
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/regeneration.py
+++ b/src/policynim/services/regeneration.py
@@ -7,6 +7,8 @@ from types import TracebackType
 from typing import Protocol
 
 from policynim.contracts import Generator
+from policynim.iterables import ordered_unique
+from policynim.lifecycle import close_if_supported
 from policynim.services.compiler import create_policy_compiler_service
 from policynim.services.conformance import PolicyConformanceService
 from policynim.services.evidence_trace import (
@@ -103,9 +105,9 @@ class PolicyRegenerationService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._compiler_service)
-        _close_component(self._generator)
-        _close_component(self._conformance_service)
+        close_if_supported(self._compiler_service)
+        close_if_supported(self._generator)
+        close_if_supported(self._conformance_service)
 
     def regenerate(
         self,
@@ -323,9 +325,9 @@ def create_policy_regeneration_service(
             conformance_service=conformance_service,
         )
     except Exception:
-        _close_component(conformance_service)
-        _close_component(generator)
-        _close_component(compiler_service)
+        close_if_supported(conformance_service)
+        close_if_supported(generator)
+        close_if_supported(compiler_service)
         raise
 
 
@@ -580,7 +582,7 @@ def _all_constraint_ids(compiled_packet: CompiledPolicyPacket) -> list[str]:
 
 
 def _all_constraint_chunk_ids(compiled_packet: CompiledPolicyPacket) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [
             citation_id
             for _category_name, constraints in _constraint_categories(compiled_packet)
@@ -605,7 +607,7 @@ def _constraint_categories(
 def _constraint_chunk_ids(
     constraints: Sequence[CompiledPolicyConstraint],
 ) -> list[str]:
-    return _ordered_unique(
+    return ordered_unique(
         [citation_id for constraint in constraints for citation_id in constraint.citation_ids]
     )
 
@@ -627,23 +629,6 @@ def _dedupe_triggers(triggers: Sequence[RegenerationTrigger]) -> list[Regenerati
         seen.add(key)
         deduped.append(trigger)
     return deduped
-
-
-def _ordered_unique(values: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        ordered.append(value)
-    return ordered
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = [

--- a/src/policynim/services/router.py
+++ b/src/policynim/services/router.py
@@ -9,6 +9,7 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
+from policynim.lifecycle import close_if_supported
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
 from policynim.types import (
@@ -117,8 +118,8 @@ class PolicyRouterService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._embedder)
-        _close_component(self._reranker)
+        close_if_supported(self._embedder)
+        close_if_supported(self._reranker)
 
     def route(self, request: RouteRequest) -> RouteResult:
         """Return task-aware selected policy evidence for a coding task."""
@@ -347,12 +348,6 @@ def _empty_route_result(request: RouteRequest, profile: TaskProfile) -> RouteRes
         ),
         retained_context=[],
     )
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()
 
 
 __all__ = ["PolicyRouterService", "create_policy_router_service", "profile_task"]

--- a/src/policynim/services/runtime_decision.py
+++ b/src/policynim/services/runtime_decision.py
@@ -19,6 +19,7 @@ from policynim.errors import (
     RuntimeRulesArtifactInvalidError,
     RuntimeRulesArtifactMissingError,
 )
+from policynim.iterables import ordered_unique
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
@@ -253,7 +254,7 @@ def _normalize_file_write_paths(request: FileWriteActionRequest) -> tuple[str, .
 
     candidate_paths.append(lexical_target.as_posix())
     candidate_paths.append(resolved_target.as_posix())
-    return tuple(_ordered_unique(candidate_paths))
+    return tuple(ordered_unique(candidate_paths))
 
 
 def _resolve_from_base(path: Path, *, base: Path) -> Path:
@@ -298,18 +299,6 @@ def _relative_posix_path(path: Path, *, root: Path) -> str | None:
         return path.relative_to(root).as_posix()
     except ValueError:
         return None
-
-
-def _ordered_unique(values: list[str]) -> list[str]:
-    """Keep first-seen string order while dropping duplicates."""
-    ordered: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        if value in seen:
-            continue
-        ordered.append(value)
-        seen.add(value)
-    return ordered
 
 
 def _rule_matches(

--- a/src/policynim/services/runtime_evidence_report.py
+++ b/src/policynim/services/runtime_evidence_report.py
@@ -6,6 +6,7 @@ from types import TracebackType
 
 from policynim.contracts import RuntimeEvidenceStoreProtocol
 from policynim.errors import PolicyNIMError
+from policynim.lifecycle import close_if_supported
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.settings import Settings, get_settings
 from policynim.storage import RuntimeEvidenceStore
@@ -36,9 +37,7 @@ class RuntimeEvidenceReportService:
 
     def close(self) -> None:
         """Release owned resources held by this service."""
-        close = getattr(self._evidence_store, "close", None)
-        if callable(close):
-            close()
+        close_if_supported(self._evidence_store)
 
     def report_session(self, session_id: str) -> RuntimeEvidenceSessionSummary:
         """Return one typed summary over the persisted session evidence."""

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -21,6 +21,7 @@ from policynim.contracts import (
     RuntimeEvidenceStoreProtocol,
 )
 from policynim.errors import RuntimeEvidencePersistenceError
+from policynim.lifecycle import close_if_supported
 from policynim.runtime_paths import resolve_runtime_path
 from policynim.services.runtime_decision import create_runtime_decision_service
 from policynim.settings import Settings, get_settings
@@ -98,8 +99,8 @@ class RuntimeExecutionService:
 
     def close(self) -> None:
         """Release owned resources held by this service."""
-        _close_component(self._decision_service)
-        _close_component(self._evidence_store)
+        close_if_supported(self._decision_service)
+        close_if_supported(self._evidence_store)
         if self._owns_http_client:
             self._http_client.close()
 
@@ -567,9 +568,3 @@ def _failure_class_from_error(exc: BaseException) -> str | None:
 
 def _elapsed_ms(start_time: float) -> float:
     return round((time.perf_counter() - start_time) * 1000, 2)
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/src/policynim/services/search.py
+++ b/src/policynim/services/search.py
@@ -6,6 +6,7 @@ from types import TracebackType
 
 from policynim.contracts import Embedder, IndexStore, Reranker
 from policynim.errors import MissingIndexError
+from policynim.lifecycle import close_if_supported
 from policynim.settings import Settings, get_settings
 from policynim.storage import create_index_store
 from policynim.types import SearchRequest, SearchResult
@@ -40,8 +41,8 @@ class SearchService:
 
     def close(self) -> None:
         """Release owned provider resources held by this service."""
-        _close_component(self._embedder)
-        _close_component(self._reranker)
+        close_if_supported(self._embedder)
+        close_if_supported(self._reranker)
 
     def search(self, request: SearchRequest) -> SearchResult:
         """Run dense retrieval followed by reranking against the local index."""
@@ -98,9 +99,3 @@ def _create_default_search_components(settings: Settings) -> tuple[Embedder, Rer
 def _ensure_index_ready(index_store: IndexStore) -> None:
     if not index_store.exists() or index_store.count() == 0:
         raise MissingIndexError("Run `policynim ingest` before searching the policy corpus.")
-
-
-def _close_component(component: object | None) -> None:
-    close = getattr(component, "close", None)
-    if callable(close):
-        close()

--- a/tests/test_iterables.py
+++ b/tests/test_iterables.py
@@ -1,0 +1,20 @@
+"""Tests for iterable helper utilities."""
+
+from __future__ import annotations
+
+from policynim.iterables import ordered_unique
+
+
+def test_ordered_unique_preserves_first_seen_order() -> None:
+    """Keep the first instance of each value while preserving order."""
+    assert ordered_unique(["alpha", "beta", "alpha", "gamma", "beta"]) == [
+        "alpha",
+        "beta",
+        "gamma",
+    ]
+
+
+def test_ordered_unique_accepts_generic_iterables() -> None:
+    """Support iterators rather than only concrete sequence inputs."""
+    values = (value for value in ("one", "one", "two"))
+    assert ordered_unique(values) == ["one", "two"]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,35 @@
+"""Tests for lifecycle helper utilities."""
+
+from __future__ import annotations
+
+from policynim.lifecycle import close_if_supported
+
+
+class _Closable:
+    """Track whether the helper invoked the close hook."""
+
+    def __init__(self) -> None:
+        """Start in the open state."""
+        self.closed = False
+
+    def close(self) -> None:
+        """Record that the resource was closed."""
+        self.closed = True
+
+
+class _NotClosable:
+    """Object without a close hook."""
+
+
+def test_close_if_supported_closes_owned_components() -> None:
+    """Call the close hook when the component exposes one."""
+    component = _Closable()
+
+    close_if_supported(component)
+
+    assert component.closed is True
+
+
+def test_close_if_supported_ignores_missing_close_hooks() -> None:
+    """Treat components without close hooks as no-ops."""
+    close_if_supported(_NotClosable())

--- a/tests/test_public_urls.py
+++ b/tests/test_public_urls.py
@@ -1,0 +1,32 @@
+"""Tests for hosted public URL helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from policynim.errors import ConfigurationError
+from policynim.public_urls import public_base_url_uses_https, public_url, require_public_url
+from policynim.settings import Settings
+
+
+def test_public_url_builds_normalized_routes() -> None:
+    """Append hosted routes without leaking double slashes."""
+    settings = Settings.model_validate({"mcp_public_base_url": "https://beta.example.com"})
+
+    assert public_url(settings, "/mcp") == "https://beta.example.com/mcp"
+    assert public_url(settings, "beta/") == "https://beta.example.com/beta"
+
+
+def test_require_public_url_rejects_missing_origin() -> None:
+    """Require an explicit public base URL when callers depend on it."""
+    with pytest.raises(ConfigurationError, match="POLICYNIM_MCP_PUBLIC_BASE_URL"):
+        require_public_url(Settings(), "/mcp")
+
+
+def test_public_base_url_uses_https_matches_scheme() -> None:
+    """Report whether the configured public origin uses HTTPS."""
+    https_settings = Settings.model_validate({"mcp_public_base_url": "https://beta.example.com"})
+    http_settings = Settings.model_validate({"mcp_public_base_url": "http://beta.example.com"})
+
+    assert public_base_url_uses_https(https_settings) is True
+    assert public_base_url_uses_https(http_settings) is False


### PR DESCRIPTION
## Summary
- consolidate duplicated `ordered_unique` logic into `policynim.iterables`
- consolidate optional close-hook handling into `policynim.lifecycle`
- centralize hosted public URL construction into `policynim.public_urls`
- remove the broad exception wrapper from the CLI doctor local-index readiness check
- add focused unit coverage for the new shared seams

## Audit findings addressed
- duplicated ordered-unique helpers across services and providers created drift-prone dead copies
- duplicated close-hook helpers across services, interfaces, and providers added hollow lifecycle indirection
- duplicated hosted public URL construction across MCP, health, and beta auth risked contract drift
- `_doctor_local_index_ready()` used `except Exception`, which could hide programming regressions behind a false "not ready" result

## Validation
- `uv run --group test --group dev ruff check .`
- `uv run --group test --group dev pyright`
- `uv run --group test pytest -q`