### PR TITLE
Harden runtime artifact writes and ingest rollback

### DIFF
--- a/src/policynim/atomic_files.py
+++ b/src/policynim/atomic_files.py
@@ -1,0 +1,37 @@
+"""Helpers for staging text artifacts before atomic replacement."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+def stage_text_artifact(
+    destination: Path,
+    *,
+    content: str,
+    ensure_trailing_newline: bool = False,
+) -> Path:
+    """Write text to a sibling temp file and return the staged path."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staged_path: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(content)
+            if ensure_trailing_newline and not content.endswith("\n"):
+                handle.write("\n")
+            staged_path = Path(handle.name)
+    except OSError:
+        if staged_path is not None:
+            with suppress(OSError):
+                staged_path.unlink(missing_ok=True)
+        raise
+    return staged_path

--- a/src/policynim/interfaces/cli.py
+++ b/src/policynim/interfaces/cli.py
@@ -10,11 +10,12 @@ import re
 import shlex
 import sys
 from collections.abc import Sequence
+from contextlib import suppress
 from datetime import datetime, timedelta
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryFile
+from tempfile import TemporaryFile
 from typing import Annotated, Literal, NoReturn, cast
 from urllib.parse import urlparse
 
@@ -25,6 +26,7 @@ from pydantic import TypeAdapter, ValidationError
 
 import policynim.config_discovery as config_discovery
 from policynim.agent_workflows import agent_workflows
+from policynim.atomic_files import stage_text_artifact
 from policynim.errors import ConfigurationError, MissingIndexError, PolicyNIMError
 from policynim.interfaces.mcp import run_server
 from policynim.runtime_paths import resolve_runtime_path
@@ -1162,27 +1164,18 @@ def _write_cli_artifact_text(output: str, content: str) -> Path:
     if target.exists() and target.is_dir():
         raise PolicyNIMError(f"Runtime evidence report output must be a file path: {target}.")
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    temp_path: str | None = None
+    staged_path: Path | None = None
     try:
-        with NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=target.parent,
-            prefix=f".{target.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as temp_file:
-            temp_path = temp_file.name
-            temp_file.write(content)
-            temp_file.write("\n")
-        os.replace(temp_path, target)
+        staged_path = stage_text_artifact(
+            target,
+            content=content,
+            ensure_trailing_newline=True,
+        )
+        staged_path.replace(target)
     except OSError as exc:
-        if temp_path is not None:
-            try:
-                Path(temp_path).unlink(missing_ok=True)
-            except OSError:
-                pass
+        if staged_path is not None:
+            with suppress(OSError):
+                staged_path.unlink(missing_ok=True)
         raise PolicyNIMError(
             f"Could not write runtime evidence report to {target}: {exc}."
         ) from exc

--- a/src/policynim/services/ingest.py
+++ b/src/policynim/services/ingest.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from contextlib import suppress
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from types import TracebackType
 from typing import Protocol
 
+from policynim.atomic_files import stage_text_artifact
 from policynim.contracts import Embedder
 from policynim.ingest import chunk_policy_documents, load_policy_documents
 from policynim.runtime_paths import resolve_corpus_root, resolve_runtime_path
@@ -84,17 +85,34 @@ class IngestService:
         chunks = chunk_policy_documents(documents)
         vectors = self._embedder.embed_documents([chunk.text for chunk in chunks])
         embedded_chunks = _attach_embeddings(chunks, vectors)
+        previous_runtime_rules_artifact = _read_existing_runtime_rules_artifact(
+            self._runtime_rules_artifact_path
+        )
         staged_artifact_path = _stage_runtime_rules_artifact(
             runtime_rules_artifact,
             self._runtime_rules_artifact_path,
         )
 
         try:
-            self._index_store.replace(embedded_chunks)
             _finalize_runtime_rules_artifact(
                 staged_artifact_path,
                 self._runtime_rules_artifact_path,
             )
+            try:
+                self._index_store.replace(embedded_chunks)
+            except Exception as exc:
+                try:
+                    _restore_runtime_rules_artifact(
+                        self._runtime_rules_artifact_path,
+                        previous_runtime_rules_artifact,
+                    )
+                except OSError as restore_exc:
+                    raise OSError(
+                        "Index replacement failed and PolicyNIM could not restore the previous "
+                        f"runtime rules artifact at {self._runtime_rules_artifact_path}: "
+                        f"{restore_exc}."
+                    ) from exc
+                raise
         except Exception:
             _cleanup_staged_runtime_rules_artifact(staged_artifact_path)
             raise
@@ -185,16 +203,20 @@ def _stage_runtime_rules_artifact(
         indent=2,
         sort_keys=False,
     )
-    with NamedTemporaryFile(
-        "w",
-        encoding="utf-8",
-        dir=destination.parent,
-        prefix=f".{destination.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as handle:
-        handle.write(f"{serialized}\n")
-        return Path(handle.name)
+    return stage_text_artifact(
+        destination,
+        content=serialized,
+        ensure_trailing_newline=True,
+    )
+
+
+def _read_existing_runtime_rules_artifact(destination: Path) -> str | None:
+    """Capture the current artifact so ingest can restore it on later failures."""
+    if not destination.exists():
+        return None
+    if destination.is_dir():
+        raise OSError(f"Runtime rules artifact path {destination} must not be a directory.")
+    return destination.read_text(encoding="utf-8")
 
 
 def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> None:
@@ -205,6 +227,20 @@ def _finalize_runtime_rules_artifact(staged_path: Path, destination: Path) -> No
 def _cleanup_staged_runtime_rules_artifact(staged_path: Path) -> None:
     """Best-effort cleanup for staged artifact files after a failed ingest."""
     staged_path.unlink(missing_ok=True)
+
+
+def _restore_runtime_rules_artifact(destination: Path, previous_content: str | None) -> None:
+    """Restore the prior artifact when index replacement fails after promotion."""
+    if previous_content is None:
+        destination.unlink(missing_ok=True)
+        return
+    staged_restore_path = stage_text_artifact(destination, content=previous_content)
+    try:
+        staged_restore_path.replace(destination)
+    except OSError:
+        with suppress(OSError):
+            staged_restore_path.unlink(missing_ok=True)
+        raise
 
 
 def _close_component(component: object | None) -> None:

--- a/src/policynim/services/runtime_execution.py
+++ b/src/policynim/services/runtime_execution.py
@@ -6,15 +6,16 @@ import logging
 import subprocess
 import time
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from types import TracebackType
 from uuid import uuid4
 
 import httpx
 
+from policynim.atomic_files import stage_text_artifact
 from policynim.contracts import (
     HTTPRequestClientProtocol,
     RuntimeDecisionServiceProtocol,
@@ -347,27 +348,12 @@ def _run_file_write(request: FileWriteActionRequest) -> _ActionExecutionResult:
     encoded = request.content.encode("utf-8")
     staged_path: Path | None = None
     try:
-        with NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=target_path.parent,
-            prefix=f".{target_path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            handle.write(request.content)
-            staged_path = Path(handle.name)
+        staged_path = stage_text_artifact(target_path, content=request.content)
         staged_path.replace(target_path)
     except OSError:
         if staged_path is not None:
-            try:
+            with suppress(OSError):
                 staged_path.unlink(missing_ok=True)
-            except OSError as cleanup_exc:
-                LOGGER.warning(
-                    "Could not remove staged runtime file-write temp file %s: %s",
-                    staged_path,
-                    cleanup_exc,
-                )
         return _ActionExecutionResult(
             succeeded=False,
             metadata=FileWriteExecutionMetadata(path=target_path, bytes_written=0),

--- a/tests/test_atomic_files.py
+++ b/tests/test_atomic_files.py
@@ -1,0 +1,24 @@
+"""Tests for shared atomic text-artifact staging."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from policynim.atomic_files import stage_text_artifact
+
+
+def test_stage_text_artifact_writes_sibling_temp_file_with_optional_newline(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "reports" / "session-1.json"
+
+    staged_path = stage_text_artifact(
+        destination,
+        content='{"session_id":"session-1"}',
+        ensure_trailing_newline=True,
+    )
+
+    assert staged_path.parent == destination.parent
+    assert staged_path.name.startswith(f".{destination.name}.")
+    assert staged_path.suffix == ".tmp"
+    assert staged_path.read_text(encoding="utf-8") == '{"session_id":"session-1"}\n'

--- a/tests/test_hosted_mcp_live.py
+++ b/tests/test_hosted_mcp_live.py
@@ -36,7 +36,7 @@ async def _authenticated_session() -> AsyncIterator[ClientSession]:
                 yield session
 
 
-def _structured_payload(result) -> dict[str, object]:  # noqa: ANN001
+def _structured_payload(result) -> dict[str, object]:
     payload = result.structuredContent
     assert isinstance(payload, dict)
     return payload

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -63,6 +63,14 @@ class RecordingIndexStore:
         return 0
 
 
+class FailingIndexStore(RecordingIndexStore):
+    """Index store that fails after the runtime rules artifact is promoted."""
+
+    def replace(self, chunks: Sequence[EmbeddedChunk]) -> None:
+        self.replace_calls += 1
+        raise RuntimeError("index replace failed")
+
+
 def test_ingest_service_builds_and_rebuilds_local_index(tmp_path: Path) -> None:
     """Build and rebuild the default SQLite index."""
     policies_dir = tmp_path / "policies"
@@ -225,6 +233,54 @@ def test_ingest_service_does_not_leave_staged_runtime_rule_artifacts_on_embed_fa
         service.run()
 
     assert not runtime_dir.exists()
+
+
+def test_ingest_service_restores_previous_runtime_rules_artifact_when_index_replace_fails(
+    tmp_path: Path,
+) -> None:
+    policies_dir = tmp_path / "policies"
+    runtime_dir = tmp_path / "runtime"
+    artifact_path = runtime_dir / "runtime_rules.json"
+    runtime_dir.mkdir(parents=True)
+    previous_artifact = '{"schema_version":1,"rules":[{"policy_id":"LEGACY-1"}]}\n'
+    artifact_path.write_text(previous_artifact, encoding="utf-8")
+    write_policy(
+        policies_dir / "backend" / "logging.md",
+        """
+        ---
+        policy_id: BACKEND-LOG-001
+        title: Logging
+        domain: backend
+        runtime_rules:
+          - action: shell_command
+            effect: confirm
+            reason: Review deploy commands.
+            command_regexes:
+              - "^deploy:"
+        ---
+        # Logging
+
+        ## Rules
+
+        Log with context.
+        """,
+    )
+
+    store = FailingIndexStore(uri=tmp_path / "index.sqlite3", table_name="policy_chunks")
+    service = IngestService(
+        embedder=MockEmbedder(),
+        index_store=store,
+        corpus_root=policies_dir,
+        embedding_model="mock-embedder",
+        runtime_rules_artifact_path=artifact_path,
+    )
+
+    with pytest.raises(RuntimeError, match="index replace failed"):
+        service.run()
+
+    assert store.replace_calls == 1
+    assert artifact_path.read_text(encoding="utf-8") == previous_artifact
+    assert not list(runtime_dir.glob(".runtime_rules.json.*.tmp"))
 
 
 def test_ingest_service_rejects_directory_runtime_rules_artifact_before_index_replace(

--- a/tests/test_nvidia_embedder.py
+++ b/tests/test_nvidia_embedder.py
@@ -31,7 +31,7 @@ class RaisingEmbeddingsClient:
         self.embeddings = self
         self._exc = exc
 
-    def create(self, **kwargs):  # noqa: ANN003
+    def create(self, **kwargs):
         raise self._exc
 
 

--- a/tests/test_nvidia_generator.py
+++ b/tests/test_nvidia_generator.py
@@ -61,7 +61,7 @@ class RaisingChatCompletions:
     def __init__(self, exc: Exception) -> None:
         self._exc = exc
 
-    def create(self, **kwargs):  # noqa: ANN003
+    def create(self, **kwargs):
         raise self._exc
 
 

--- a/tests/test_nvidia_policy_compiler.py
+++ b/tests/test_nvidia_policy_compiler.py
@@ -68,7 +68,7 @@ class RaisingChatCompletions:
     def __init__(self, exc: Exception) -> None:
         self._exc = exc
 
-    def create(self, **kwargs):  # noqa: ANN003
+    def create(self, **kwargs):
         raise self._exc
 
 

--- a/tests/test_nvidia_policy_conformance.py
+++ b/tests/test_nvidia_policy_conformance.py
@@ -27,7 +27,7 @@ class MockChatCompletions:
         self.content = content
         self.calls: list[dict[str, object]] = []
 
-    def create(self, **kwargs):  # noqa: ANN003
+    def create(self, **kwargs):
         self.calls.append(kwargs)
         return SimpleNamespace(
             choices=[
@@ -69,7 +69,7 @@ class RaisingChatCompletions:
     def __init__(self, exc: Exception) -> None:
         self._exc = exc
 
-    def create(self, **kwargs):  # noqa: ANN003
+    def create(self, **kwargs):
         raise self._exc
 
 


### PR DESCRIPTION
## Summary
- restore the previous runtime rules artifact when ingest index replacement fails after artifact promotion
- share sibling temp-file staging across CLI evidence-report writes, runtime file writes, and ingest artifact staging
- remove stale `noqa` suppressions in tests and add regression coverage for the new staging helper and ingest rollback path

## Audit findings addressed
- State drift: `IngestService.run()` could leave a refreshed SQLite index paired with stale runtime rules when the artifact handoff failed across the two persisted outputs.
- Abstractions and path safety: runtime-owned text artifacts repeated nearly identical temp-file staging logic in multiple modules, with slightly different cleanup behavior.
- Dead code: several test-only `# noqa` directives no longer suppressed any active rule.

## Validation
- `uv run --group test --group dev ruff check src tests`
- `uv run --group test --group dev pyright`
- `uv run --group test pytest -q` (`583 passed, 10 skipped` on Monday, July 20, 2026)
